### PR TITLE
MVP of Rust UDFs

### DIFF
--- a/arroyo-api/migrations/V3__add_udfs.sql
+++ b/arroyo-api/migrations/V3__add_udfs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pipeline_definitions
+ADD COLUMN udfs JSONB NOT NULL DEFAULT '[]';

--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -99,13 +99,13 @@ INSERT INTO pipelines (organization_id, created_by, name, type, current_version)
 VALUES (:organization_id, :created_by, :name, :type, :current_version)
 RETURNING id;
 
---! create_pipeline_definition (textual_repr?)
-INSERT INTO pipeline_definitions (organization_id, created_by, pipeline_id, version, textual_repr, program)
-VALUES  (:organization_id, :created_by, :pipeline_id, :version, :textual_repr, :program)
+--! create_pipeline_definition (textual_repr?, udfs?)
+INSERT INTO pipeline_definitions (organization_id, created_by, pipeline_id, version, textual_repr, udfs, program)
+VALUES  (:organization_id, :created_by, :pipeline_id, :version, :textual_repr, :udfs, :program)
 RETURNING id;
 
---! get_pipeline: DbPipeline(textual_repr?)
-SELECT pipelines.id as id, name, type, textual_repr, program FROM pipelines
+--! get_pipeline: DbPipeline(textual_repr?, udfs?)
+SELECT pipelines.id as id, name, type, textual_repr, udfs, program FROM pipelines
 INNER JOIN pipeline_definitions as d ON pipelines.id = d.pipeline_id AND pipelines.current_version = d.version
 WHERE pipelines.id = :pipeline_id AND pipelines.organization_id = :organization_id;
 
@@ -143,16 +143,16 @@ VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_definition
 --! create_job_status
 INSERT INTO job_statuses (id, organization_id) VALUES (:id, :organization_id);
 
---! get_jobs: (start_time?, finish_time?, state?, tasks?, textual_repr?, failure_message?, run_id?)
-SELECT job_configs.id as id, pipeline_name, stop, textual_repr, start_time, finish_time, state, tasks, pipeline_definition, failure_message, run_id
+--! get_jobs: (start_time?, finish_time?, state?, tasks?, textual_repr?, failure_message?, run_id?, udfs?)
+SELECT job_configs.id as id, pipeline_name, stop, textual_repr, start_time, finish_time, state, tasks, pipeline_definition, failure_message, run_id, udfs
 FROM job_configs
          LEFT JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipeline_definitions ON pipeline_definition = pipeline_definitions.id
 WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
---! get_job_details: (start_time?, finish_time?, state?, tasks?, textual_repr?, failure_message?, run_id?)
-SELECT pipeline_name, stop, parallelism_overrides, state, start_time, finish_time, tasks, textual_repr, program, pipeline_definition, failure_message, run_id
+--! get_job_details: (start_time?, finish_time?, state?, tasks?, textual_repr?, udfs?, failure_message?, run_id?)
+SELECT pipeline_name, stop, parallelism_overrides, state, start_time, finish_time, tasks, textual_repr, program, pipeline_definition, udfs, failure_message, run_id
 FROM job_configs
          LEFT JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipeline_definitions ON pipeline_definition = pipeline_definitions.id

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -28,6 +28,12 @@ use crate::{
     AuthData,
 };
 
+const TEST_UDF: &'static str = r#"
+fn test_udf(x: u64) -> u64 {
+  x * x
+}
+"#;
+
 async fn compile_sql<'e, E>(
     sql: &CreateSqlJob,
     auth_data: &AuthData,

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -29,8 +29,8 @@ use crate::{
 };
 
 const TEST_UDF: &'static str = r#"
-fn test_udf(x: u64) -> u64 {
-  x * x
+fn my_sqr(x: Option<u64>) -> Option<u64> {
+  Some(x? * x?)
 }
 "#;
 
@@ -43,6 +43,8 @@ where
     E: GenericClient,
 {
     let mut schema_provider = ArroyoSchemaProvider::new();
+
+    schema_provider.add_rust_udf(TEST_UDF).unwrap();
 
     for source in sources::get_sources(auth_data, tx).await? {
         let s: Source = source.try_into().map_err(log_and_map)?;

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -5,7 +5,7 @@ use arroyo_rpc::grpc::api::sink::SinkType;
 use arroyo_rpc::grpc::api::{
     self, connection, create_pipeline_req, BuiltinSink, Connection, CreatePipelineReq,
     CreateSqlJob, PipelineDef, PipelineGraphReq, PipelineGraphResp, PipelineProgram, SqlError,
-    SqlErrors,
+    SqlErrors, Udf, UdfLanguage,
 };
 use arroyo_sql::{ArroyoSchemaProvider, SqlConfig};
 
@@ -13,6 +13,7 @@ use cornucopia_async::GenericClient;
 use deadpool_postgres::Transaction;
 use petgraph::Direction;
 use prost::Message;
+use serde_json::Value;
 use tracing::log::info;
 
 use std::str::FromStr;
@@ -28,12 +29,6 @@ use crate::{
     AuthData,
 };
 
-const TEST_UDF: &'static str = r#"
-fn my_sqr(x: Option<u64>) -> Option<u64> {
-  Some(x? * x?)
-}
-"#;
-
 async fn compile_sql<'e, E>(
     sql: &CreateSqlJob,
     auth_data: &AuthData,
@@ -44,7 +39,18 @@ where
 {
     let mut schema_provider = ArroyoSchemaProvider::new();
 
-    schema_provider.add_rust_udf(TEST_UDF).unwrap();
+    for (i, udf) in sql.udfs.iter().enumerate() {
+        match UdfLanguage::from_i32(udf.language) {
+            Some(UdfLanguage::Rust) => {
+                schema_provider.add_rust_udf(&udf.definition).map_err(|e| {
+                    Status::invalid_argument(format!("Could not process UDF: {:?}", e))
+                })?;
+            }
+            None => {
+                return Err(required_field(&format!("udfs[{}].language", i)));
+            }
+        }
+    }
 
     for source in sources::get_sources(auth_data, tx).await? {
         let s: Source = source.try_into().map_err(log_and_map)?;
@@ -181,6 +187,7 @@ pub(crate) async fn create_pipeline<'a>(
     let sinks;
     let text;
     let compute_parallelism;
+    let udfs: Option<Vec<Udf>>;
 
     match req.config.ok_or_else(|| required_field("config"))? {
         create_pipeline_req::Config::Program(bytes) => {
@@ -197,6 +204,7 @@ pub(crate) async fn create_pipeline<'a>(
             sources = vec![];
             sinks = vec![];
             text = None;
+            udfs = None;
             compute_parallelism = false;
         }
         create_pipeline_req::Config::Sql(sql) => {
@@ -211,6 +219,15 @@ pub(crate) async fn create_pipeline<'a>(
             pipeline_type = PipelineType::sql;
             (program, sources, sinks) = compile_sql(&sql, &auth, tx).await?;
             text = Some(sql.query);
+            udfs = Some(
+                sql.udfs
+                    .iter()
+                    .map(|t| Udf {
+                        language: t.language.clone(),
+                        definition: t.definition.clone(),
+                    })
+                    .collect(),
+            );
             compute_parallelism = sql.parallelism == 0;
         }
     };
@@ -271,6 +288,7 @@ pub(crate) async fn create_pipeline<'a>(
             &pipeline_id,
             &version,
             &text,
+            &udfs.map(|t| serde_json::to_value(&t).unwrap()),
             &program,
         )
         .one()
@@ -310,6 +328,8 @@ impl TryInto<PipelineDef> for DbPipeline {
             name: self.name,
             r#type: format!("{:?}", self.r#type),
             definition: self.textual_repr,
+            udfs: serde_json::from_value(self.udfs.unwrap_or_else(|| Value::Array(vec![])))
+                .map_err(log_and_map)?,
             job_graph: Some(program.as_job_graph()),
         })
     }
@@ -343,6 +363,7 @@ pub(crate) async fn sql_graph(
     let sql = CreateSqlJob {
         query: req.query,
         parallelism: 1,
+        udfs: req.udfs,
         sink: Some(Sink::Builtin(BuiltinSink::Null as i32)),
     };
 

--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -33,6 +33,20 @@ proto3.util.setEnumType(BuiltinSink, "arroyo_api.BuiltinSink", [
 ]);
 
 /**
+ * @generated from enum arroyo_api.UdfLanguage
+ */
+export enum UdfLanguage {
+  /**
+   * @generated from enum value: Rust = 0;
+   */
+  Rust = 0,
+}
+// Retrieve enum metadata with: proto3.getEnumType(UdfLanguage)
+proto3.util.setEnumType(UdfLanguage, "arroyo_api.UdfLanguage", [
+  { no: 0, name: "Rust" },
+]);
+
+/**
  * @generated from enum arroyo_api.StopType
  */
 export enum StopType {
@@ -383,6 +397,49 @@ proto3.util.setEnumType(KafkaOffsetMode, "arroyo_api.KafkaOffsetMode", [
 ]);
 
 /**
+ * @generated from message arroyo_api.CreateUdf
+ */
+export class CreateUdf extends Message<CreateUdf> {
+  /**
+   * @generated from field: arroyo_api.UdfLanguage language = 1;
+   */
+  language = UdfLanguage.Rust;
+
+  /**
+   * @generated from field: string definition = 2;
+   */
+  definition = "";
+
+  constructor(data?: PartialMessage<CreateUdf>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.CreateUdf";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "language", kind: "enum", T: proto3.getEnumType(UdfLanguage) },
+    { no: 2, name: "definition", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateUdf {
+    return new CreateUdf().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CreateUdf {
+    return new CreateUdf().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CreateUdf {
+    return new CreateUdf().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: CreateUdf | PlainMessage<CreateUdf> | undefined, b: CreateUdf | PlainMessage<CreateUdf> | undefined): boolean {
+    return proto3.util.equals(CreateUdf, a, b);
+  }
+}
+
+/**
  * @generated from message arroyo_api.CreateSqlJob
  */
 export class CreateSqlJob extends Message<CreateSqlJob> {
@@ -395,6 +452,11 @@ export class CreateSqlJob extends Message<CreateSqlJob> {
    * @generated from field: uint64 parallelism = 2;
    */
   parallelism = protoInt64.zero;
+
+  /**
+   * @generated from field: repeated arroyo_api.CreateUdf udfs = 5;
+   */
+  udfs: CreateUdf[] = [];
 
   /**
    * @generated from oneof arroyo_api.CreateSqlJob.sink
@@ -423,6 +485,7 @@ export class CreateSqlJob extends Message<CreateSqlJob> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "parallelism", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 5, name: "udfs", kind: "message", T: CreateUdf, repeated: true },
     { no: 3, name: "builtin", kind: "enum", T: proto3.getEnumType(BuiltinSink), oneof: "sink" },
     { no: 4, name: "user", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "sink" },
   ]);
@@ -620,6 +683,11 @@ export class PipelineGraphReq extends Message<PipelineGraphReq> {
    */
   query = "";
 
+  /**
+   * @generated from field: repeated arroyo_api.CreateUdf udfs = 2;
+   */
+  udfs: CreateUdf[] = [];
+
   constructor(data?: PartialMessage<PipelineGraphReq>) {
     super();
     proto3.util.initPartial(data, this);
@@ -629,6 +697,7 @@ export class PipelineGraphReq extends Message<PipelineGraphReq> {
   static readonly typeName = "arroyo_api.PipelineGraphReq";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "udfs", kind: "message", T: CreateUdf, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PipelineGraphReq {
@@ -736,6 +805,49 @@ export class GetPipelineReq extends Message<GetPipelineReq> {
 }
 
 /**
+ * @generated from message arroyo_api.Udf
+ */
+export class Udf extends Message<Udf> {
+  /**
+   * @generated from field: arroyo_api.UdfLanguage language = 1;
+   */
+  language = UdfLanguage.Rust;
+
+  /**
+   * @generated from field: string definition = 2;
+   */
+  definition = "";
+
+  constructor(data?: PartialMessage<Udf>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.Udf";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "language", kind: "enum", T: proto3.getEnumType(UdfLanguage) },
+    { no: 2, name: "definition", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Udf {
+    return new Udf().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Udf {
+    return new Udf().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Udf {
+    return new Udf().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Udf | PlainMessage<Udf> | undefined, b: Udf | PlainMessage<Udf> | undefined): boolean {
+    return proto3.util.equals(Udf, a, b);
+  }
+}
+
+/**
  * @generated from message arroyo_api.PipelineDef
  */
 export class PipelineDef extends Message<PipelineDef> {
@@ -760,6 +872,11 @@ export class PipelineDef extends Message<PipelineDef> {
   definition?: string;
 
   /**
+   * @generated from field: repeated arroyo_api.Udf udfs = 6;
+   */
+  udfs: Udf[] = [];
+
+  /**
    * @generated from field: arroyo_api.JobGraph job_graph = 5;
    */
   jobGraph?: JobGraph;
@@ -776,6 +893,7 @@ export class PipelineDef extends Message<PipelineDef> {
     { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "definition", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 6, name: "udfs", kind: "message", T: Udf, repeated: true },
     { no: 5, name: "job_graph", kind: "message", T: JobGraph },
   ]);
 
@@ -2820,6 +2938,11 @@ export class JobStatus extends Message<JobStatus> {
   definition?: string;
 
   /**
+   * @generated from field: repeated arroyo_api.Udf udfs = 12;
+   */
+  udfs: Udf[] = [];
+
+  /**
    * @generated from field: optional string failure_message = 10;
    */
   failureMessage?: string;
@@ -2842,6 +2965,7 @@ export class JobStatus extends Message<JobStatus> {
     { no: 5, name: "finish_time", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
     { no: 6, name: "tasks", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
     { no: 7, name: "definition", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 12, name: "udfs", kind: "message", T: Udf, repeated: true },
     { no: 10, name: "failure_message", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
   ]);
 

--- a/arroyo-console/src/routes/pipelines/JobDetail.tsx
+++ b/arroyo-console/src/routes/pipelines/JobDetail.tsx
@@ -77,7 +77,7 @@ import * as util from "../../lib/util";
 import { PipelineGraph } from "./JobGraph";
 import { ApiClient } from "../../main";
 import { PipelineOutputs } from "./JobOutputs";
-import { SqlEditor } from "./SqlEditor";
+import { CodeEditor } from "./SqlEditor";
 import PipelineConfigModal from "./PipelineConfigModal";
 
 interface JobDetailState {
@@ -225,6 +225,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
           <Tab>Outputs</Tab>
           <Tab>Checkpoints</Tab>
           <Tab>Query</Tab>
+          <Tab>UDFs</Tab>
         </TabList>
         <TabPanels h="100%">
           <TabPanel h="100%">
@@ -283,7 +284,15 @@ export function JobDetail({ client }: { client: ApiClient }) {
 
           <TabPanel>
             <Box>
-              <SqlEditor query={state.pipeline?.jobStatus?.definition!} readOnly={true} />
+              <CodeEditor query={state.pipeline?.jobStatus?.definition!} readOnly={true} />
+            </Box>
+          </TabPanel>
+
+          <TabPanel>
+            <Box>
+              <CodeEditor query={(state.pipeline?.jobStatus?.udfs || [{definition: ""}])[0].definition}
+                language="rust"
+                readOnly={true} />
             </Box>
           </TabPanel>
         </TabPanels>

--- a/arroyo-console/src/routes/pipelines/SqlEditor.tsx
+++ b/arroyo-console/src/routes/pipelines/SqlEditor.tsx
@@ -2,7 +2,7 @@ import { Textarea } from "@chakra-ui/react";
 import Editor from "@monaco-editor/react";
 import { Dispatch } from "react";
 
-export function SqlEditor({ query, setQuery, readOnly }: { query: string; setQuery?: Dispatch<string>, readOnly?: boolean }) {
+export function CodeEditor({ query, setQuery, readOnly, language }: { query: string; setQuery?: Dispatch<string>, readOnly?: boolean, language?: string }) {
   const onChange = (value: string | undefined) => {
     if (setQuery != null) {
       setQuery(value || "");
@@ -12,7 +12,7 @@ export function SqlEditor({ query, setQuery, readOnly }: { query: string; setQue
   return (
     <Editor
       height="50vh"
-      defaultLanguage="sql"
+      defaultLanguage={language || "sql"}
       onChange={onChange}
       theme="vs-dark"
       options={{ minimap: { enabled: false }, wordWrap: "on", readOnly: readOnly || false }}

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -10,9 +10,21 @@ enum BuiltinSink {
   Log = 2;
 }
 
+
+enum UdfLanguage {
+  Rust = 0;
+}
+
+message CreateUdf {
+  string name = 1;
+  string body = 2;
+  UdfLanguage language = 3;
+}
+
 message CreateSqlJob {
   string query = 1;
   uint64 parallelism = 2;
+
   oneof sink {
     BuiltinSink builtin = 3;
     string user = 4;

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -16,14 +16,15 @@ enum UdfLanguage {
 }
 
 message CreateUdf {
-  string name = 1;
-  string body = 2;
-  UdfLanguage language = 3;
+  UdfLanguage language = 1;
+  string definition = 2;
 }
 
 message CreateSqlJob {
   string query = 1;
   uint64 parallelism = 2;
+
+  repeated CreateUdf udfs = 5;
 
   oneof sink {
     BuiltinSink builtin = 3;
@@ -53,6 +54,7 @@ message SqlErrors {
 
 message PipelineGraphReq {
   string query = 1;
+  repeated CreateUdf udfs = 2;
 }
 
 message PipelineGraphResp {
@@ -66,11 +68,17 @@ message GetPipelineReq {
   string pipeline_id = 1;
 }
 
+message Udf {
+  UdfLanguage language = 1;
+  string definition = 2;
+}
+
 message PipelineDef {
   string pipeline_id = 1;
   string name = 2;
   string type = 3;
   optional string definition = 4;
+  repeated Udf udfs = 6;
   JobGraph job_graph = 5;
 }
 
@@ -387,6 +395,7 @@ message JobStatus {
   optional uint64 finish_time = 5;
   optional uint64 tasks = 6;
   optional string definition = 7;
+  repeated Udf udfs = 12;
   optional string failure_message = 10;
 }
 

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -14,11 +14,11 @@ use datafusion_expr::{
     aggregate_function,
     expr::Sort,
     type_coercion::aggregates::{avg_return_type, sum_return_type},
-    BinaryExpr, BuiltinScalarFunction, Expr, ExprSchemable, TryCast, TypeSignature,
+    BinaryExpr, BuiltinScalarFunction, Expr, TryCast,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_quote, parse_str, Ident, ItemFn};
+use syn::{parse_quote, parse_str, Ident};
 
 #[derive(Debug, Clone)]
 pub struct BinaryOperator(datafusion_expr::Operator);

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::comparison_chain)]
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use anyhow::Result;
 use anyhow::{anyhow, bail};
 use arrow_schema::DataType;
 use arroyo_datastream::{Operator, Program, WindowType};
-use datafusion::catalog::schema::SchemaProvider;
 
 use datafusion_common::{DFField, ScalarValue};
 use datafusion_expr::{

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -17,10 +17,7 @@ use syn::{parse_quote, Type};
 use crate::expressions::ExpressionContext;
 use crate::{
     expressions::{AggregationExpression, Column, ColumnExpression, Expression, SortExpression},
-    operators::{
-        AggregateProjection, GroupByKind, Projection, TwoPhaseAggregateProjection,
-        TwoPhaseAggregation,
-    },
+    operators::{AggregateProjection, GroupByKind, Projection, TwoPhaseAggregateProjection},
     plan_graph::get_program_from_operator_with_plan,
     types::{interval_month_day_nanos_to_duration, StructDef, StructField, TypeDef},
     ArroyoSchemaProvider, SqlConfig, SqlSource,
@@ -854,7 +851,7 @@ impl<'a> SqlPipelineBuilder<'a> {
             .collect();
         let two_phase_field_computations = aggr_expr
             .iter()
-            .map(|expr| TwoPhaseAggregation::from_expression(&mut ctx, expr))
+            .map(|expr| ctx.as_two_phase_aggregation(expr))
             .collect::<Result<Vec<_>>>();
 
         match (two_phase_field_computations, window) {

--- a/arroyo-sql/src/test.rs
+++ b/arroyo-sql/src/test.rs
@@ -1,8 +1,9 @@
 use arrow_schema::{DataType, TimeUnit};
 use arroyo_datastream::{NexmarkSource, Source};
 
+use crate::pipeline::get_program_from_plan;
 use crate::{
-    parse_and_get_program,
+    get_plan_from_query, parse_and_get_program,
     types::{StructDef, StructField, TypeDef},
     ArroyoSchemaProvider, SqlConfig,
 };
@@ -201,7 +202,7 @@ async fn test_udf() {
     let mut schema_provider = ArroyoSchemaProvider::new();
 
     schema_provider
-        .add_rust_udf("fn my_sqr(x: u64) -> u64 { x * x }")
+        .add_rust_udf("fn my_sqr(x: i64) -> i64 { x * x }")
         .unwrap();
 
     schema_provider.add_source_with_type(
@@ -218,7 +219,6 @@ async fn test_udf() {
 
     let sql = "SELECT my_sqr(bid.auction) FROM nexmark";
 
-    parse_and_get_program(sql, schema_provider, SqlConfig::default())
-        .await
-        .unwrap();
+    let plan = get_plan_from_query(&sql, &schema_provider).unwrap();
+    get_program_from_plan(SqlConfig::default(), schema_provider, &plan).unwrap();
 }

--- a/arroyo-sql/src/test.rs
+++ b/arroyo-sql/src/test.rs
@@ -202,11 +202,11 @@ async fn test_udf() {
     let mut schema_provider = ArroyoSchemaProvider::new();
 
     schema_provider
-        .add_rust_udf("fn my_sqr(x: i64) -> i64 { x * x }")
+        .add_rust_udf("fn my_sqr(x: u64) -> u64 { x * x }")
         .unwrap();
 
     schema_provider.add_source_with_type(
-        1,
+        Some(1),
         "nexmark".to_string(),
         test_schema(),
         NexmarkSource {
@@ -219,6 +219,6 @@ async fn test_udf() {
 
     let sql = "SELECT my_sqr(bid.auction) FROM nexmark";
 
-    let plan = get_plan_from_query(&sql, &schema_provider).unwrap();
+    let plan = get_plan_from_query(&sql, &mut schema_provider).unwrap();
     get_program_from_plan(SqlConfig::default(), schema_provider, &plan).unwrap();
 }

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -19,7 +19,7 @@ use datafusion_common::ScalarValue;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use regex::Regex;
-use syn::{parse_quote, parse_str, Type};
+use syn::{parse_quote, parse_str, FnArg, Type};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StructDef {
@@ -469,5 +469,15 @@ pub(crate) fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> R
         )
     } else {
         Ok(DataType::Decimal128(precision, scale))
+    }
+}
+
+pub fn rust_to_datafusion(typ: &Type) -> Option<DataType> {
+    match typ {
+        Type::Path(pat) => match pat.path.get_ident()?.to_string().as_str() {
+            "u64" => Some(DataType::UInt64),
+            _ => None,
+        },
+        _ => None,
     }
 }

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -20,7 +20,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use regex::Regex;
 use syn::PathArguments::AngleBracketed;
-use syn::{parse_quote, parse_str, FnArg, GenericArgument, Type};
+use syn::{parse_quote, parse_str, GenericArgument, Type};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StructDef {
@@ -182,7 +182,22 @@ pub enum TypeDef {
 fn rust_to_arrow(typ: &Type) -> std::result::Result<DataType, ()> {
     match typ {
         Type::Path(pat) => match pat.path.get_ident().ok_or(())?.to_string().as_str() {
+            "bool" => Ok(DataType::Boolean),
+            "i8" => Ok(DataType::Int8),
+            "i16" => Ok(DataType::Int16),
+            "i32" => Ok(DataType::Int32),
+            "i64" => Ok(DataType::Int64),
+            "u8" => Ok(DataType::UInt8),
+            "u16" => Ok(DataType::UInt16),
+            "u32" => Ok(DataType::UInt32),
             "u64" => Ok(DataType::UInt64),
+            "f16" => Ok(DataType::Float16),
+            "f32" => Ok(DataType::Float32),
+            "f64" => Ok(DataType::Float64),
+            "std::time::SystemTime" => Ok(DataType::Timestamp(TimeUnit::Microsecond, None)),
+            "std::time::Duration" => Ok(DataType::Duration(TimeUnit::Microsecond)),
+            "String" => Ok(DataType::Utf8),
+            "Vec<u8>" => Ok(DataType::Binary),
             _ => Err(()),
         },
         _ => Err(()),

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -530,13 +530,3 @@ pub(crate) fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> R
         Ok(DataType::Decimal128(precision, scale))
     }
 }
-
-pub fn rust_to_datafusion(typ: &Type) -> Option<DataType> {
-    match typ {
-        Type::Path(pat) => match pat.path.get_ident()?.to_string().as_str() {
-            "u64" => Some(DataType::UInt64),
-            _ => None,
-        },
-        _ => None,
-    }
-}

--- a/k8s/arroyo/Chart.yaml
+++ b/k8s/arroyo/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
     email: support@arroyo.systems
     url: https://arroyo.dev
 
-icon: https://github.com/ArroyoSystems/arroyo/blob/9ca9d1eeb6ef07593f0491a806928fac8e4d341a/docs/images/arroyo_logo.png
+icon: https://raw.githubusercontent.com/ArroyoSystems/arroyo/master/docs/images/arroyo_logo.png


### PR DESCRIPTION
This PR adds SQL support for UDFs written in Rust.

For example, it's now possible to register a UDF, for example:

```rust
fn my_square(x: i64) -> i64 {
  x * x
}
```

and use it from SQL like this:

```sql
SELECT my_square(auction.bid) FROM nexmark
```

UDF names, types, and nullability behavior are all automatically determined by the function definition. For the above example, the argument is `i64`, which will compile into a SQL UDF that on nullable inputs (like `auction.bid`) will be called only if the value is not null. Alternatively, we could define `fn my_square(x: Option<i64>)`, which will instead be called on all inputs.

This PR also includes a basic UI for defining UDFs:
![image](https://user-images.githubusercontent.com/100920/236564637-3a2b8e00-a6e7-439d-90bc-7769ca2ca354.png)

This is the start our UDF support. Next steps:
* Better error messages when UDF compilation fails
* Ability to include cargo dependencies in UDF
* Python and JS UDFs
* UDAFs
* Stateful UDFs