### PR TITLE
single-arm64 image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 target
+docker/single/Dockerfile.*
+arroyo-console/node_modules

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ you need to get a test Arroyo system up and running.
 ```bash
 $ docker run -p 8000:8000 -p 8001:8001 ghcr.io/arroyosystems/arroyo:single
 ```
-
+If you're on an arm64 machine, instead use ghcr.io/arroyosystems/arroyo:single-arm64.
 This will run all of the core arroyo services and a temporary Postgres database. The web UI will be exposed at
 http://localhost:8000.
 

--- a/arroyo-controller/src/compiler.rs
+++ b/arroyo-controller/src/compiler.rs
@@ -211,6 +211,8 @@ arroyo-types = {{ path = "{}/arroyo-types" }}
 wee_alloc = "0.4.5"
 wasm-bindgen = "0.2"
 serde_json = "1.0"
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
 "#,
             arroyo_dir.to_string_lossy()
         );

--- a/docker/single/Cargo.toml
+++ b/docker/single/Cargo.toml
@@ -2,5 +2,9 @@
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
 
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
+
 [profile.release]
 incremental = true

--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -2,18 +2,20 @@ FROM ubuntu:22.04
 ENV TZ=Etc/UTC
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt/arroyo/src
+ARG MOLD_ARCH
+ARG PROTO_ARCH
 
 RUN apt-get update
 RUN apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl \
     cmake clang wget postgresql postgresql-client supervisor python3 python-is-python3 sudo bash
 
-RUN wget https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-x86_64-linux.tar.gz && \
+RUN wget https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-${MOLD_ARCH}-linux.tar.gz && \
     tar xvfz mold*.tar.gz && \
     mv mold*-linux/bin/* /usr/bin && \
     mv mold*-linux/libexec/* /usr/libexec && \
     rm -rf mold*
 
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip && \
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-${PROTO_ARCH}.zip && \
     unzip protoc*.zip && \
     mv bin/protoc /usr/local/bin
 
@@ -48,8 +50,7 @@ RUN service postgresql start && \
     mv target/release/arroyo-api /usr/local/bin/arroyo-api && \
     mv target/release/arroyo-controller /usr/local/bin/arroyo-controller && \
     cargo clean
-
-RUN bash -c "cd arroyo-console && source ~/.bashrc && /root/.local/share/pnpm/pnpm build"
+RUN bash -c "cd arroyo-console && source ~/.bashrc && /root/.local/share/pnpm/pnpm install && /root/.local/share/pnpm/pnpm build"
 
 EXPOSE 8000 8001
 


### PR DESCRIPTION
This brings us to parity between x86 and arm64. I disabled wasm-opt as it doesn't support arm64, per this ticket:  https://github.com/WebAssembly/binaryen/issues/5337.