### PR TITLE
Run workflows on pull requests as well as pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-rust:


### PR DESCRIPTION
This is required for workflows to run on PRs opened by outside contributors