### PR TITLE
Helm: Create service account for Postgres deployment

### DIFF
--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -74,6 +74,10 @@ postgresql:
     initdb:
       user: postgres
 
+  serviceAccount:
+    create: true
+    name: arroyo-postgresql
+
 
 prometheus:
   deploy: true


### PR DESCRIPTION
The default service account for the Postgres is `default`.
The change will be useful for the end users to apply extra policies for special deployments.
Such as `PodSecurityPolicy`.

Ref: https://github.com/bitnami/charts/tree/main/bitnami/postgresql#other-parameters

This change worked on my K8s cluster.