### PR TITLE
Add pipeline edit modal with parallelism control

### DIFF
--- a/arroyo-console/src/routes/pipelines/PipelineConfigModal.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineConfigModal.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+} from "@chakra-ui/react";
+
+export interface PipelineConfigModalProps {
+  isOpen: boolean;
+  parallelism: number;
+  onClose: () => void;
+  updateJobParallelism: (parallelism: number) => void;
+}
+
+const MAX_PARALLELISM = 10;
+
+const PipelineConfigModal: React.FC<PipelineConfigModalProps> = ({
+  isOpen,
+  parallelism,
+  onClose,
+  updateJobParallelism,
+}) => {
+  const [parallelismInputValue, setParallelismInputValue] = useState<number | undefined>(
+    parallelism
+  );
+
+  const close = () => {
+    onClose();
+
+    // reset state
+    setParallelismInputValue(parallelism);
+  };
+
+  const onConfirm = () => {
+    if (parallelismInputValue) {
+      updateJobParallelism(parallelismInputValue);
+    }
+    onClose();
+  };
+
+  const pipelineRequiresRestart = parallelismInputValue != parallelism;
+
+  let changeAlert = <></>;
+  if (pipelineRequiresRestart) {
+    changeAlert = (
+      <Alert status="warning">
+        <AlertIcon />
+        <AlertDescription>These changes require a pipeline restart.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const parallelismInput = (
+    <NumberInput
+      isRequired
+      min={1}
+      max={MAX_PARALLELISM}
+      value={parallelismInputValue ?? ""}
+      onChange={(valueAsString, valueAsNumber) => {
+        if (isNaN(valueAsNumber)) {
+          setParallelismInputValue(undefined);
+        } else {
+          setParallelismInputValue(valueAsNumber);
+        }
+      }}
+    >
+      <NumberInputField bg="gray.800" />
+      <NumberInputStepper>
+        <NumberIncrementStepper />
+        <NumberDecrementStepper />
+      </NumberInputStepper>
+    </NumberInput>
+  );
+
+  let parallelismHasError = false;
+  let parallelismErrorText = "";
+  let saveEnabled: boolean;
+
+  if (!parallelismInputValue) {
+    parallelismHasError = true;
+    parallelismErrorText = "Enter a valid number.";
+  }
+
+  saveEnabled = !parallelismHasError;
+
+  const parallelismForm = (
+    <FormControl isRequired isInvalid={parallelismHasError}>
+      <FormLabel>Parallelism</FormLabel>
+      {parallelismInput}
+      <FormHelperText>Number of parallel substacks for each node (maximum 10)</FormHelperText>
+      <FormErrorMessage>{parallelismErrorText}</FormErrorMessage>
+    </FormControl>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={close}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Edit Pipeline Configuration</ModalHeader>
+        <ModalCloseButton />
+        {changeAlert}
+        <ModalBody>{parallelismForm}</ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" mr={3} isDisabled={!saveEnabled} onClick={onConfirm}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default PipelineConfigModal;


### PR DESCRIPTION
Add an "Edit" button on the job details page that opens up a modal. The modal contains a form that can be used to change the parallelism.

Resolves: #74

---

This is a work in progress. Still to do:

- [x] add more validation to the form
- [ ] ~~indicate on the job details page that the pipeline is restarting~~
  I guess it already does this?
- [ ] maybe change the design of the restart warning?

---

The modal:
<img width="1582" alt="image" src="https://user-images.githubusercontent.com/8881183/234272065-49abbe89-0d0c-4a82-9a56-044d9ed26cb5.png">

If you change the parallelism value:

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/8881183/234272212-f0b691b2-f6da-4052-8f82-7a9a97dbc996.png">
