### PR TITLE
Add basic end-to-end integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: cargo build --release --all-features
       - name: Test
         run: cargo nextest run --release
+      - name: Integ
+        run: target/release/integ
   build-console:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip
           unzip protoc*.zip
           sudo mv bin/protoc /usr/local/bin
-          cargo install wasm-pack
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Kafka
         run: |
           wget --progress=dot --show-progress https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip
           unzip protoc*.zip
           sudo mv bin/protoc /usr/local/bin
+          cargo install wasm-pack
       - name: Install Kafka
         run: |
           wget --progress=dot --show-progress https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz
@@ -63,13 +64,13 @@ jobs:
           kafka_*/bin/kafka-storage.sh format -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/kraft/server.properties
           kafka_*/bin/kafka-server-start.sh -daemon kafka_*/config/kraft/server.properties
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --all-features
       - name: Test
-        run: cargo nextest run --release
+        run: cargo nextest run
       - name: Integ
         run: |
           mkdir /tmp/arroyo-integ
-          OUTPUT_DIR=/tmp/arroyo-integ target/release/integ
+          OUTPUT_DIR=/tmp/arroyo-integ DEBUG=true target/debug/integ
   build-console:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
       - name: Test
         run: cargo nextest run --release
       - name: Integ
-        run: target/release/integ
+        run: |
+          mkdir /tmp/arroyo-integ
+          OUTPUT_DIR=/tmp/arroyo-integ target/release/integ
   build-console:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -3317,6 +3317,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "integ"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "arroyo-rpc",
+ "arroyo-types",
+ "rand",
+ "refinery",
+ "tokio",
+ "tokio-postgres",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,9 +5178,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6762a07453650132443ac393c5bf4836f790e0d96958507cfd05d560f05034a9"
+checksum = "431fd1854421586de5e83614052cb0d2d82025647829db6d9499b27385e58a6b"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -5172,9 +5188,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb938c73230daa3fbd5ed56f5638068df0e444897e1fd94f30103b0bbc52c00"
+checksum = "ebe9a0b52b3bc15434bccebe267fe279d08e1fe1771bd492822412c50ec120d2"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -5186,6 +5202,8 @@ dependencies = [
  "siphasher",
  "thiserror",
  "time 0.3.20",
+ "tokio",
+ "tokio-postgres",
  "toml 0.7.3",
  "url",
  "walkdir",
@@ -5193,9 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b95c4a9354004140b5ac1d3606cbb71c86107887f09d54955f12f97a637c041"
+checksum = "effe7bc109e071e59425848e04d56507a0a5eecaf95e6acbf28168604f82753a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "arroyo-state",
     "arroyo-types",
     "arroyo-worker",
+    "integ",
 ]
 
 exclude = [

--- a/arroyo-api/src/sources.rs
+++ b/arroyo-api/src/sources.rs
@@ -389,14 +389,14 @@ impl TryFrom<SchemaField> for SourceField {
         let sql_name = match value.typ {
             SchemaFieldType::Primitive(p) => Some(String::from(primitive_to_sql(&p))),
             SchemaFieldType::Struct(..) => None,
-            SchemaFieldType::NamedStruct(..) => None
+            SchemaFieldType::NamedStruct(..) => None,
         };
 
         Ok(SourceField {
             field_name: value.name,
             field_type: Some(api::SourceFieldType {
                 r#type: Some(typ),
-                sql_name
+                sql_name,
             }),
             nullable: value.nullable,
         })

--- a/arroyo-compiler-service/src/main.rs
+++ b/arroyo-compiler-service/src/main.rs
@@ -169,10 +169,15 @@ pub struct CompileService {
 impl CompileService {
     async fn get_output(&self) -> io::Result<Output> {
         if self.debug {
+            let args = if std::env::var("VERBOSE").is_ok() {
+                vec!["build", "--verbose"]
+            } else {
+                vec!["build"]
+            };
+
             Command::new("cargo")
                 .current_dir(&self.build_dir)
-                .arg("build")
-                .arg("--verbose")
+                .args(&args)
                 .output()
                 .await
         } else {

--- a/arroyo-compiler-service/src/main.rs
+++ b/arroyo-compiler-service/src/main.rs
@@ -226,7 +226,7 @@ impl CompileService {
                 .current_dir(&build_dir.join("wasm-fns"))
                 .output()
                 .await
-                .unwrap();
+                .expect("wasm-pack not found -- install with `cargo install wasm-pack`");
 
             if !result.status.success() {
                 return Err(io::Error::new(

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "integ"
+version = "0.2.0"
+edition = "2021"
+
+[dependencies]
+arroyo-rpc = { path = "../arroyo-rpc" }
+arroyo-types = { path = "../arroyo-types" }
+
+anyhow = "1.0.71"
+tokio = { version = "1.16.1", features = ["full"] }
+rand = "0.8.5"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+tonic = "0.8.2"
+refinery = { version = "0.8.9", features = ["tokio-postgres"] }
+tokio-postgres = "0.7.8"

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -121,13 +121,15 @@ pub async fn main() {
         .await
         .unwrap();
 
+    let output_dir = std::env::var("OUTPUT_DIR").unwrap_or_else(|_| "/tmp/arroyo".to_string());
+
     info!("Starting services");
     run_service(format!("target/{}/arroyo-api", profile), &[], vec![]).expect("Failed to run api");
     run_service(
         format!("target/{}/arroyo-controller", profile),
         &[],
         vec![
-            ("OUTPUT_DIR".to_string(), "/tmp/arroyo".to_string()),
+            ("OUTPUT_DIR".to_string(), output_dir.clone()),
             (
                 "REMOTE_COMPILER_ENDPOINT".to_string(),
                 "http://localhost:9000".to_string(),
@@ -138,7 +140,7 @@ pub async fn main() {
     run_service(
         format!("target/{}/arroyo-compiler-service", profile),
         &["start"],
-        vec![("OUTPUT_DIR".to_string(), "/tmp/arroyo".to_string())],
+        vec![("OUTPUT_DIR".to_string(), output_dir.clone())],
     )
     .expect("Failed to run compiler service");
 

--- a/integ/src/main.rs
+++ b/integ/src/main.rs
@@ -1,0 +1,244 @@
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use arroyo_rpc::grpc::api::{
+    api_grpc_client::ApiGrpcClient, create_pipeline_req, BuiltinSink, CreateJobReq,
+    CreatePipelineReq, CreateSourceReq, GetJobsReq, JobCheckpointsReq, JobDetailsReq,
+    NexmarkSourceConfig, StopType, UpdateJobReq,
+};
+use arroyo_types::DatabaseConfig;
+use rand::RngCore;
+use tokio_postgres::NoTls;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+mod embedded {
+    use refinery::embed_migrations;
+    embed_migrations!("../arroyo-api/migrations");
+}
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub fn run_service(name: &'static str, args: &[&str], env: Vec<(String, String)>) -> Result<()> {
+    let child = tokio::process::Command::new(name)
+        .args(args)
+        .envs(env)
+        .kill_on_drop(true)
+        .spawn()?;
+
+    tokio::spawn(async move {
+        let output = child.wait_with_output().await.unwrap();
+        info!(
+            "--------------\n{} exited with code {:?}\nstderr: {}",
+            name,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    });
+
+    Ok(())
+}
+
+async fn wait_for_state(client: &mut ApiGrpcClient<Channel>, job_id: &str, expected_state: &str) {
+    let mut last_state = "None".to_string();
+    while last_state != expected_state {
+        let resp = client
+            .get_job_details(JobDetailsReq {
+                job_id: job_id.to_string(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        let status = resp.job_status.unwrap();
+        if last_state != status.state {
+            info!("Job transitioned to {}", status.state);
+            last_state = status.state;
+        }
+
+        if last_state == "Failed" {
+            panic!("Job transitioned to failed");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn connect() -> ApiGrpcClient<Channel> {
+    let start = Instant::now();
+
+    loop {
+        if start.elapsed() > CONNECT_TIMEOUT {
+            panic!(
+                "Failed to connect to API server after {:?}",
+                CONNECT_TIMEOUT
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let Ok(mut client) = ApiGrpcClient::connect("http://localhost:8001").await else {
+            continue;
+        };
+
+        if client.get_jobs(GetJobsReq {}).await.is_ok() {
+            return client;
+        }
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let run_id = rand::thread_rng().next_u32();
+
+    let c = DatabaseConfig::load();
+    let mut config = tokio_postgres::Config::new();
+    config.dbname(&c.name);
+    config.host(&c.host);
+    config.port(c.port);
+    config.user(&c.user);
+    config.password(&c.password);
+
+    let (mut client, connection) = config.connect(NoTls).await.unwrap();
+
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            warn!("Connection error: {}", error);
+        }
+    });
+
+    info!("Running migrations on {}", c.name);
+    embedded::migrations::runner()
+        .run_async(&mut client)
+        .await
+        .unwrap();
+
+    info!("Starting services");
+    run_service("target/debug/arroyo-api", &[], vec![]).expect("Failed to run api");
+    run_service(
+        "target/debug/arroyo-controller",
+        &[],
+        vec![
+            ("OUTPUT_DIR".to_string(), "/tmp/arroyo".to_string()),
+            (
+                "REMOTE_COMPILER_ENDPOINT".to_string(),
+                "http://localhost:9000".to_string(),
+            ),
+        ],
+    )
+    .expect("Failed to run controller");
+    run_service(
+        "target/debug/arroyo-compiler-service",
+        &["start"],
+        vec![
+            ("OUTPUT_DIR".to_string(), "/tmp/arroyo".to_string()),
+            ("DEBUG".to_string(), "true".to_string()),
+        ],
+    )
+    .expect("Failed to run compiler service");
+
+    let mut client = connect().await;
+
+    // create a source
+    let source_name = format!("source_{}", run_id);
+    info!("Creating source {}", source_name);
+    client
+        .create_source(CreateSourceReq {
+            name: source_name.clone(),
+            schema: None,
+            type_oneof: Some(
+                arroyo_rpc::grpc::api::create_source_req::TypeOneof::Nexmark(NexmarkSourceConfig {
+                    events_per_second: 10,
+                    runtime_micros: None,
+                }),
+            ),
+        })
+        .await
+        .unwrap();
+    info!("Created source");
+
+    // create a pipeline
+    let pipeline_name = format!("pipeline_{}", run_id);
+    info!("Creating pipeline {}", pipeline_name);
+    let pipeline_id = client
+        .create_pipeline(CreatePipelineReq {
+            name: pipeline_name.clone(),
+            config: Some(create_pipeline_req::Config::Sql(
+                arroyo_rpc::grpc::api::CreateSqlJob {
+                    query: format!(
+                        "select count(*) from {} where auction is not null group \
+                by hop(interval '2 seconds', interval '10 seconds')",
+                        source_name
+                    ),
+                    parallelism: 1,
+                    udfs: vec![],
+                    sink: Some(arroyo_rpc::grpc::api::create_sql_job::Sink::Builtin(
+                        BuiltinSink::Web as i32,
+                    )),
+                },
+            )),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .pipeline_id;
+    info!("Created pipeline {}", pipeline_id);
+
+    // create a job
+    info!("Creating job");
+    let job_id = client
+        .create_job(CreateJobReq {
+            pipeline_id: pipeline_id.clone(),
+            checkpoint_interval_micros: 2_000_000,
+            preview: false,
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .job_id;
+
+    info!("Created job {}", job_id);
+
+    // wait for job to enter running phase
+    info!("Waiting until running");
+    wait_for_state(&mut client, &job_id, "Running").await;
+
+    // wait for a checkpoint
+    info!("Waiting for 10 successful checkpoints");
+    loop {
+        let checkpoints = client
+            .get_checkpoints(JobCheckpointsReq {
+                job_id: job_id.clone(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        if let Some(checkpoint) = checkpoints.checkpoints.iter().find(|c| c.epoch == 10) {
+            if checkpoint.finish_time.is_some() {
+                break;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // stop job
+    info!("Stopping job");
+    client
+        .update_job(UpdateJobReq {
+            job_id: job_id.clone(),
+            checkpoint_interval_micros: None,
+            stop: Some(StopType::Checkpoint as i32),
+            parallelism: None,
+        })
+        .await
+        .unwrap();
+
+    info!("Waiting for stop");
+    wait_for_state(&mut client, &job_id, "Stopped").await;
+
+    info!("Test successful ✅")
+}


### PR DESCRIPTION
This PR adds a simple integration test that:

* Starts up the services
* Creates a nexmark source
* Starts a pipeline with this SQL:
```sql
select count(*) from nexmark where auction is not null group
                by hop(interval '2 seconds', interval '10 seconds')
```
* waits for the pipeline to get to the RUNNING state
* waits for 10 successful checkpoints
* stops the job
* waits for it to successfully finish

Now that we have the ability to write integration tests, we can extend this:
* More cases (stop and re-starts, rescaling, recovery, etc.)
* More complex SQL
* Sources and sinks
* Correctness testing on output 

This PR also changes the CI to use debug mode to speed it up a bit. Since we're not using the artifacts produced by it at all, doing everything in release mode isn't necessary.