### PR TITLE
Fix query compilation error when sorting floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "local-ip-address",
  "md-5 0.10.5",
  "once_cell",
+ "ordered-float 3.7.0",
  "petgraph",
  "prometheus",
  "prost 0.11.9",
@@ -4308,6 +4309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5682,7 +5692,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.0",
  "serde",
 ]
 
@@ -6283,7 +6293,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.0",
 ]
 
 [[package]]

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -167,6 +167,7 @@ impl ArroyoSchemaProvider {
         type_name: Option<String>,
     ) {
         let name: String = name.into();
+
         self.sources.insert(
             name.clone(),
             SqlSource {

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -259,6 +259,16 @@ impl TypeDef {
         }
     }
 
+    pub fn is_float(&self) -> bool {
+        match self {
+            TypeDef::DataType(dt, _) => match dt {
+                DataType::Float16 | DataType::Float32 | DataType::Float64 => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
     pub fn get_literal(scalar: &ScalarValue) -> syn::Expr {
         if scalar.is_null() {
             return parse_quote!("None");

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -1,6 +1,6 @@
 use bincode::{config, Decode, Encode};
 use serde::ser::SerializeStruct;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Debug;
@@ -9,7 +9,7 @@ use std::ops::RangeInclusive;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[derive(Copy, Hash, Debug, Clone, Eq, PartialEq, Encode, Decode, PartialOrd, Ord)]
+#[derive(Copy, Hash, Debug, Clone, Eq, PartialEq, Encode, Decode, PartialOrd, Ord, Deserialize)]
 pub struct Window {
     pub start_time: SystemTime,
     pub end_time: SystemTime,

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -41,6 +41,7 @@ serde = "1.0"
 sha2 = "0.10"
 md-5 = "0.10"
 hex = "0.4"
+ordered-float = "3"
 
 tonic = "0.8"
 prost = "0.11"

--- a/arroyo-worker/src/lib.rs
+++ b/arroyo-worker/src/lib.rs
@@ -33,6 +33,8 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
+pub use ordered_float::OrderedFloat;
+
 pub mod engine;
 mod inq_reader;
 mod network_manager;

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "local-ip-address",
  "md-5 0.10.5",
  "once_cell",
+ "ordered-float 3.7.0",
  "petgraph",
  "prometheus",
  "prost",
@@ -2421,6 +2422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,7 +3632,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Attempting to sort by a float field currently causes query compilation errors, due to the unmet requirement that the float implement Ord. This PR fixes that by ensuring that floats are wrapped in [OrderedFloat](https://docs.rs/ordered-float/latest/ordered_float/struct.OrderedFloat.html) before it's used in a context where Ord is required. 