### PR TITLE
use parse_quote for typed quoting in arroyo-sql.

### DIFF
--- a/arroyo-server-common/src/lib.rs
+++ b/arroyo-server-common/src/lib.rs
@@ -10,7 +10,7 @@ use hyper::Body;
 use lazy_static::lazy_static;
 use prometheus::{register_int_counter, IntCounter, TextEncoder};
 #[cfg(linux)]
-use pyroscope::{PyroscopeAgent, pyroscope::PyroscopeAgentRunning};
+use pyroscope::{pyroscope::PyroscopeAgentRunning, PyroscopeAgent};
 #[cfg(linux)]
 use pyroscope_pprofrs::{pprof_backend, PprofConfig};
 use std::str::FromStr;
@@ -28,7 +28,7 @@ use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::{DefaultOnFailure, TraceLayer};
 
 use tracing::metadata::LevelFilter;
-use tracing::{info, span, warn, Level};
+use tracing::{info, span, Level};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -20,12 +20,12 @@ use datafusion_expr::{
 };
 use petgraph::graph::{DiGraph, NodeIndex};
 use quote::{format_ident, quote};
-use syn::{parse_str, Type};
+use syn::{parse_quote, parse_str, Type};
 
 use crate::{
     expressions::{
-        parse_expression, to_expression_generator, Column, ColumnExpression, Expression,
-        ExpressionGenerator, SortExpression,
+        to_expression_generator, Column, ColumnExpression, Expression, ExpressionGenerator,
+        SortExpression,
     },
     operators::{
         AggregateProjection, GroupByKind, Projection, TwoPhaseAggregateProjection,
@@ -278,13 +278,12 @@ impl JoinOperator {
 
         let return_struct = self.output_struct(left_struct, right_struct);
         let return_type = return_struct.get_type();
-        let tokens = quote!(
+        parse_quote!(
                 #return_type {
                     #(#assignments)
                     ,*
                 }
-        );
-        parse_expression(tokens)
+        )
     }
 }
 

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -827,7 +827,10 @@ impl Engine {
 
         thread::spawn(move || {
             #[cfg(linux)]
-            let _agent = arroyo_server_common::try_profile_start("node", [("job_id", job_id.as_str())].to_vec());
+            let _agent = arroyo_server_common::try_profile_start(
+                "node",
+                [("job_id", job_id.as_str())].to_vec(),
+            );
             // push to metrics gateway
             loop {
                 let metrics = prometheus::gather();


### PR DESCRIPTION
We were jumping through some hoops because I didn't know about parse_quote!(), which is basically a typed quote!(). 