### PR TITLE
Gitpod support for Arroyo

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,11 @@
+FROM gitpod/workspace-postgres:2023-05-08-21-16-55
+
+RUN sudo apt-get update 
+RUN sudo apt-get install -y pkg-config build-essential libssl-dev openssl cmake curl
+ 
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip \
+    && unzip protoc-21.8-linux-x86_64.zip \
+    && sudo mv bin/protoc /usr/local/bin
+
+RUN cargo install wasm-pack && cargo install refinery_cli
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       until pg_isready ; do sleep 1; done
       psql -c "CREATE USER arroyo WITH PASSWORD 'arroyo' SUPERUSER;"
       createdb arroyo
-      refinery migrate -c dev/refinery.toml -p arroyo-api/migrations -t 1
+      refinery migrate -c dev/refinery.toml -p arroyo-api/migrations
 
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,8 +4,6 @@ image:
 tasks:
   - init: cargo build
     command: cargo watch -x run
-  - name: Start Postgres in background
-    init: sudo service postgresql start
   - name: Set up arroyo database
     command: |
       until pg_isready ; do sleep 1; done

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: cargo build
+    command: cargo watch -x run
+  - name: Start Postgres in background
+    init: sudo service postgresql start
+  - name: Set up arroyo database
+    command: |
+      until pg_isready ; do sleep 1; done
+      psql -c "CREATE USER arroyo WITH PASSWORD 'arroyo' SUPERUSER;"
+      createdb arroyo
+      refinery migrate -c dev/refinery.toml -p arroyo-api/migrations -t 1
+
+
+ports:
+  - name: postgres
+    port: 5432
+    onOpen: ignore

--- a/dev/refinery.toml
+++ b/dev/refinery.toml
@@ -1,0 +1,8 @@
+[main]
+db_type = "Postgres"
+db_host = "localhost"
+db_port = "5432"
+db_user = "arroyo"
+db_pass = "arroyo"
+db_name = "arroyo"
+trust_cert = false


### PR DESCRIPTION
Gitpod is a popular IDE in the cloud that helps developers collaborate by removing the initial barrier required to setup the environment. 

Everyone can use Gitpod for free on open source code, just by opening the following url:

https://gitpod.io#/https://github.com/ArroyoSystems/arroyo

However, in the case of Arroyo, binary dependencies are required as documented in https://doc.arroyo.dev/developing/dev-setup. Once this PR is merged, one can use Gitpod and find all pre-requisites installed, making really easy to become new contributor to GitPod.

Before the PR is merged, the image might need to be re-built and is not cached, but after this is merged, the startup will be really fast. You can try it like so:

https://gitpod.io#/https://github.com/edmondop/arroyo/tree/gitpod
