### PR TITLE
sql: Rework top N window functions.

### DIFF
--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -58,12 +58,11 @@ impl Projection {
         StructDef { name: None, fields }
     }
     pub fn to_truncated_syn_expression(&self, terms: usize) -> syn::Expr {
-        println!("self: {:?}, terms{:?}", self, terms);
         let assignments: Vec<_> = self
             .field_computations
             .iter()
             .enumerate()
-            .skip(self.field_computations.len() - terms)
+            .take(terms)
             .map(|(i, field)| {
                 let field_name = self.field_names[i].clone();
                 let name = field_name.name;
@@ -93,7 +92,7 @@ impl Projection {
             .field_computations
             .iter()
             .enumerate()
-            .skip(self.field_computations.len() - terms)
+            .take(terms)
             .map(|(i, computation)| {
                 let field_name = self.field_names[i].clone();
                 let field_type = computation.return_type();
@@ -330,7 +329,7 @@ impl TwoPhaseAggregateProjection {
             .map(|(i, field_computation)| {
                 let expr = field_computation.combine_bin_syn_expr();
                 let i: syn::Index = parse_str(&i.to_string()).unwrap();
-                parse_quote!({let current_bin = current_bin.#i;
+                parse_quote!({let current_bin = current_bin.#i.clone();
                     let new_bin = arg.#i.clone();  #expr})
             })
             .collect();
@@ -353,7 +352,7 @@ impl TwoPhaseAggregateProjection {
             .map(|(i, field_computation)| {
                 let expr = field_computation.bin_syn_expr();
                 let i: syn::Index = parse_str(&i.to_string()).unwrap();
-                parse_quote!({let current_bin = Some(current_bin.#i); #expr})
+                parse_quote!({let current_bin = Some(current_bin.#i.clone()); #expr})
             })
             .collect();
         let none_assignments: Vec<syn::Expr> = self

--- a/arroyo-worker/src/operators/functions/regexp.rs
+++ b/arroyo-worker/src/operators/functions/regexp.rs
@@ -28,7 +28,6 @@ pub fn regexp_replace(argument: String, regex: String, replacement: String) -> S
 mod tests {
 
     use super::*;
-    use std::error::Error;
 
     #[test]
     pub fn test_regexp_match_is_correct() {


### PR DESCRIPTION
This allows users to sort window functions in the SlidingTopN case, so queries like
```
SELECT * FROM (
SELECT ROW_NUMBER() OVER (
    PARTITION BY window
    ORDER BY count DESC, auction) as row_num, *
FROM (SELECT count(*) as count,
    bid.auction as auction,
    hop(interval '5 seconds', interval '15 seconds') as window
        FROM nexmark
        group by 2,3)) WHERE row_num < 2
```
I also added a clone to some of the partial aggregate code, so that you can aggregate strings, like bid.extra.