### PR TITLE
Add backpressure metric

### DIFF
--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -1715,7 +1715,7 @@ export class EventSourceSource extends Message<EventSourceSource> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "arroyo_api.EventSourceSource";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -3728,6 +3728,11 @@ export class SubtaskMetrics extends Message<SubtaskMetrics> {
    */
   messagesSent: Metric[] = [];
 
+  /**
+   * @generated from field: repeated arroyo_api.Metric backpressure = 5;
+   */
+  backpressure: Metric[] = [];
+
   constructor(data?: PartialMessage<SubtaskMetrics>) {
     super();
     proto3.util.initPartial(data, this);
@@ -3740,6 +3745,7 @@ export class SubtaskMetrics extends Message<SubtaskMetrics> {
     { no: 2, name: "bytes_sent", kind: "message", T: Metric, repeated: true },
     { no: 3, name: "messages_recv", kind: "message", T: Metric, repeated: true },
     { no: 4, name: "messages_sent", kind: "message", T: Metric, repeated: true },
+    { no: 5, name: "backpressure", kind: "message", T: Metric, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SubtaskMetrics {
@@ -4956,7 +4962,7 @@ export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime = proto3;
+  static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "arroyo_api.EventSourceSourceConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -503,6 +503,7 @@ message SubtaskMetrics {
   repeated Metric bytes_sent = 2;
   repeated Metric messages_recv = 3;
   repeated Metric messages_sent = 4;
+  repeated Metric backpressure = 5;
 }
 
 message JobMetricsReq {

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -427,6 +427,8 @@ pub static MESSAGES_RECV: &str = "arroyo_worker_messages_recv";
 pub static MESSAGES_SENT: &str = "arroyo_worker_messages_sent";
 pub static BYTES_RECV: &str = "arroyo_worker_bytes_recv";
 pub static BYTES_SENT: &str = "arroyo_worker_bytes_sent";
+pub static TX_QUEUE_SIZE: &str = "arroyo_worker_tx_queue_size";
+pub static TX_QUEUE_REM: &str = "arroyo_worker_tx_queue_rem";
 
 #[derive(Debug, Copy, Clone, Encode, Decode)]
 pub struct CheckpointBarrier {

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -181,7 +181,8 @@ pub struct Collector<K: Key, T: Data> {
     _ts: PhantomData<(K, T)>,
     sent_bytes: Option<IntCounter>,
     sent_messages: Option<IntCounter>,
-    tx_queue_size: Vec<Vec<Option<IntGauge>>>,
+    tx_queue_rem_gauges: Vec<Vec<Option<IntGauge>>>,
+    tx_queue_size_gauges: Vec<Vec<Option<IntGauge>>>,
 }
 
 impl<K: Key, T: Data> Collector<K, T> {
@@ -202,9 +203,13 @@ impl<K: Key, T: Data> Collector<K, T> {
         if self.out_qs.len() == 1 {
             let idx = out_idx(&record.key, self.out_qs[0].len());
 
-            self.tx_queue_size[0][idx]
+            self.tx_queue_rem_gauges[0][idx]
                 .iter()
                 .for_each(|g| g.set(self.out_qs[0][idx].tx.capacity() as i64));
+
+            self.tx_queue_size_gauges[0][idx]
+                .iter()
+                .for_each(|g| g.set(QUEUE_SIZE as i64));
 
             self.out_qs[0][idx]
                 .send(Message::Record(record), &self.sent_bytes)
@@ -215,9 +220,13 @@ impl<K: Key, T: Data> Collector<K, T> {
 
             for (i, out_node_qs) in self.out_qs.iter().enumerate() {
                 let idx = out_idx(&key, out_node_qs.len());
-                self.tx_queue_size[i][idx]
+                self.tx_queue_rem_gauges[i][idx]
                     .iter()
                     .for_each(|c| c.set(self.out_qs[i][idx].tx.capacity() as i64));
+
+                self.tx_queue_size_gauges[i][idx]
+                    .iter()
+                    .for_each(|c| c.set(QUEUE_SIZE as i64));
 
                 out_node_qs[idx]
                     .send(message.clone(), &self.sent_bytes)
@@ -321,7 +330,28 @@ impl<K: Key, T: Data> Context<K, T> {
             counters.insert(BYTES_SENT, c);
         }
 
-        let tx_queue_size = out_qs
+        let tx_queue_size_gauges = out_qs
+            .iter()
+            .enumerate()
+            .map(|(i, qs)| {
+                qs.iter()
+                    .enumerate()
+                    .map(|(j, _)| {
+                        gauge_for_task(
+                            &task_info,
+                            "arroyo_worker_tx_queue_size",
+                            "Size of a tx queue",
+                            labels! {
+                                "next_node".to_string() => format!("{}", i),
+                                "next_node_idx".to_string() => format!("{}", j)
+                            },
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let tx_queue_rem_gauges = out_qs
             .iter()
             .enumerate()
             .map(|(i, qs)| {
@@ -342,6 +372,7 @@ impl<K: Key, T: Data> Context<K, T> {
             })
             .collect();
 
+
         Context {
             task_info,
             control_rx,
@@ -351,7 +382,8 @@ impl<K: Key, T: Data> Context<K, T> {
                 out_qs,
                 sent_messages: counters.remove(MESSAGES_SENT),
                 sent_bytes: counters.remove(BYTES_SENT),
-                tx_queue_size,
+                tx_queue_rem_gauges,
+                tx_queue_size_gauges,
                 _ts: PhantomData,
             },
             state,


### PR DESCRIPTION
Add a new per-subtask metric that is the percentage the subtask is being backpressured. It's calculated from the remaining capacity of the queue.

This is a prerequisite for showing the backpressure in the UI (#75).