### PR TITLE
better S3 environment variable names.

### DIFF
--- a/arroyo-compiler-service/src/main.rs
+++ b/arroyo-compiler-service/src/main.rs
@@ -38,7 +38,7 @@ pub async fn main() {
 
     let last_used = Arc::new(AtomicU64::new(to_millis(SystemTime::now())));
 
-    let s3_bucket = std::env::var("S3_BUCKET").ok();
+    let s3_bucket = std::env::var("S3_COMPILER_BUCKET").ok();
     let s3_region = std::env::var("S3_REGION").ok();
     let output_dir = std::env::var("OUTPUT_DIR").ok();
 

--- a/arroyo-state/src/parquet.rs
+++ b/arroyo-state/src/parquet.rs
@@ -33,8 +33,8 @@ use tokio::sync::oneshot;
 use tracing::warn;
 use tracing::{debug, info};
 
-pub const S3_STORAGE_ENGINE_ENV: &str = "S3_BUCKET";
-pub const S3_REGION_ENV: &str = "S3_STORAGE_REGION";
+pub const S3_STORAGE_ENGINE_ENV: &str = "S3_STORAGE_BUCKET";
+pub const S3_REGION_ENV: &str = "S3_REGION";
 
 pub struct ParquetBackend {
     epoch: u32,


### PR DESCRIPTION
compiler and state should share a region, but have different bucket variables.