### PR TITLE
sql: Support virtual fields and overriding timestamp via event_time_field

### DIFF
--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -58,11 +58,12 @@ impl Projection {
         StructDef { name: None, fields }
     }
     pub fn to_truncated_syn_expression(&self, terms: usize) -> syn::Expr {
+        println!("self: {:?}, terms{:?}", self, terms);
         let assignments: Vec<_> = self
             .field_computations
             .iter()
-            .take(terms)
             .enumerate()
+            .skip(self.field_computations.len() - terms)
             .map(|(i, field)| {
                 let field_name = self.field_names[i].clone();
                 let name = field_name.name;
@@ -91,8 +92,8 @@ impl Projection {
         let fields = self
             .field_computations
             .iter()
-            .take(terms)
             .enumerate()
+            .skip(self.field_computations.len() - terms)
             .map(|(i, computation)| {
                 let field_name = self.field_names[i].clone();
                 let field_type = computation.return_type();

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -188,9 +188,9 @@ impl FusedExpressionOperatorBuilder {
                 self.sequence.push(record_transform.clone());
                 self.output_types.push(node.output_type.clone());
                 match record_transform {
-                    RecordTransform::ValueProjection(_) | RecordTransform::KeyProjection(_) => {
-                        self.add_projection()
-                    }
+                    RecordTransform::ValueProjection(_)
+                    | RecordTransform::KeyProjection(_)
+                    | RecordTransform::TimestampAssignment(_) => self.add_projection(),
                     RecordTransform::Filter(_) => self.add_filter(),
                 }
                 true

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -493,7 +493,7 @@ fn convert_simple_data_type(sql_type: &SQLDataType) -> Result<DataType> {
         | SQLDataType::Varchar(_)
         | SQLDataType::Text
         | SQLDataType::String => Ok(DataType::Utf8),
-        SQLDataType::Timestamp(None, TimezoneInfo::None) => {
+        SQLDataType::Timestamp(None, TimezoneInfo::None) | SQLDataType::Datetime(_) => {
             Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
         }
         SQLDataType::Date => Ok(DataType::Date32),


### PR DESCRIPTION
This adds two complementary features: 
Virtual columns and overriding the timestamp with a SQL column. These are currently restricted to tables created in SQL with connections, but should be expanded upon in the future.

### Virtual Columns
We use the postgres syntax of `field_name field_type GENERATED ALWAYS AS ($EXPRESSION)`. The `$EXPRESSION` is will come through the SQL AST as a `sqlparser::ast::Expr`. This then needs to be converted to dataFusion's Expr, and then Arroyo's Expression. I don't love how disjoint this is from the normal dataflow, but we're restricted by DataFusion's capabilities right now. 

### Event Time Field
We also now support overriding the timestamp from a source configured within SQL. This is done by the `event_time_field` parameter in the `WITH` clause of the `CREATE TABLE` statement. If present it will validate that the column exists and is a timestamp. Currently the pipeline will panic if the timestamp column is null, something that should be configurable in the future.