### PR TITLE
Windowless Joins

### DIFF
--- a/arroyo-console/src/routes/sources/ConfigureSource.tsx
+++ b/arroyo-console/src/routes/sources/ConfigureSource.tsx
@@ -51,7 +51,7 @@ function ConfigureImpulse({
         <Input
           type="number"
           value={config.intervalMicros}
-          onChange={onChangeNumber(state, setState, "intervalMs", config)}
+          onChange={onChangeNumber(state, setState, "intervalMicros", config)}
         />
         <FormHelperText>
           The number of microseconds in between the event times of subsequent events emmitted by the

--- a/arroyo-node/src/main.rs
+++ b/arroyo-node/src/main.rs
@@ -10,7 +10,7 @@ use arroyo_rpc::grpc::{
     controller_grpc_client::ControllerGrpcClient, node_grpc_server::NodeGrpc,
     node_grpc_server::NodeGrpcServer, GetWorkersReq, GetWorkersResp, HeartbeatNodeReq,
     RegisterNodeReq, StartWorkerReq, StartWorkerResp, StopWorkerReq, StopWorkerResp,
-    WorkerFinishedReq,
+    StopWorkerStatus, WorkerFinishedReq,
 };
 use arroyo_types::{
     grpc_port, ports, to_millis, NodeId, WorkerId, CONTROLLER_ADDR_ENV, JOB_ID_ENV, NODE_ID_ENV,
@@ -199,14 +199,14 @@ impl NodeGrpc for NodeServer {
         let (running, pid, job_id) = {
             let workers = self.workers.lock().unwrap();
 
-            let worker = workers.get(&WorkerId(req.worker_id)).ok_or_else(|| {
-                Status::failed_precondition(format!("No worker with id {}", req.worker_id))
-            })?;
+            let Some(worker) = workers.get(&WorkerId(req.worker_id)) else {
+                return Ok(Response::new(StopWorkerResp { status: StopWorkerStatus::NotFound.into()}));
+            };
 
             (worker.running, worker.pid, worker.job_id.clone())
         };
 
-        let stopped = if running {
+        let status = if running {
             info!(
                 message = "stopping worker",
                 worker_id = req.worker_id,
@@ -224,8 +224,15 @@ impl NodeGrpc for NodeServer {
             );
             true
         };
+        let status = if status {
+            StopWorkerStatus::Stopped
+        } else {
+            StopWorkerStatus::StopFailed
+        };
 
-        Ok(Response::new(StopWorkerResp { stopped }))
+        Ok(Response::new(StopWorkerResp {
+            status: status.into(),
+        }))
     }
 
     async fn get_workers(

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -145,6 +145,7 @@ message Operator {
     TumblingWindowAggregator tumbling_window_aggregator = 18;
     TumblingTopN tumbling_top_n = 19;
     SlidingAggregatingTopN sliding_aggregating_top_n = 20;
+    JoinWithExpiration join_with_expiration = 21;
   }
 }
 
@@ -308,6 +309,11 @@ message SlidingAggregatingTopN {
   string mem_type = 10;
   string sort_key_type = 11;
   uint64 max_elements = 12;
+}
+
+message JoinWithExpiration {
+  uint64 left_expiration_micros = 1;
+  uint64 right_expiration_micros = 2;
 }
 enum ExpressionReturnType {
   UNUSED_ERT = 0;

--- a/arroyo-rpc/proto/rpc.proto
+++ b/arroyo-rpc/proto/rpc.proto
@@ -181,7 +181,6 @@ message ParquetStoreData {
   uint64 max_timestamp_micros = 6;
 }
 
-
 // Checkpoint metadata
 message CheckpointMetadata {
   string job_id = 1;
@@ -355,7 +354,13 @@ message StopWorkerReq {
 }
 
 message StopWorkerResp {
-  bool stopped = 1;
+  StopWorkerStatus status = 1;
+}
+enum StopWorkerStatus {
+  PLACEHOLDER = 0;
+  STOPPED = 1;
+  STOP_FAILED = 2;
+  NOT_FOUND = 3;
 }
 
 service NodeGrpc {

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -407,7 +407,10 @@ impl Column {
         if let datafusion_expr::Expr::Column(column) = expr {
             Ok(Self::convert(column))
         } else {
-            bail!("only support converting column expressions to columns.")
+            bail!(
+                "only support converting column expressions to columns, not {}",
+                expr
+            )
         }
     }
 }

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -135,6 +135,14 @@ pub fn interval_month_day_nanos_to_duration(serialized_value: i128) -> Duration 
     std::time::Duration::from_secs(days_to_seconds) + std::time::Duration::from_nanos(nanos)
 }
 
+// quote a duration as a syn::Expr
+pub fn duration_to_syn_expr(duration: Duration) -> syn::Expr {
+    let secs = duration.as_secs();
+    let nanos = duration.subsec_nanos();
+
+    parse_quote!(std::time::Duration::new(#secs, #nanos))
+}
+
 impl From<StructField> for Field {
     fn from(struct_field: StructField) -> Self {
         let (dt, nullable) = match struct_field.data_type {

--- a/arroyo-state/src/tables.rs
+++ b/arroyo-state/src/tables.rs
@@ -271,7 +271,10 @@ impl<'a, K: Key, V: Data, S: BackingStore> KeyTimeMultiMap<'a, K, V, S> {
         self.cache.expire_entries_before(expiration_time);
     }
 
-    pub async fn get_all_values_with_timestamps(&mut self, key: &mut K) -> Vec<(SystemTime, &V)> {
+    pub async fn get_all_values_with_timestamps(
+        &mut self,
+        key: &mut K,
+    ) -> Option<impl Iterator<Item = (SystemTime, &V)>> {
         self.cache.get_all_values_with_timestamps(key)
     }
 }
@@ -328,14 +331,17 @@ impl<K: Key, V: Data> KeyTimeMultiMapCache<K, V> {
         }
     }
 
-    fn get_all_values_with_timestamps(&mut self, key: &mut K) -> Vec<(SystemTime, &V)> {
-        if let Some(key_map) = self.values.get_mut(key) {
-            key_map
+    fn get_all_values_with_timestamps(
+        &mut self,
+        key: &mut K,
+    ) -> Option<impl Iterator<Item = (SystemTime, &V)>> {
+        if let Some(key_map) = self.values.get(key) {
+            let result = key_map
                 .iter()
-                .flat_map(|(time, values)| values.iter().map(move |value| (*time, value)))
-                .collect()
+                .flat_map(|(time, values)| values.iter().map(move |value| (*time, value)));
+            Some(result)
         } else {
-            vec![]
+            None
         }
     }
 

--- a/arroyo-worker/src/operators/join_with_expiration.rs
+++ b/arroyo-worker/src/operators/join_with_expiration.rs
@@ -1,0 +1,124 @@
+use std::{marker::PhantomData, time::Duration};
+
+use arroyo_macro::{co_process_fn, StreamNode};
+use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableType, TableWriteBehavior};
+use arroyo_state::tables::KeyTimeMultiMap;
+use arroyo_types::*;
+
+use crate::engine::Context;
+
+#[derive(StreamNode)]
+pub struct JoinWithExpiration<K: Key, T1: Data, T2: Data> {
+    left_expiration: Duration,
+    right_expiration: Duration,
+    _t: PhantomData<(K, T1, T2)>,
+}
+
+#[co_process_fn(in_k1=K, in_t1=T1, in_k2=K, in_t2=T2, out_k=K, out_t=(T1,T2))]
+impl<K: Key, T1: Data, T2: Data> JoinWithExpiration<K, T1, T2> {
+    fn name(&self) -> String {
+        "JoinWithExperiation".to_string()
+    }
+
+    pub fn new(left_expiration: Duration, right_expiration: Duration) -> Self {
+        Self {
+            left_expiration,
+            right_expiration,
+            _t: PhantomData,
+        }
+    }
+
+    fn tables(&self) -> Vec<TableDescriptor> {
+        vec![
+            TableDescriptor {
+                name: "l".to_string(),
+                description: "join left state".to_string(),
+                table_type: TableType::KeyTimeMultiMap as i32,
+                delete_behavior: TableDeleteBehavior::NoReadsBeforeWatermark as i32,
+                write_behavior: TableWriteBehavior::NoWritesBeforeWatermark as i32,
+                retention_micros: self.left_expiration.as_micros() as u64,
+            },
+            TableDescriptor {
+                name: "r".to_string(),
+                description: "join right state".to_string(),
+                table_type: TableType::KeyTimeMultiMap as i32,
+                delete_behavior: TableDeleteBehavior::NoReadsBeforeWatermark as i32,
+                write_behavior: TableWriteBehavior::NoWritesBeforeWatermark as i32,
+                retention_micros: self.right_expiration.as_micros() as u64,
+            },
+        ]
+    }
+
+    async fn process_left(&mut self, record: &Record<K, T1>, ctx: &mut Context<K, (T1, T2)>) {
+        if let Some(watermark) = ctx.watermark() {
+            if record.timestamp < watermark {
+                return;
+            }
+        };
+        let mut right_state: KeyTimeMultiMap<K, T2, _> =
+            ctx.state.get_key_time_multi_map('r').await;
+        let mut key = record.key.clone().unwrap();
+        let value = record.value.clone();
+        let records = {
+            let right_rows = right_state.get_all_values_with_timestamps(&mut key).await;
+            let mut records = vec![];
+            for (timestamp, right_value) in right_rows {
+                records.push(Record {
+                    timestamp: record.timestamp.max(timestamp),
+                    key: Some(key.clone()),
+                    value: (value.clone(), right_value.clone()),
+                });
+            }
+            records
+        };
+        for record in records {
+            ctx.collect(record).await;
+        }
+        let mut left_state = ctx.state.get_key_time_multi_map('l').await;
+        left_state.insert(record.timestamp, key, value).await;
+    }
+
+    async fn process_right(&mut self, record: &Record<K, T2>, ctx: &mut Context<K, (T1, T2)>) {
+        if let Some(watermark) = ctx.watermark() {
+            if record.timestamp < watermark {
+                return;
+            }
+        };
+
+        let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;
+        let mut key = record.key.clone().unwrap();
+        let value = record.value.clone();
+        let records = {
+            let left_rows = left_state.get_all_values_with_timestamps(&mut key).await;
+            let mut records = vec![];
+            for (timestamp, left_value) in left_rows {
+                records.push(Record {
+                    timestamp: record.timestamp.max(timestamp),
+                    key: Some(key.clone()),
+                    value: (left_value.clone(), value.clone()),
+                });
+            }
+            records
+        };
+        for record in records {
+            ctx.collect(record).await;
+        }
+        let mut right_state = ctx.state.get_key_time_multi_map('r').await;
+        right_state.insert(record.timestamp, key, value).await;
+    }
+
+    async fn handle_watermark(
+        &mut self,
+        _watermark: std::time::SystemTime,
+        ctx: &mut Context<K, (T1, T2)>,
+    ) {
+        let Some(watermark) = ctx.watermark() else {return};
+        let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;
+        left_state.expire_entries_before(watermark - self.left_expiration);
+        let mut right_state: KeyTimeMultiMap<K, T2, _> =
+            ctx.state.get_key_time_multi_map('r').await;
+        right_state.expire_entries_before(watermark - self.right_expiration);
+        ctx.broadcast(arroyo_types::Message::Watermark(watermark))
+            .await;
+    }
+}

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -20,6 +20,7 @@ use wasmtime::{
     PoolingAllocationStrategy, Store, TypedFunc,
 };
 pub mod aggregating_window;
+pub mod join_with_expiration;
 pub mod joins;
 pub mod sinks;
 pub mod sliding_top_n_aggregating_window;

--- a/arroyo-worker/src/operators/sources/mod.rs
+++ b/arroyo-worker/src/operators/sources/mod.rs
@@ -36,7 +36,7 @@ pub enum ImpulseSpec {
     EventsPerSecond(f32),
 }
 
-#[derive(StreamNode)]
+#[derive(StreamNode, Debug)]
 pub struct ImpulseSourceFunc {
     interval: Option<Duration>,
     spec: ImpulseSpec,
@@ -112,7 +112,6 @@ impl ImpulseSourceFunc {
                 .interval
                 .map(|d| self.state.start_time + d * self.state.counter as u32)
                 .unwrap_or_else(SystemTime::now);
-
             ctx.collect(Record {
                 timestamp,
                 key: None,

--- a/arroyo-worker/src/operators/sources/nexmark/mod.rs
+++ b/arroyo-worker/src/operators/sources/nexmark/mod.rs
@@ -247,7 +247,7 @@ impl NexmarkConfig {
             num_active_people: 1000,
             occasional_delay_seconds: 3,
             prob_delayed_event: 0.1,
-            out_of_order_group_size: 1,
+            out_of_order_group_size: 50,
         }
     }
 


### PR DESCRIPTION
This changes how we handle joins whose inputs don't contain a preceding window operator. Now each record is joined against all of the existing records on the other side, emitting pairs. This only supports inner joins. I've also made several changes/improvements, including

- Standardize how Durations are quoted into a single function `duration_to_syn_expr()`.
- Fix support for impulses with a specified intervalMicros.
- Add some out-of-orderness to Nexmark.
- Set the default allowed-lateness for SQL pipelines to 1 second, rather than 0.