### PR TITLE
Fix top n optimization for sliding windows

### DIFF
--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -413,7 +413,7 @@ impl Optimizer for WindowTopNOptimization {
                             return false;
                         };
                         let tumbling_local_operator = PlanOperator::TumblingLocalAggregator {
-                            width,
+                            width: slide,
                             projection: two_phase_projection.clone(),
                         };
                         let bin_type = two_phase_projection.bin_type();


### PR DESCRIPTION
Currently it incorrectly pre-aggregates over the width instead of the slide 