### PR TITLE
Add backpressure graph and color pipeline nodes

### DIFF
--- a/arroyo-console/src/routes/pipelines/JobGraph.tsx
+++ b/arroyo-console/src/routes/pipelines/JobGraph.tsx
@@ -2,7 +2,8 @@ import { Box, Text } from '@chakra-ui/react';
 import dagre from 'dagre';
 import { useMemo } from 'react';
 import ReactFlow, { Handle, Position, Background } from 'reactflow';
-import { JobNode, JobGraph } from '../../gen/api_pb';
+import { JobNode, JobGraph, JobMetricsResp } from '../../gen/api_pb';
+import { getBackpressureColor, getOperatorBackpressure } from '../../lib/util';
 
 function PipelineGraphNode({
   data,
@@ -11,6 +12,7 @@ function PipelineGraphNode({
     node: JobNode;
     setActiveOperator: (op: string) => void;
     isActive: boolean;
+    operatorBackpressure: number;
   };
 }) {
   function handleClick(click: any) {
@@ -23,7 +25,11 @@ function PipelineGraphNode({
   }
 
   return (
-    <Box className={className} onClick={handleClick}>
+    <Box
+      bg={getBackpressureColor(data.operatorBackpressure)}
+      className={className}
+      onClick={handleClick}
+    >
       <Handle type="target" position={Position.Top} />
       <Text userSelect="none" pointerEvents="none">
         {data.node.operator}
@@ -35,10 +41,12 @@ function PipelineGraphNode({
 
 export function PipelineGraph({
   graph,
+  metrics,
   setActiveOperator,
   activeOperator,
 }: {
   graph: JobGraph;
+  metrics?: JobMetricsResp;
   setActiveOperator: (op: string) => void;
   activeOperator?: string;
 }) {
@@ -53,6 +61,7 @@ export function PipelineGraph({
         node: node,
         setActiveOperator: setActiveOperator,
         isActive: node.nodeId == activeOperator,
+        operatorBackpressure: getOperatorBackpressure(metrics, node.nodeId),
       },
       position: {
         x: 0,

--- a/arroyo-console/src/routes/pipelines/pipelines.css
+++ b/arroyo-console/src/routes/pipelines/pipelines.css
@@ -17,11 +17,10 @@
   border-width: 1px;
   border-style: solid;
   border-color: #1a192b;
-  background-color: white;
 }
 
 .pipelineGraph .pipelineGraphNode.active {
-  background-color: rgb(149, 243, 220);
+  font-weight: bold;
 }
 
 .pipelineInfo {
@@ -39,7 +38,7 @@
 }
 
 .pipelineInfo .fieldName {
-  width: 90px;
+  width: 130px;
   font-weight: bold;
   text-transform: lowercase;
 }


### PR DESCRIPTION
Add a graph in the OperatorDetail component that displays the backpressure metric.

Color the operator nodes in the pipeline graph according to the maximum backpressure of all its subtasks.

Resolves: #75

---

<img width="1538" alt="image" src="https://github.com/ArroyoSystems/arroyo/assets/8881183/ad07d6f3-cb74-42d8-b1ca-1441c2aca94f">
