### PR TITLE
remove key_range from TaskAssignment

### DIFF
--- a/arroyo-compiler-service/src/main.rs
+++ b/arroyo-compiler-service/src/main.rs
@@ -206,7 +206,6 @@ impl CompilerGrpc for CompileService {
         &self,
         request: Request<CompileQueryReq>,
     ) -> Result<Response<CompileQueryResp>, Status> {
-
         self.last_used
             .store(to_millis(SystemTime::now()), Ordering::Relaxed);
 

--- a/arroyo-rpc/proto/rpc.proto
+++ b/arroyo-rpc/proto/rpc.proto
@@ -264,15 +264,9 @@ message TableDescriptor {
 
 // Worker
 
-message KeyRange {
-  uint64 start = 1;
-  uint64 end = 2;
-}
-
 message TaskAssignment {
   string operator_id = 1;
   uint64 operator_subtask = 2;
-  KeyRange key_range = 3;
   uint64 worker_id = 4;
   string worker_addr = 5;
 }

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info, warn};
 pub use arroyo_macro::StreamNode;
 use arroyo_rpc::grpc::controller_grpc_client::ControllerGrpcClient;
 use arroyo_rpc::grpc::{
-    CheckpointMetadata, HeartbeatReq, KeyRange, TableDeleteBehavior, TableDescriptor, TableType,
+    CheckpointMetadata, HeartbeatReq, TableDeleteBehavior, TableDescriptor, TableType,
     TableWriteBehavior, TaskAssignment, TaskCheckpointCompletedReq, TaskCheckpointEventReq,
     TaskFailedReq, TaskFinishedReq, TaskStartedReq,
 };
@@ -784,10 +784,6 @@ impl Engine {
                     TaskAssignment {
                         operator_id: n.id().to_string(),
                         operator_subtask: n.subtask_idx() as u64,
-                        key_range: Some(KeyRange {
-                            start: 0,
-                            end: u64::MAX,
-                        }),
                         worker_id: worker_id.0,
                         worker_addr: "locahost:0".to_string(),
                     },


### PR DESCRIPTION
We aren't using this, which is good because the range_for_subtask function has some edge cases we weren't handling. The functions actually used for assigning ranges are correct.