### PR TITLE
Fix overlapping graph nodes for joins

### DIFF
--- a/arroyo-console/src/routes/pipelines/JobGraph.tsx
+++ b/arroyo-console/src/routes/pipelines/JobGraph.tsx
@@ -70,7 +70,7 @@ export function PipelineGraph({
       x: 0,
       y: 0,
       width: 200,
-      height: 60,
+      height: 100,
     };
   });
 

--- a/arroyo-console/src/routes/pipelines/pipelines.css
+++ b/arroyo-console/src/routes/pipelines/pipelines.css
@@ -10,7 +10,7 @@
 .pipelineGraph .pipelineGraphNode {
   padding: 10px;
   border-radius: 3px;
-  width: 150px;
+  width: 200px;
   font-size: 12px;
   color: #222;
   text-align: center;


### PR DESCRIPTION
Change the styling so that nodes with long operator names don't overlap.

Fixes: #116

---

Before:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/3d9082c2-6923-478b-8ce8-480a4823fad7)


After:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/d6d0cd18-2403-448f-9c90-f5b34bad8a1e)
