### PR TITLE
Add HTTP connections and add support for event source tables in SQL

### DIFF
--- a/arroyo-api/migrations/V5__add_http_connection.sql
+++ b/arroyo-api/migrations/V5__add_http_connection.sql
@@ -1,0 +1,2 @@
+ALTER TYPE connection_type
+ADD VALUE 'http';

--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -4107,6 +4107,49 @@ export class KinesisConnection extends Message<KinesisConnection> {
 }
 
 /**
+ * @generated from message arroyo_api.HttpConnection
+ */
+export class HttpConnection extends Message<HttpConnection> {
+  /**
+   * @generated from field: string url = 1;
+   */
+  url = "";
+
+  /**
+   * @generated from field: string headers = 2;
+   */
+  headers = "";
+
+  constructor(data?: PartialMessage<HttpConnection>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.HttpConnection";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "headers", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): HttpConnection {
+    return new HttpConnection().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): HttpConnection {
+    return new HttpConnection().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): HttpConnection {
+    return new HttpConnection().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: HttpConnection | PlainMessage<HttpConnection> | undefined, b: HttpConnection | PlainMessage<HttpConnection> | undefined): boolean {
+    return proto3.util.equals(HttpConnection, a, b);
+  }
+}
+
+/**
  * @generated from message arroyo_api.Connection
  */
 export class Connection extends Message<Connection> {
@@ -4130,6 +4173,12 @@ export class Connection extends Message<Connection> {
      */
     value: KinesisConnection;
     case: "kinesis";
+  } | {
+    /**
+     * @generated from field: arroyo_api.HttpConnection http = 6;
+     */
+    value: HttpConnection;
+    case: "http";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
@@ -4153,6 +4202,7 @@ export class Connection extends Message<Connection> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "kafka", kind: "message", T: KafkaConnection, oneof: "connection_type" },
     { no: 3, name: "kinesis", kind: "message", T: KinesisConnection, oneof: "connection_type" },
+    { no: 6, name: "http", kind: "message", T: HttpConnection, oneof: "connection_type" },
     { no: 4, name: "sources", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 5, name: "sinks", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
   ]);
@@ -4198,6 +4248,12 @@ export class CreateConnectionReq extends Message<CreateConnectionReq> {
      */
     value: KinesisConnection;
     case: "kinesis";
+  } | {
+    /**
+     * @generated from field: arroyo_api.HttpConnection http = 4;
+     */
+    value: HttpConnection;
+    case: "http";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<CreateConnectionReq>) {
@@ -4211,6 +4267,7 @@ export class CreateConnectionReq extends Message<CreateConnectionReq> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "kafka", kind: "message", T: KafkaConnection, oneof: "connection_type" },
     { no: 3, name: "kinesis", kind: "message", T: KinesisConnection, oneof: "connection_type" },
+    { no: 4, name: "http", kind: "message", T: HttpConnection, oneof: "connection_type" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateConnectionReq {
@@ -4943,19 +5000,19 @@ export class NexmarkSourceConfig extends Message<NexmarkSourceConfig> {
  */
 export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
   /**
-   * @generated from field: string url = 1;
+   * @generated from field: string connection = 1;
    */
-  url = "";
+  connection = "";
 
   /**
-   * @generated from field: string events = 2;
+   * @generated from field: string path = 2;
+   */
+  path = "";
+
+  /**
+   * @generated from field: string events = 3;
    */
   events = "";
-
-  /**
-   * @generated from field: string headers = 3;
-   */
-  headers = "";
 
   constructor(data?: PartialMessage<EventSourceSourceConfig>) {
     super();
@@ -4965,9 +5022,9 @@ export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "arroyo_api.EventSourceSourceConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "events", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "headers", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 1, name: "connection", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "events", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EventSourceSourceConfig {
@@ -4984,6 +5041,61 @@ export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
 
   static equals(a: EventSourceSourceConfig | PlainMessage<EventSourceSourceConfig> | undefined, b: EventSourceSourceConfig | PlainMessage<EventSourceSourceConfig> | undefined): boolean {
     return proto3.util.equals(EventSourceSourceConfig, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.EventSourceSourceDef
+ */
+export class EventSourceSourceDef extends Message<EventSourceSourceDef> {
+  /**
+   * @generated from field: string connection_name = 1;
+   */
+  connectionName = "";
+
+  /**
+   * @generated from field: arroyo_api.HttpConnection connection = 2;
+   */
+  connection?: HttpConnection;
+
+  /**
+   * @generated from field: string path = 3;
+   */
+  path = "";
+
+  /**
+   * @generated from field: string events = 4;
+   */
+  events = "";
+
+  constructor(data?: PartialMessage<EventSourceSourceDef>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.EventSourceSourceDef";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "connection_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "connection", kind: "message", T: HttpConnection },
+    { no: 3, name: "path", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "events", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EventSourceSourceDef {
+    return new EventSourceSourceDef().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): EventSourceSourceDef {
+    return new EventSourceSourceDef().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): EventSourceSourceDef {
+    return new EventSourceSourceDef().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: EventSourceSourceDef | PlainMessage<EventSourceSourceDef> | undefined, b: EventSourceSourceDef | PlainMessage<EventSourceSourceDef> | undefined): boolean {
+    return proto3.util.equals(EventSourceSourceDef, a, b);
   }
 }
 
@@ -5208,9 +5320,9 @@ export class SourceDef extends Message<SourceDef> {
     case: "nexmark";
   } | {
     /**
-     * @generated from field: arroyo_api.EventSourceSourceConfig event_source = 11;
+     * @generated from field: arroyo_api.EventSourceSourceDef event_source = 11;
      */
-    value: EventSourceSourceConfig;
+    value: EventSourceSourceDef;
     case: "eventSource";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
@@ -5236,7 +5348,7 @@ export class SourceDef extends Message<SourceDef> {
     { no: 4, name: "impulse", kind: "message", T: ImpulseSourceConfig, oneof: "source_type" },
     { no: 5, name: "file", kind: "message", T: FileSourceConfig, oneof: "source_type" },
     { no: 6, name: "nexmark", kind: "message", T: NexmarkSourceConfig, oneof: "source_type" },
-    { no: 11, name: "event_source", kind: "message", T: EventSourceSourceConfig, oneof: "source_type" },
+    { no: 11, name: "event_source", kind: "message", T: EventSourceSourceDef, oneof: "source_type" },
     { no: 7, name: "sql_fields", kind: "message", T: SourceField, repeated: true },
   ]);
 

--- a/arroyo-console/src/routes/connections/Connections.tsx
+++ b/arroyo-console/src/routes/connections/Connections.tsx
@@ -23,7 +23,7 @@ import {
   CloseButton,
 } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import { FaStream } from 'react-icons/fa';
+import { FaGlobeAmericas, FaStream } from 'react-icons/fa';
 import { FiXCircle } from 'react-icons/fi';
 import { SiApachekafka } from 'react-icons/si';
 import { useLinkClickHandler } from 'react-router-dom';
@@ -42,6 +42,7 @@ interface ColumnDef {
 const icons = {
   kafka: SiApachekafka,
   kinesis: FaStream,
+  http: FaGlobeAmericas,
 };
 
 const columns: Array<ColumnDef> = [

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -543,7 +543,11 @@ message SaslAuth {
   string password = 4;
 }
 message KinesisConnection {
+}
 
+message HttpConnection {
+  string url = 1;
+  string headers = 2;
 }
 
 message Connection {
@@ -551,6 +555,7 @@ message Connection {
   oneof connection_type {
     KafkaConnection kafka = 2;
     KinesisConnection kinesis = 3;
+    HttpConnection http = 6;
   }
 
   int32 sources = 4;
@@ -562,6 +567,7 @@ message CreateConnectionReq {
   oneof connection_type {
     KafkaConnection kafka = 2;
     KinesisConnection kinesis = 3;
+    HttpConnection http = 4;
   }
 }
 
@@ -670,9 +676,16 @@ message NexmarkSourceConfig {
 }
 
 message EventSourceSourceConfig {
-  string url = 1;
-  string events = 2;
-  string headers = 3;
+  string connection = 1;
+  string path = 2;
+  string events = 3;
+}
+
+message EventSourceSourceDef {
+  string connection_name = 1;
+  HttpConnection connection = 2;
+  string path = 3;
+  string events = 4;
 }
 
 message CreateSourceReq {
@@ -710,7 +723,7 @@ message SourceDef {
     ImpulseSourceConfig impulse = 4;
     FileSourceConfig file = 5;
     NexmarkSourceConfig nexmark = 6;
-    EventSourceSourceConfig event_source = 11;
+    EventSourceSourceDef event_source = 11;
   }
 
   repeated SourceField sql_fields = 7;

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -189,6 +189,20 @@ pub fn to_nanos(time: SystemTime) -> u128 {
 pub fn from_nanos(ts: u128) -> SystemTime {
     UNIX_EPOCH + Duration::from_nanos(ts as u64)
 }
+
+pub fn string_to_map(s: &str) -> Option<HashMap<String, String>> {
+    if s.trim().is_empty() {
+        return Some(HashMap::new());
+    }
+
+    s.split(',')
+        .map(|s| {
+            let mut kv = s.trim().split(':');
+            Some((kv.next()?.trim().to_string(), kv.next()?.trim().to_string()))
+        })
+        .collect()
+}
+
 pub trait Key: Debug + Clone + Encode + Decode + Hash + PartialEq + Eq + Send + 'static {}
 impl<T: Debug + Clone + Encode + Decode + Hash + PartialEq + Eq + Send + 'static> Key for T {}
 

--- a/arroyo-worker/src/operators/sources/eventsource.rs
+++ b/arroyo-worker/src/operators/sources/eventsource.rs
@@ -152,7 +152,7 @@ where
                                         }
                                     }
                                     SSE::Comment(s) => {
-                                        warn!("Unhandled comment {:?}", s);
+                                        debug!("Received comment {:?}", s);
                                     }
                                 }
                             }


### PR DESCRIPTION
Event sources are now configured via a connection (containing the HTTP endpoint and headers--typically auth related), which allows them to be created in SQL:

```sql
CREATE TABLE mastodon (
    value TEXT
)
WITH (
    connection = 'mastodon',
    path = '/streaming/public',
    events = 'update',
    serialization_mode = 'raw_json');
```