### PR TITLE
Add event source source operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "ctor 0.1.26",
+ "eventsource-client",
  "futures",
  "governor",
  "hex",
@@ -1200,7 +1201,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
  "tokio",
@@ -2113,6 +2114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct 0.6.1",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2649,22 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eventsource-client"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b91e5ec5c794bbec5f639620f0bafe421b6d27dec66ac1ce3fdb6f009db3a6c"
+dependencies = [
+ "futures",
+ "hyper",
+ "hyper-rustls 0.22.1",
+ "hyper-timeout",
+ "log",
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -3175,6 +3201,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
@@ -3182,10 +3225,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.20.8",
+ "rustls-native-certs 0.6.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -5239,7 +5282,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -5249,14 +5292,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
  "url",
@@ -5481,14 +5524,39 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5589,6 +5657,16 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -6446,13 +6524,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -7418,6 +7507,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -7432,7 +7531,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/arroyo-api/migrations/V4__add_sources.sql
+++ b/arroyo-api/migrations/V4__add_sources.sql
@@ -1,0 +1,2 @@
+ALTER TYPE source_type
+ADD VALUE 'event_source';

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -167,6 +167,7 @@ async fn set_default_parallelism(_auth: &AuthData, program: &mut Program) -> Res
             Operator::NexmarkSource {
                 first_event_rate, ..
             } => (*first_event_rate as f32 / 50_000.0).round() as usize,
+            Operator::EventSourceSource { .. } => 1,
             op => panic!("Found non-source in a source position in graph: {:?}", op),
         });
     }

--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -1352,6 +1352,12 @@ export class Operator extends Message<Operator> {
     case: "kafkaSource";
   } | {
     /**
+     * @generated from field: arroyo_api.EventSourceSource event_source_source = 22;
+     */
+    value: EventSourceSource;
+    case: "eventSourceSource";
+  } | {
+    /**
      * @generated from field: arroyo_api.WasmUdfs wasm_udfs = 4;
      */
     value: WasmUdfs;
@@ -1465,6 +1471,7 @@ export class Operator extends Message<Operator> {
     { no: 1, name: "file_source", kind: "message", T: FileSource, oneof: "operator" },
     { no: 2, name: "impulse_source", kind: "message", T: ImpulseSource, oneof: "operator" },
     { no: 3, name: "kafka_source", kind: "message", T: KafkaSource, oneof: "operator" },
+    { no: 22, name: "event_source_source", kind: "message", T: EventSourceSource, oneof: "operator" },
     { no: 4, name: "wasm_udfs", kind: "message", T: WasmUdfs, oneof: "operator" },
     { no: 5, name: "window", kind: "message", T: WindowOperator, oneof: "operator" },
     { no: 6, name: "aggregator", kind: "enum", T: proto3.getEnumType(Aggregator), oneof: "operator" },
@@ -1670,6 +1677,61 @@ export class KafkaSource extends Message<KafkaSource> {
 
   static equals(a: KafkaSource | PlainMessage<KafkaSource> | undefined, b: KafkaSource | PlainMessage<KafkaSource> | undefined): boolean {
     return proto3.util.equals(KafkaSource, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.EventSourceSource
+ */
+export class EventSourceSource extends Message<EventSourceSource> {
+  /**
+   * @generated from field: string url = 1;
+   */
+  url = "";
+
+  /**
+   * @generated from field: map<string, string> headers = 2;
+   */
+  headers: { [key: string]: string } = {};
+
+  /**
+   * @generated from field: arroyo_api.SerializationMode serialization_mode = 3;
+   */
+  serializationMode = SerializationMode.JSON;
+
+  /**
+   * @generated from field: repeated string events = 4;
+   */
+  events: string[] = [];
+
+  constructor(data?: PartialMessage<EventSourceSource>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.EventSourceSource";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "headers", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
+    { no: 3, name: "serialization_mode", kind: "enum", T: proto3.getEnumType(SerializationMode) },
+    { no: 4, name: "events", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EventSourceSource {
+    return new EventSourceSource().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): EventSourceSource {
+    return new EventSourceSource().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): EventSourceSource {
+    return new EventSourceSource().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: EventSourceSource | PlainMessage<EventSourceSource> | undefined, b: EventSourceSource | PlainMessage<EventSourceSource> | undefined): boolean {
+    return proto3.util.equals(EventSourceSource, a, b);
   }
 }
 
@@ -4865,6 +4927,55 @@ export class NexmarkSourceConfig extends Message<NexmarkSourceConfig> {
 }
 
 /**
+ * @generated from message arroyo_api.EventSourceSourceConfig
+ */
+export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
+  /**
+   * @generated from field: string url = 1;
+   */
+  url = "";
+
+  /**
+   * @generated from field: string events = 2;
+   */
+  events = "";
+
+  /**
+   * @generated from field: string headers = 3;
+   */
+  headers = "";
+
+  constructor(data?: PartialMessage<EventSourceSourceConfig>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.EventSourceSourceConfig";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "events", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "headers", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EventSourceSourceConfig {
+    return new EventSourceSourceConfig().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): EventSourceSourceConfig {
+    return new EventSourceSourceConfig().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): EventSourceSourceConfig {
+    return new EventSourceSourceConfig().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: EventSourceSourceConfig | PlainMessage<EventSourceSourceConfig> | undefined, b: EventSourceSourceConfig | PlainMessage<EventSourceSourceConfig> | undefined): boolean {
+    return proto3.util.equals(EventSourceSourceConfig, a, b);
+  }
+}
+
+/**
  * @generated from message arroyo_api.CreateSourceReq
  */
 export class CreateSourceReq extends Message<CreateSourceReq> {
@@ -4905,6 +5016,12 @@ export class CreateSourceReq extends Message<CreateSourceReq> {
      */
     value: NexmarkSourceConfig;
     case: "nexmark";
+  } | {
+    /**
+     * @generated from field: arroyo_api.EventSourceSourceConfig event_source = 7;
+     */
+    value: EventSourceSourceConfig;
+    case: "eventSource";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<CreateSourceReq>) {
@@ -4921,6 +5038,7 @@ export class CreateSourceReq extends Message<CreateSourceReq> {
     { no: 4, name: "impulse", kind: "message", T: ImpulseSourceConfig, oneof: "type_oneof" },
     { no: 5, name: "file", kind: "message", T: FileSourceConfig, oneof: "type_oneof" },
     { no: 6, name: "nexmark", kind: "message", T: NexmarkSourceConfig, oneof: "type_oneof" },
+    { no: 7, name: "event_source", kind: "message", T: EventSourceSourceConfig, oneof: "type_oneof" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateSourceReq {
@@ -5076,6 +5194,12 @@ export class SourceDef extends Message<SourceDef> {
      */
     value: NexmarkSourceConfig;
     case: "nexmark";
+  } | {
+    /**
+     * @generated from field: arroyo_api.EventSourceSourceConfig event_source = 11;
+     */
+    value: EventSourceSourceConfig;
+    case: "eventSource";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
@@ -5100,6 +5224,7 @@ export class SourceDef extends Message<SourceDef> {
     { no: 4, name: "impulse", kind: "message", T: ImpulseSourceConfig, oneof: "source_type" },
     { no: 5, name: "file", kind: "message", T: FileSourceConfig, oneof: "source_type" },
     { no: 6, name: "nexmark", kind: "message", T: NexmarkSourceConfig, oneof: "source_type" },
+    { no: 11, name: "event_source", kind: "message", T: EventSourceSourceConfig, oneof: "source_type" },
     { no: 7, name: "sql_fields", kind: "message", T: SourceField, repeated: true },
   ]);
 

--- a/arroyo-console/src/routes/sources/ConfigureSource.tsx
+++ b/arroyo-console/src/routes/sources/ConfigureSource.tsx
@@ -16,6 +16,7 @@ import { Link } from "react-router-dom";
 import {
   Connection,
   CreateSourceReq,
+  EventSourceSourceConfig,
   ImpulseSourceConfig,
   KafkaSourceConfig,
   NexmarkSourceConfig,
@@ -241,6 +242,59 @@ function ConfigureKafka({
   );
 }
 
+function ConfigureEventSource({
+  state,
+  setState,
+  setReady,
+}: {
+  state: CreateSourceReq;
+  setState: Dispatch<CreateSourceReq>;
+  setReady: Dispatch<boolean>;
+}) {
+  const config = state.typeOneof.value as EventSourceSourceConfig;
+
+  useEffect(() => setReady(config.url != ""));
+
+  return (
+    <Stack spacing={5}>
+      <FormControl isRequired>
+        <FormLabel>URL</FormLabel>
+        <Input
+          type="url"
+          value={config.url}
+          onChange={onChangeString(state, setState, "url", config)}
+        />
+        <FormHelperText>The URL endpoint to connect to</FormHelperText>
+      </FormControl>
+
+      <FormControl isRequired>
+        <FormLabel>Headers</FormLabel>
+        <Input
+          type="text"
+          value={config.headers}
+          placeholder="Authorization: <token>, Content-Type: application/json"
+          onChange={onChangeString(state, setState, "headers", config)}
+        />
+        <FormHelperText>Comma-seperated list of headers to send</FormHelperText>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Events</FormLabel>
+        <Input
+          type="string"
+          value={config.events}
+          onChange={onChangeString(state, setState, "events", config)}
+        />
+        <FormHelperText>
+          Comma-separated list of event types that the source will accept; leave blank to read all
+          events
+        </FormHelperText>
+      </FormControl>
+    </Stack>
+  );
+}
+
+
 export function ConfigureSource({
   state,
   setState,
@@ -269,6 +323,14 @@ export function ConfigureSource({
         client={client}
       />,
     ],
+    [
+      "eventSource",
+      <ConfigureEventSource
+        state={state}
+        setState={setState}
+        setReady={setReady}
+        />
+    ]
   ]);
 
   const onClick = async () => {

--- a/arroyo-console/src/routes/sources/CreateSource.tsx
+++ b/arroyo-console/src/routes/sources/CreateSource.tsx
@@ -43,13 +43,14 @@ import { ApiGrpc } from "../../gen/api_connectweb";
 import { RadioCard, RadioCardGroup } from "../../lib/RadioGroup";
 
 import { SiApachekafka } from "react-icons/si";
-import { FaStream } from "react-icons/fa";
+import { FaStream, FaSync } from "react-icons/fa";
 import { RiAuctionLine } from "react-icons/ri";
 import { GiMetronome } from "react-icons/gi";
 import {
   Connection,
   CreateJobReq,
   CreateSourceReq,
+  EventSourceSourceConfig,
   GetConnectionsReq,
   ImpulseSourceConfig,
   KafkaSourceConfig,
@@ -314,6 +315,12 @@ const sourceTypes = [
     icon: FaStream,
     description: "AWS Kinesis stream (coming soon)",
     disabled: true,
+  },
+  {
+    name: "eventSource",
+    icon: FaSync,
+    description: "(also known as Server-Sent Events)",
+    initialState: new EventSourceSourceConfig({}),
   },
   {
     name: "nexmark",

--- a/arroyo-console/src/routes/sources/DefineSchema.tsx
+++ b/arroyo-console/src/routes/sources/DefineSchema.tsx
@@ -76,7 +76,7 @@ export function ChooseSchemaType({
         {state.typeOneof.case == "kafka" ? (
           <RadioCard value="confluentSchema">Confluent Schema Registry</RadioCard>
         ) : null}
-        <RadioCard value="rawJson">Raw Schema</RadioCard>
+        <RadioCard value="rawJson">Raw Json</RadioCard>
       </RadioCardGroup>
       <Button variant="primary" onClick={onClick}>
         Continue

--- a/arroyo-macro/src/lib.rs
+++ b/arroyo-macro/src/lib.rs
@@ -414,7 +414,7 @@ fn impl_stream_node_type(
                 let local_idx = idx - (in_partitions / #handler_count) * #i;
                 tracing::debug!("[{}] Received message {}-{}, {:?} [{:?}]", ctx.task_info.operator_name, #i, local_idx, message, stacker::remaining_stack());
 
-                if let Message::Record(record) = &message {
+                if let arroyo_types::Message::Record(record) = &message {
                     ctx.counters
                         .get("arroyo_worker_messages_recv")
                         .expect("msg received")
@@ -672,7 +672,7 @@ fn impl_stream_node_type(
 
             crate::process_fn::ProcessFnUtils::send_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::FinishedSync).await;
 
-            ctx.broadcast(Message::Barrier(checkpoint_barrier)).await;
+            ctx.broadcast(arroyo_types::Message::Barrier(checkpoint_barrier)).await;
 
             checkpoint_barrier.then_stop
         }
@@ -682,7 +682,7 @@ fn impl_stream_node_type(
         async fn handle_watermark_int(&mut self, watermark: std::time::SystemTime, ctx: &mut crate::engine::Context<#out_k, #out_t>) {
             // process timers
             use tracing::trace;
-            trace!("handling watermark {} for {}-{}", to_millis(watermark), ctx.task_info.operator_name, ctx.task_info.task_index);
+            trace!("handling watermark {} for {}-{}", arroyo_types::to_millis(watermark), ctx.task_info.operator_name, ctx.task_info.task_index);
 
             let finished = crate::process_fn::ProcessFnUtils::finished_timers(watermark, ctx).await;
 

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -149,6 +149,7 @@ message Operator {
     FileSource file_source = 1;
     ImpulseSource impulse_source = 2;
     KafkaSource kafka_source = 3;
+    EventSourceSource event_source_source = 22;
     WasmUdfs wasm_udfs = 4;
     WindowOperator window = 5;
     Aggregator aggregator = 6;
@@ -190,6 +191,13 @@ message KafkaSource {
   SerializationMode serialization_mode = 4;
   uint32 messages_per_second = 5;
   map<string, string> client_configs = 6;
+}
+
+message EventSourceSource {
+  string url = 1;
+  map<string, string> headers = 2;
+  SerializationMode serialization_mode = 3;
+  repeated string events = 4;
 }
 
 enum SerializationMode {
@@ -659,6 +667,12 @@ message NexmarkSourceConfig {
   optional uint64 runtime_micros = 2;
 }
 
+message EventSourceSourceConfig {
+  string url = 1;
+  string events = 2;
+  string headers = 3;
+}
+
 message CreateSourceReq {
   string name = 1;
 
@@ -669,6 +683,7 @@ message CreateSourceReq {
     ImpulseSourceConfig impulse = 4;
     FileSourceConfig file = 5;
     NexmarkSourceConfig nexmark = 6;
+    EventSourceSourceConfig event_source = 7;
   }
 }
 
@@ -693,6 +708,7 @@ message SourceDef {
     ImpulseSourceConfig impulse = 4;
     FileSourceConfig file = 5;
     NexmarkSourceConfig nexmark = 6;
+    EventSourceSourceConfig event_source = 11;
   }
 
   repeated SourceField sql_fields = 7;

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -22,8 +22,6 @@ wasmtime = "1.0"
 lazy_static = "1.4.0"
 petgraph = "0.6"
 chrono = "0.4"
-rdkafka = { version = "0.28", features = ["cmake-build"] }
-rdkafka-sys = "=4.2.0"
 prometheus = {version = "0.13", features = ["process"] }
 futures = "0.3"
 tokio = { version = "1", features = ["full", "tracing"] }
@@ -49,6 +47,11 @@ prost = "0.11"
 #logging
 tracing = "0.1"
 governor = "0.5.1"
+
+# connectors
+rdkafka = { version = "0.28", features = ["cmake-build"] }
+rdkafka-sys = "=4.2.0"
+eventsource-client = "0.11.0"
 
 [dev-dependencies]
 test-case = "2.2"

--- a/arroyo-worker/src/operators/sources/eventsource.rs
+++ b/arroyo-worker/src/operators/sources/eventsource.rs
@@ -1,0 +1,185 @@
+use crate::engine::Context;
+use crate::SourceFinishType;
+use arroyo_macro::{source_fn, StreamNode};
+use arroyo_rpc::grpc::{StopMode, TableDescriptor};
+use arroyo_rpc::ControlMessage;
+use arroyo_state::tables::GlobalKeyedState;
+use arroyo_types::{Data, Record};
+use bincode::{Decode, Encode};
+use eventsource_client::{Client, SSE};
+use futures::StreamExt;
+use serde::de::DeserializeOwned;
+use std::collections::HashSet;
+use std::marker::PhantomData;
+use std::time::SystemTime;
+use tokio::select;
+use tracing::{debug, info, warn};
+
+use crate::operators::SerializationMode;
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, PartialOrd, Default)]
+pub struct EventSourceState {
+    last_id: Option<String>,
+}
+
+#[derive(StreamNode, Clone)]
+pub struct EventSourceSourceFunc<T>
+where
+    T: DeserializeOwned + Data,
+{
+    url: String,
+    headers: Vec<(String, String)>,
+    events: Vec<String>,
+    serialization_mode: SerializationMode,
+    state: EventSourceState,
+    _t: PhantomData<T>,
+}
+
+#[source_fn(out_k = (), out_t = T)]
+impl<T> EventSourceSourceFunc<T>
+where
+    T: DeserializeOwned + Data,
+{
+    pub fn new(
+        url: &str,
+        headers: Vec<(&str, &str)>,
+        events: Vec<&str>,
+        serialization_mode: SerializationMode,
+    ) -> EventSourceSourceFunc<T> {
+        EventSourceSourceFunc {
+            url: url.to_string(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            events: events.into_iter().map(|s| s.to_string()).collect(),
+            serialization_mode,
+            state: EventSourceState::default(),
+            _t: PhantomData,
+        }
+    }
+
+    fn name(&self) -> String {
+        "EventSourceSource".to_string()
+    }
+
+    fn tables(&self) -> Vec<TableDescriptor> {
+        vec![arroyo_state::global_table("e", "event source state")]
+    }
+
+    async fn on_start(&mut self, ctx: &mut Context<(), T>) {
+        let s: GlobalKeyedState<(), EventSourceState, _> =
+            ctx.state.get_global_keyed_state('e').await;
+
+        if let Some(state) = s.get(&()) {
+            self.state = state.clone();
+        }
+    }
+
+    async fn our_handle_control_message(
+        &mut self,
+        ctx: &mut Context<(), T>,
+        msg: Option<ControlMessage>,
+    ) -> Option<SourceFinishType> {
+        match msg? {
+            ControlMessage::Checkpoint(c) => {
+                debug!("starting checkpointing {}", ctx.task_info.task_index);
+                let mut s: GlobalKeyedState<(), EventSourceState, _> =
+                    ctx.state.get_global_keyed_state('e').await;
+                s.insert((), self.state.clone()).await;
+
+                if self.checkpoint(c, ctx).await {
+                    return Some(SourceFinishType::Immediate);
+                }
+            }
+            ControlMessage::Stop { mode } => {
+                info!("Stopping eventsource source: {:?}", mode);
+
+                match mode {
+                    StopMode::Graceful => {
+                        return Some(SourceFinishType::Graceful);
+                    }
+                    StopMode::Immediate => {
+                        return Some(SourceFinishType::Immediate);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    async fn run(&mut self, ctx: &mut Context<(), T>) -> SourceFinishType {
+        let mut client = eventsource_client::ClientBuilder::for_url(&self.url).unwrap();
+
+        if let Some(id) = &self.state.last_id {
+            client = client.last_event_id(id.clone());
+        }
+
+        for (k, v) in &self.headers {
+            client = client.header(k, &v).unwrap();
+        }
+
+        let mut stream = client.build().stream();
+        let events: HashSet<_> = self.events.iter().cloned().collect();
+
+        // since there's no way to partition across an event source, only read on the first task
+        if ctx.task_info.task_index == 0 {
+            loop {
+                select! {
+                    message = stream.next()  => {
+                        match message {
+                            Some(Ok(msg)) => {
+                                match msg {
+                                    SSE::Event(event) => {
+                                        if let Some(id) = event.id {
+                                            self.state.last_id = Some(id);
+                                        }
+
+                                        if events.is_empty() || events.contains(&event.event_type) {
+                                            match self.serialization_mode.deserialize_str(&event.data) {
+                                                Ok(value) => {
+                                                    ctx.collector.collect(Record {
+                                                        timestamp: SystemTime::now(),
+                                                        key: None,
+                                                        value,
+                                                    }).await;
+                                                }
+                                                Err(e) => {
+                                                    warn!("Invalid message from EventSource: {:}", e);
+                                                }
+                                            }
+
+                                        }
+                                    }
+                                    SSE::Comment(s) => {
+                                        warn!("Unhandled comment {:?}", s);
+                                    }
+                                }
+                            }
+                            Some(Err(e)) => {
+                                panic!("Error while reading from EventSource: {:?}", e);
+                            }
+                            None => {
+                                info!("Socket closed");
+                                return SourceFinishType::Final;
+                            }
+                        }
+                    }
+                    control_message = ctx.control_rx.recv() => {
+                        if let Some(r) = self.our_handle_control_message(ctx, control_message).await {
+                            return r;
+                        }
+                    }
+                }
+            }
+        } else {
+            // otherwise just process control messages
+            loop {
+                let msg = ctx.control_rx.recv().await;
+                if let Some(r) = self.our_handle_control_message(ctx, msg).await {
+                    return r;
+                }
+            }
+        }
+    }
+}

--- a/arroyo-worker/src/operators/sources/mod.rs
+++ b/arroyo-worker/src/operators/sources/mod.rs
@@ -21,6 +21,7 @@ use tokio::select;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
+pub mod eventsource;
 pub mod kafka;
 pub mod nexmark;
 

--- a/arroyo-worker/src/operators/sources/nexmark/mod.rs
+++ b/arroyo-worker/src/operators/sources/nexmark/mod.rs
@@ -4,7 +4,7 @@ use arroyo_macro::source_fn;
 use arroyo_rpc::grpc::{StopMode, TableDescriptor};
 use arroyo_rpc::ControlMessage;
 use arroyo_types::nexmark::*;
-use arroyo_types::{Message, *};
+use arroyo_types::*;
 use bincode::{Decode, Encode};
 use rand::{distributions::Alphanumeric, rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use std::collections::HashMap;

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "ctor 0.1.26",
+ "eventsource-client",
  "futures",
  "governor",
  "hex",
@@ -1018,6 +1019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct 0.6.1",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1221,22 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eventsource-client"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b91e5ec5c794bbec5f639620f0bafe421b6d27dec66ac1ce3fdb6f009db3a6c"
+dependencies = [
+ "futures",
+ "hyper",
+ "hyper-rustls 0.22.1",
+ "hyper-timeout",
+ "log",
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -1639,15 +1665,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2984,7 +3027,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2994,15 +3037,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.20.8",
+ "rustls-native-certs 0.6.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3167,14 +3210,39 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3230,6 +3298,16 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -3749,13 +3827,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -4458,6 +4547,16 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a source for the [EventSource protocol](https://html.spec.whatwg.org/multipage/server-sent-events.html) (also called server-sent events).

This is a lightweight, HTTP streaming protocol. Supporting it allows Arroyo to read from a variety of open streaming sources, like the mastodon firehose (https://docs.joinmastodon.org/methods/streaming/#public), for example the one available at https://mstdn.social/api/v1/streaming/public.

This PR also refactors the serialization code used by the kafka source, to make it usable from other sources without code duplication.