### PR TITLE
Updating SQL Queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Kafka
         run: |
-          wget --progress=dot --show-progress https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz
+          wget --progress=dot --show-progress https://downloads.apache.org/kafka/3.5.0/kafka_2.12-3.5.0.tgz
           tar xvfz kafka*.tgz
           mkdir /tmp/kraft-combined-logs
           kafka_*/bin/kafka-storage.sh format -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/kraft/server.properties

--- a/arroyo-api/src/optimizations.rs
+++ b/arroyo-api/src/optimizations.rs
@@ -232,7 +232,7 @@ impl FusedExpressionOperatorBuilder {
     }
 
     fn get_operator(self) -> Operator {
-        let name = format!("fused<{}>", self.names.join(","));
+        let name = format!("api_fused<{}>", self.names.join(","));
         let fused_body_tokens = self.body;
         let return_type = self.current_return_type.unwrap();
         let return_value = match return_type {

--- a/arroyo-api/src/sources.rs
+++ b/arroyo-api/src/sources.rs
@@ -106,6 +106,7 @@ pub fn nexmark_schema() -> SourceSchema {
                     vec![
                         SchemaField::new("id", Primitive(Int64)),
                         SchemaField::new("description", Primitive(String)),
+                        SchemaField::new("item_name", Primitive(String)),
                         SchemaField::new("initial_bid", Primitive(Int64)),
                         SchemaField::new("reserve", Primitive(Int64)),
                         SchemaField::new("datetime", Primitive(UnixMillis)),

--- a/arroyo-controller/src/compiler.rs
+++ b/arroyo-controller/src/compiler.rs
@@ -1,7 +1,7 @@
 use crate::states::fatal;
 use anyhow::{anyhow, Result};
 use arroyo_datastream::{
-    AggregateBehavior, EdgeType, Operator, Program, SlidingAggregatingTopN,
+    AggregateBehavior, EdgeType, NonWindowAggregator, Operator, Program, SlidingAggregatingTopN,
     SlidingWindowAggregator, TumblingTopN, TumblingWindowAggregator, WasmBehavior, WatermarkType,
     WindowType,
 };
@@ -654,7 +654,7 @@ wasm-opt = false
                     let in_t = parse_type(&input.unwrap().weight().value);
                     let out_k = parse_type(&output.unwrap().weight().key);
                     let out_t = parse_type(&output.unwrap().weight().value);
-                    let func: syn::ExprClosure = parse_str(&quote!(|record, _| {#expr}).to_string()).unwrap();
+                    let func: syn::ExprClosure = parse_quote!(|record, _| {#expr});
                     match return_type {
                         arroyo_datastream::ExpressionReturnType::Predicate => {
                             quote! {
@@ -839,7 +839,7 @@ wasm-opt = false
                         #max_elements))
                 }
                 }
-                Operator::JoinWithExpiration { left_expiration, right_expiration } => {
+                Operator::JoinWithExpiration { left_expiration, right_expiration, join_type } => {
                     let mut inputs: Vec<_> = program.graph.edges_directed(idx, Direction::Incoming)
                         .collect();
                     inputs.sort_by_key(|e| e.weight().typ.clone());
@@ -851,10 +851,63 @@ wasm-opt = false
                     let in_t2 = parse_type(&inputs[1].weight().value);
                     let left_expiration = duration_to_syn_expr(*left_expiration);
                     let right_expiration = duration_to_syn_expr(*right_expiration);
+                    match join_type {
+                        arroyo_types::JoinType::Inner => quote!{
+                            Box::new(arroyo_worker::operators::join_with_expiration::
+                                inner_join::<#in_k, #in_t1, #in_t2>(#left_expiration, #right_expiration))
+                        },
+                        arroyo_types::JoinType::Left => quote!{
+                            Box::new(arroyo_worker::operators::join_with_expiration::
+                                left_join::<#in_k, #in_t1, #in_t2>(#left_expiration, #right_expiration))
+                        },
+                        arroyo_types::JoinType::Right => quote!{
+                            Box::new(arroyo_worker::operators::join_with_expiration::
+                                right_join::<#in_k, #in_t1, #in_t2>(#left_expiration, #right_expiration))
+                        },
+                        arroyo_types::JoinType::Full => quote!{
+                            Box::new(arroyo_worker::operators::join_with_expiration::
+                                full_join::<#in_k, #in_t1, #in_t2>(#left_expiration, #right_expiration))
+                        },
+                    }
+                },
+                Operator::UpdatingOperator { name, expression } => {
+                    let expr : syn::Expr = parse_str(expression).expect(expression);
+                    let in_k = parse_type(&input.unwrap().weight().key);
+                    let in_t = parse_type(&input.unwrap().weight().value);
+                    let out_t = parse_type(&output.unwrap().weight().value);
+                    let func: syn::ExprClosure = parse_quote!(|arg| {
+                        #expr});
                     quote!{
-                        Box::new(arroyo_worker::operators::join_with_expiration::
-                            JoinWithExpiration::<#in_k, #in_t1, #in_t2>::
-                        new(#left_expiration, #right_expiration))
+                        Box::new(arroyo_worker::operators::OptionMapOperator::<#in_k, #in_t, #in_k, #out_t>::
+                            updating_operator(#name.to_string(), #func))
+                    }
+                },
+                Operator::NonWindowAggregator(NonWindowAggregator { expiration, aggregator, bin_merger, bin_type }) => {
+                    let in_k = parse_type(&input.unwrap().weight().key);
+                    let in_t = parse_type(&input.unwrap().weight().value);
+                    let updating_out_t = parse_type(&output.unwrap().weight().value);
+                    let out_t = extract_container_type("UpdatingData", &updating_out_t).unwrap();
+                    let bin_t = parse_type(bin_type);
+                    let expiration = duration_to_syn_expr(*expiration);
+                    let aggregator: syn::ExprClosure = parse_str(aggregator).unwrap();
+                    let bin_merger: syn::ExprClosure = parse_str(bin_merger).unwrap();
+                    quote!{
+                        Box::new(arroyo_worker::operators::updating_aggregate::
+                            UpdatingAggregateOperator::<#in_k, #in_t, #bin_t, #out_t>::
+                        new(#expiration,
+                            #aggregator,
+                            #bin_merger))
+                    }
+                },
+                Operator::UpdatingKeyOperator { name, expression } => {
+                    let updating_in_t = parse_type(&input.unwrap().weight().value);
+                    let in_t = extract_container_type("UpdatingData", &updating_in_t).unwrap();
+                    let out_k = parse_type(&output.unwrap().weight().key);
+                    let expr : syn::Expr = parse_str(expression).expect(expression);
+                    quote! {
+                        Box::new(arroyo_worker::operators::
+                            KeyMapUpdatingOperator::<#in_t, #out_k>::
+                        new(#name.to_string(), #expr))
                     }
                 },
             };

--- a/arroyo-macro/src/lib.rs
+++ b/arroyo-macro/src/lib.rs
@@ -397,7 +397,7 @@ fn impl_stream_node_type(
             #i => {
                 let message = match item {
                     crate::engine::QueueItem::Data(datum) => {
-                        *datum.downcast().unwrap()
+                        *datum.downcast().expect(&format!("failed to downcast data in {}", self.name()))
                     }
                     crate::engine::QueueItem::Bytes(bs) => {
                         ctx.counters

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -169,6 +169,9 @@ message Operator {
     SlidingAggregatingTopN sliding_aggregating_top_n = 20;
     JoinWithExpiration join_with_expiration = 21;
     ExpressionWatermark expression_watermark = 23;
+    UpdatingOperator updating_operator = 24;
+    NonWindowAggregator non_window_aggregator = 25;
+    UpdatingKeyOperator updating_key_operator = 26;
   }
 }
 
@@ -355,12 +358,38 @@ message SlidingAggregatingTopN {
 message JoinWithExpiration {
   uint64 left_expiration_micros = 1;
   uint64 right_expiration_micros = 2;
+  JoinType join_type = 3;
 }
+
+message UpdatingOperator {
+  string name = 1;
+  string expression = 2;
+}
+
+message NonWindowAggregator {
+  uint64 expiration_micros = 1;
+  string aggregator = 2;
+  string bin_merger = 3;
+  string bin_type = 4;
+}
+
+message UpdatingKeyOperator {
+  string name = 1;
+  string expression = 2;
+}
+
 enum ExpressionReturnType {
   UNUSED_ERT = 0;
   PREDICATE = 1;
   RECORD = 2;
   OPTIONAL_RECORD = 3;
+}
+
+enum JoinType {
+  INNER = 0;
+  LEFT = 1;
+  RIGHT = 2;
+  FULL = 3;
 }
 
 enum OffsetMode {

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -2443,7 +2443,7 @@ impl WrapTypeExpression {
         let arg = self.arg.to_syn_expression();
 
         if self.arg.nullable() {
-            parse_quote!(#arg.map(|f| #path(f)))
+            parse_quote!(#arg.map_over_inner(|f| #path(f)))
         } else {
             parse_quote!(#path(#arg))
         }

--- a/arroyo-sql/src/external.rs
+++ b/arroyo-sql/src/external.rs
@@ -142,10 +142,47 @@ pub struct SqlSink {
     pub id: Option<i64>,
     pub struct_def: StructDef,
     pub sink_config: SinkConfig,
+    pub updating_type: SinkUpdateType,
+}
+
+#[derive(Clone, Debug)]
+pub enum SinkUpdateType {
+    Allow,
+    Disallow,
+    Force,
 }
 
 impl SqlSink {
-    pub fn try_new(
+    pub fn new_from_sink_config(struct_def: StructDef, sink_config: SinkConfig) -> Self {
+        let updating_type = match &sink_config {
+            SinkConfig::Kafka {
+                bootstrap_servers: _,
+                topic: _,
+                client_configs,
+            } => {
+                if SerializationMode::from_config_value(
+                    client_configs.get("serialization_mode").map(|x| x.as_str()),
+                )
+                .is_updating()
+                {
+                    SinkUpdateType::Force
+                } else {
+                    SinkUpdateType::Disallow
+                }
+            }
+            SinkConfig::Console
+            | SinkConfig::File { directory: _ }
+            | SinkConfig::Grpc
+            | SinkConfig::Null => SinkUpdateType::Allow,
+        };
+        Self {
+            id: None,
+            struct_def,
+            sink_config,
+            updating_type,
+        }
+    }
+    pub fn try_new_from_connection(
         id: Option<i64>,
         struct_def: StructDef,
         connection: Connection,
@@ -154,6 +191,17 @@ impl SqlSink {
         let Some(ConnectionType::Kafka(kafka_config)) = connection.connection_type else {
             bail!("Only Kafka sinks are supported")
         };
+        let serialization_mode = SerializationMode::from_config_value(
+            connection_config
+                .get("serialization_mode")
+                .map(|x| x.as_str()),
+        );
+        let updating_type = if serialization_mode.is_updating() {
+            SinkUpdateType::Force
+        } else {
+            SinkUpdateType::Disallow
+        };
+
         let topic = Arc::new(connection_config)
             .get("topic")
             .cloned()
@@ -166,6 +214,7 @@ impl SqlSink {
                 bootstrap_servers: kafka_config.bootstrap_servers,
                 client_configs: auth_config_to_hashmap(kafka_config.auth_config),
             },
+            updating_type,
         })
     }
 }

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -398,11 +398,7 @@ pub fn parse_and_get_program_sync(
         let struct_def = non_sink_output.return_type();
         let sink = SqlOperator::Sink(
             "default_sink".to_string(),
-            SqlSink {
-                id: None,
-                struct_def,
-                sink_config: config.sink,
-            },
+            SqlSink::new_from_sink_config(struct_def, config.sink),
             Box::new(non_sink_output),
         );
         sql_pipeline_builder.output_nodes.push(sink);

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -5,17 +5,18 @@ use std::{
 
 use arrow_schema::DataType;
 use arroyo_datastream::{
-    EdgeType, ExpressionReturnType, Operator, Program, SlidingAggregatingTopN,
-    SlidingWindowAggregator, StreamEdge, StreamNode, TumblingTopN, TumblingWindowAggregator,
-    WatermarkType, WindowAgg, WindowType,
+    EdgeType, ExpressionReturnType, NonWindowAggregator, Operator, Program, SerializationMode,
+    SlidingAggregatingTopN, SlidingWindowAggregator, StreamEdge, StreamNode, TumblingTopN,
+    TumblingWindowAggregator, WatermarkType, WindowAgg, WindowType,
 };
+
 use petgraph::graph::{DiGraph, NodeIndex};
 use quote::quote;
 use syn::{parse_quote, parse_str};
 
 use crate::{
     expressions::SortExpression,
-    external::{SqlSink, SqlSource},
+    external::{SinkUpdateType, SqlSink, SqlSource},
     operators::{AggregateProjection, GroupByKind, Projection, TwoPhaseAggregateProjection},
     optimizations::optimize,
     pipeline::{
@@ -36,6 +37,11 @@ pub enum PlanOperator {
     WindowAggregate {
         window: WindowType,
         projection: AggregateProjection,
+    },
+    NonWindowAggregate {
+        input_is_update: bool,
+        expiration: Duration,
+        projection: TwoPhaseAggregateProjection,
     },
     WindowMerge {
         key_struct: StructDef,
@@ -84,6 +90,8 @@ pub enum PlanOperator {
     },
     // for external nodes, mainly sinks.
     StreamOperator(String, Operator),
+    ToDebezium,
+    FromDebezium,
     Sink(String, SqlSink),
 }
 
@@ -102,6 +110,7 @@ pub struct FusedRecordTransform {
     pub output_types: Vec<PlanType>,
     pub expression_return_type: ExpressionReturnType,
 }
+
 impl FusedRecordTransform {
     fn to_operator(&self) -> Operator {
         match self.expression_return_type {
@@ -113,10 +122,12 @@ impl FusedRecordTransform {
 
     fn to_predicate_operator(&self) -> Operator {
         let mut predicates = Vec::new();
+        let mut names = Vec::new();
         for expression in &self.expressions {
             let RecordTransform::Filter(predicate)= expression else {
                 panic!("FusedRecordTransform.to_predicate_operator() called on non-predicate expression");
             };
+            names.push("filter");
             predicates.push(predicate.to_syn_expression());
         }
         let predicate: syn::Expr = parse_quote!( {
@@ -124,7 +135,7 @@ impl FusedRecordTransform {
             #(#predicates)&&*
         });
         Operator::ExpressionOperator {
-            name: "fused".to_string(),
+            name: format!("sql_fused<{}>", names.join(",")),
             expression: quote!(#predicate).to_string(),
             return_type: ExpressionReturnType::Predicate,
         }
@@ -132,11 +143,13 @@ impl FusedRecordTransform {
 
     fn to_record_operator(&self) -> Operator {
         let mut record_expressions: Vec<syn::Stmt> = Vec::new();
+        let mut names = Vec::new();
         for i in 0..self.expressions.len() {
             let expression = &self.expressions[i];
             let output_type = &self.output_types[i];
             match expression {
                 RecordTransform::ValueProjection(projection) => {
+                    names.push("value_project");
                     let expr = projection.to_syn_expression();
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
@@ -151,6 +164,7 @@ impl FusedRecordTransform {
                     ));
                 }
                 RecordTransform::KeyProjection(projection) => {
+                    names.push("key_project");
                     let expr = projection.to_syn_expression();
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
@@ -165,13 +179,19 @@ impl FusedRecordTransform {
                     ));
                 }
                 RecordTransform::TimestampAssignment(timestamp_expression) => {
+                    names.push("timestamp_assignment");
                     let expr = timestamp_expression.to_syn_expression();
                     let record_type = output_type.record_type();
+                    let unwrap_tokens = if timestamp_expression.nullable() {
+                        Some(quote!(.expect("require a non-null timestamp")))
+                    } else {
+                        None
+                    };
                     record_expressions.push(parse_quote!(
 
                             let record: #record_type = { let arg = &record.value;
                                 arroyo_types::Record {
-                                timestamp: #expr,
+                                timestamp: #expr #unwrap_tokens,
                                 key: record.key.clone(),
                                 value: record.value.clone()
                         }
@@ -186,19 +206,22 @@ impl FusedRecordTransform {
             record
         });
         Operator::ExpressionOperator {
-            name: "fused".to_string(),
+            name: format!("sql_fused<{}>", names.join(",")),
             expression: quote!(#combined).to_string(),
             return_type: ExpressionReturnType::Record,
         }
     }
 
     fn to_optional_record_operator(&self) -> Operator {
+        let mut names = Vec::new();
         let mut record_expressions: Vec<syn::Stmt> = Vec::new();
         for i in 0..self.expressions.len() {
             let expression = &self.expressions[i];
             let output_type = &self.output_types[i];
-            match expression {
-                RecordTransform::ValueProjection(projection) => {
+            let is_updating = matches!(output_type, PlanType::Updating(_));
+            match (expression, is_updating) {
+                (RecordTransform::ValueProjection(projection), false) => {
+                    names.push("value_project");
                     let expr = projection.to_syn_expression();
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
@@ -212,7 +235,22 @@ impl FusedRecordTransform {
                     };
                     ));
                 }
-                RecordTransform::KeyProjection(projection) => {
+                (RecordTransform::ValueProjection(projection), true) => {
+                    names.push("updating_value_project");
+                    let expr = projection.to_syn_expression();
+                    let record_type = output_type.record_type();
+                    record_expressions.push(parse_quote!(
+                            let record: #record_type = { let arg = &record.value;
+                                arroyo_types::Record {
+                                timestamp: record.timestamp,
+                                key: None,
+                                value: arg.map_over_inner(|arg| #expr)?
+                        }
+                    };
+                    ));
+                }
+                (RecordTransform::KeyProjection(projection), false) => {
+                    names.push("key_project");
                     let expr = projection.to_syn_expression();
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
@@ -226,28 +264,60 @@ impl FusedRecordTransform {
                     };
                     ));
                 }
-                RecordTransform::Filter(predicate) => {
+                (RecordTransform::Filter(predicate), false) => {
+                    names.push("filter");
                     let expr = predicate.to_syn_expression();
+                    let unwrap = if predicate.nullable() {
+                        quote!(.unwrap_or(false))
+                    } else {
+                        quote!()
+                    };
                     record_expressions.push(parse_quote!(
-                        if !{let arg = &record.value;#expr} {
+                        if !{let arg = &record.value;#expr #unwrap} {
                             return None;
                         }
                     ));
                 }
-                RecordTransform::TimestampAssignment(timestamp_expression) => {
+                (RecordTransform::Filter(predicate), true) => {
+                    names.push("updating_filter");
+                    let expr = predicate.to_syn_expression();
+                    let record_type = output_type.record_type();
+                    let unwrap = if predicate.nullable() {
+                        quote!(.unwrap_or(false))
+                    } else {
+                        quote!()
+                    };
+                    record_expressions.push(parse_quote!(
+                            let record: #record_type = { let arg = &record.value;
+                                arroyo_types::Record {
+                                timestamp: record.timestamp,
+                                key: record.key.clone(),
+                                value: arg.filter(|arg| #expr #unwrap)?
+                        }
+                    };
+                        ));
+                }
+                (RecordTransform::TimestampAssignment(timestamp_expression), false) => {
+                    names.push("timestamp_assignment");
                     let expr = timestamp_expression.to_syn_expression();
+                    let unwrap_tokens = if timestamp_expression.nullable() {
+                        Some(quote!(.expect("require a non-null timestamp")))
+                    } else {
+                        None
+                    };
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
 
                             let record: #record_type = { let arg = &record.value;
                                 arroyo_types::Record {
-                                timestamp: #expr,
+                                timestamp: #expr #unwrap_tokens,
                                 key: record.key.clone(),
                                 value: record.value.clone()
                         }
                     };
                     ));
                 }
+                _ => unimplemented!(),
             }
         }
         let combined: syn::Expr = parse_quote!({
@@ -279,6 +349,25 @@ impl PlanNode {
         }
     }
 
+    fn from_record_transform(record_transform: RecordTransform, input_node: &PlanNode) -> Self {
+        let input_type = &input_node.output_type;
+        let output_type = match &record_transform {
+            RecordTransform::ValueProjection(value_projection) => {
+                input_type.with_value(value_projection.output_struct())
+            }
+            RecordTransform::KeyProjection(key_projection) => {
+                input_type.with_key(key_projection.output_struct())
+            }
+            RecordTransform::TimestampAssignment(_) | RecordTransform::Filter(_) => {
+                input_type.clone()
+            }
+        };
+        PlanNode {
+            operator: PlanOperator::RecordTransform(record_transform),
+            output_type,
+        }
+    }
+
     fn prefix(&self) -> String {
         match &self.operator {
             PlanOperator::Source(name, _) => name.to_string(),
@@ -305,6 +394,9 @@ impl PlanNode {
             PlanOperator::SlidingAggregatingTopN { .. } => "sliding_aggregating_top_n".to_string(),
             PlanOperator::TumblingTopN { .. } => "tumbling_top_n".to_string(),
             PlanOperator::Sink(name, _) => format!("sink_{}", name),
+            PlanOperator::ToDebezium => "to_debezium".to_string(),
+            PlanOperator::FromDebezium => "from_debezium".to_string(),
+            PlanOperator::NonWindowAggregate { .. } => "non_window_aggregate".to_string(),
         }
     }
 
@@ -312,7 +404,9 @@ impl PlanNode {
         match &self.operator {
             PlanOperator::Source(_name, source) => source.get_operator(sql_config),
             PlanOperator::Watermark(watermark) => Operator::Watermark(watermark.clone()),
-            PlanOperator::RecordTransform(record_transform) => record_transform.as_operator(),
+            PlanOperator::RecordTransform(record_transform) => {
+                record_transform.as_operator(self.output_type.is_updating())
+            }
             PlanOperator::WindowAggregate { window, projection } => {
                 let aggregate_expr = projection.to_syn_expression();
                 arroyo_datastream::Operator::Window {
@@ -333,24 +427,48 @@ impl PlanNode {
                 let merge_expr = group_by_kind.to_syn_expression(key_struct, value_struct);
                 let merge_struct_type =
                     SqlOperator::merge_struct_type(key_struct, value_struct).get_type();
-                let expression: syn::Expr = parse_quote!(
-                    {
-                        let aggregate = record.value.clone();
-                        let key = record.key.clone().unwrap();
-                        let timestamp = record.timestamp.clone();
-                        let arg = #merge_struct_type { key, aggregate , timestamp};
-                        let value = #merge_expr;
-                        arroyo_types::Record {
-                            timestamp: record.timestamp,
-                            key: None,
-                            value,
+                if self.output_type.is_updating() {
+                    let expression: syn::Expr = parse_quote!(
+                        {
+                            let value = record.value.map_over_inner(|value| {
+                                let aggregate = value.clone();
+                                let key = record.key.clone().unwrap();
+                                let timestamp = record.timestamp.clone();
+                                let arg = #merge_struct_type { key, aggregate , timestamp};
+                                #merge_expr
+                            })?;
+                            Some(arroyo_types::Record {
+                                timestamp: record.timestamp,
+                                key: None,
+                                value,
+                            })
                         }
+                    );
+                    Operator::ExpressionOperator {
+                        name: "merge".to_string(),
+                        expression: quote!(#expression).to_string(),
+                        return_type: arroyo_datastream::ExpressionReturnType::OptionalRecord,
                     }
-                );
-                Operator::ExpressionOperator {
-                    name: "aggregation".to_string(),
-                    expression: quote!(#expression).to_string(),
-                    return_type: arroyo_datastream::ExpressionReturnType::Record,
+                } else {
+                    let expression: syn::Expr = parse_quote!(
+                        {
+                            let aggregate = record.value.clone();
+                            let key = record.key.clone().unwrap();
+                            let timestamp = record.timestamp.clone();
+                            let arg = #merge_struct_type { key, aggregate , timestamp};
+                            let value = #merge_expr;
+                            arroyo_types::Record {
+                                timestamp: record.timestamp,
+                                key: None,
+                                value,
+                            }
+                        }
+                    );
+                    Operator::ExpressionOperator {
+                        name: "merge".to_string(),
+                        expression: quote!(#expression).to_string(),
+                        return_type: arroyo_datastream::ExpressionReturnType::Record,
+                    }
                 }
             }
             PlanOperator::TumblingWindowTwoPhaseAggregator {
@@ -395,10 +513,11 @@ impl PlanNode {
             PlanOperator::JoinWithExpiration {
                 left_expiration,
                 right_expiration,
-                join_type: _,
+                join_type,
             } => Operator::JoinWithExpiration {
                 left_expiration: *left_expiration,
                 right_expiration: *right_expiration,
+                join_type: join_type.clone().into(),
             },
             PlanOperator::JoinListMerge(join_type, struct_pair) => {
                 let merge_struct =
@@ -418,13 +537,22 @@ impl PlanNode {
                     join_type.join_struct_type(&struct_pair.left, &struct_pair.right);
                 let merge_expr =
                     join_type.merge_syn_expression(&struct_pair.left, &struct_pair.right);
-                assert!(*join_type == JoinType::Inner);
-                MethodCompiler::merge_pair_operator(
-                    "join_merge",
-                    merge_struct.get_type(),
-                    merge_expr,
-                )
-                .unwrap()
+                match join_type {
+                    JoinType::Inner => MethodCompiler::merge_pair_operator(
+                        "join_merge",
+                        merge_struct.get_type(),
+                        merge_expr,
+                    )
+                    .unwrap(),
+                    JoinType::Left | JoinType::Right | JoinType::Full => {
+                        MethodCompiler::merge_pair_updating_operator(
+                            "updating_join_merge",
+                            merge_struct.get_type(),
+                            merge_expr,
+                        )
+                        .unwrap()
+                    }
+                }
             }
             PlanOperator::WindowFunction(WindowFunctionOperator {
                 window_function,
@@ -560,23 +688,21 @@ impl PlanNode {
                         #projection_expr
                     }
                 ).to_string();
-                let operator =
-                    arroyo_datastream::Operator::SlidingAggregatingTopN(SlidingAggregatingTopN {
-                        width: *width,
-                        slide: *slide,
-                        bin_merger: quote!(|arg, current_bin| {#bin_merger}).to_string(),
-                        in_memory_add: quote!(|current, bin_value| {#in_memory_add}).to_string(),
-                        in_memory_remove: quote!(|current, bin_value| {#in_memory_remove})
-                            .to_string(),
-                        partitioning_func: quote!(|arg| {#partition_function}).to_string(),
-                        extractor,
-                        aggregator,
-                        bin_type: quote!(#bin_type).to_string(),
-                        mem_type: quote!(#mem_type).to_string(),
-                        sort_key_type,
-                        max_elements: *max_elements,
-                    });
-                operator
+
+                arroyo_datastream::Operator::SlidingAggregatingTopN(SlidingAggregatingTopN {
+                    width: *width,
+                    slide: *slide,
+                    bin_merger: quote!(|arg, current_bin| {#bin_merger}).to_string(),
+                    in_memory_add: quote!(|current, bin_value| {#in_memory_add}).to_string(),
+                    in_memory_remove: quote!(|current, bin_value| {#in_memory_remove}).to_string(),
+                    partitioning_func: quote!(|arg| {#partition_function}).to_string(),
+                    extractor,
+                    aggregator,
+                    bin_type: quote!(#bin_type).to_string(),
+                    mem_type: quote!(#mem_type).to_string(),
+                    sort_key_type,
+                    max_elements: *max_elements,
+                })
             }
             PlanOperator::TumblingTopN {
                 width,
@@ -668,6 +794,87 @@ impl PlanNode {
                     arroyo_datastream::SinkConfig::Null => arroyo_datastream::Operator::NullSink,
                 }
             }
+            PlanOperator::ToDebezium => arroyo_datastream::Operator::ExpressionOperator {
+                name: "to_debezium".into(),
+                expression: quote!({
+                    arroyo_types::Record {
+                        timestamp: record.timestamp,
+                        key: None,
+                        value: record.value.clone().into(),
+                    }
+                })
+                .to_string(),
+                return_type: ExpressionReturnType::Record,
+            },
+            PlanOperator::FromDebezium => arroyo_datastream::Operator::ExpressionOperator {
+                name: "from_debezium".into(),
+                expression: quote!({
+                    arroyo_types::Record {
+                        timestamp: record.timestamp,
+                        key: None,
+                        value: record.value.clone().into(),
+                    }
+                })
+                .to_string(),
+                return_type: ExpressionReturnType::Record,
+            },
+            PlanOperator::NonWindowAggregate {
+                input_is_update,
+                projection,
+                expiration,
+            } => {
+                if *input_is_update {
+                    let sliding = projection.sliding_aggregation_syn_expression();
+                    let bin_merger = projection.bin_merger_syn_expression();
+                    let bin_type = projection.bin_type();
+                    let memory_type = projection.memory_type();
+                    let memory_add = projection.memory_add_syn_expression();
+                    let memory_remove = projection.memory_remove_syn_expression();
+
+                    arroyo_datastream::Operator::NonWindowAggregator(NonWindowAggregator {
+                        expiration: *expiration,
+                        aggregator: quote!(|arg| {#sliding}).to_string(),
+                        bin_merger: quote!(|arg, current| {
+                            let current_bin: Option<#bin_type> = None;
+                            let updating_bin = arg.map_over_inner(|arg| #bin_merger);
+                            if let Some(updating_bin) = updating_bin {
+                                match updating_bin {
+                                    arroyo_types::UpdatingData::Retract(retract) => {
+                                        let bin_value = retract;
+                                        let current = current.expect(&format!("retracting means there should be state for {:?}", retract)).clone();
+                                        #memory_remove
+                                    },
+                                    arroyo_types::UpdatingData::Update { old, new } => {
+                                        let current = current.expect("retracting means there should be state").clone();
+                                        let bin_value = old;
+                                        let current = #memory_remove;
+                                        let bin_value = new;
+                                        Some(#memory_add)
+                                    },
+                                    arroyo_types::UpdatingData::Append(append) => {
+                                        let bin_value = append;
+                                        let current = current.cloned();
+                                        Some(#memory_add)
+                                    }
+                                }
+                            } else {
+                                None
+                            }
+                        }).to_string(),
+                        bin_type: quote!(#memory_type).to_string(),
+                    })
+                } else {
+                    let aggregate_expr = projection.tumbling_aggregation_syn_expression();
+                    let bin_merger = projection.bin_merger_syn_expression();
+                    let bin_type = projection.bin_type();
+                    arroyo_datastream::Operator::NonWindowAggregator(NonWindowAggregator {
+                        expiration: *expiration,
+                        aggregator: quote!(|arg| {#aggregate_expr}).to_string(),
+                        bin_merger: quote!(|arg, current_bin| {Some(#bin_merger)}).to_string(),
+                        bin_type: quote!(#bin_type).to_string(),
+                    })
+                }
+            }
         }
     }
 
@@ -724,6 +931,13 @@ impl PlanNode {
                 );
                 output_types.extend(merge_struct.all_structs());
             }
+            PlanOperator::NonWindowAggregate {
+                input_is_update: _,
+                expiration: _,
+                projection,
+            } => {
+                output_types.extend(projection.output_struct().all_structs());
+            }
 
             _ => {}
         }
@@ -733,55 +947,7 @@ impl PlanNode {
 
 #[derive(Debug, Clone)]
 pub struct PlanEdge {
-    pub edge_data_type: PlanType,
     pub edge_type: EdgeType,
-}
-impl PlanEdge {
-    fn into_stream_edge(&self) -> StreamEdge {
-        match &self.edge_data_type {
-            PlanType::Unkeyed(value_struct) => {
-                StreamEdge::unkeyed_edge(value_struct.struct_name(), self.edge_type.clone())
-            }
-            PlanType::Keyed { key, value } => StreamEdge::keyed_edge(
-                key.struct_name(),
-                value.struct_name(),
-                self.edge_type.clone(),
-            ),
-            PlanType::KeyedPair {
-                key,
-                left_value,
-                right_value,
-            } => StreamEdge::keyed_edge(
-                key.struct_name(),
-                format!(
-                    "({},{})",
-                    left_value.struct_name(),
-                    right_value.struct_name()
-                ),
-                self.edge_type.clone(),
-            ),
-            PlanType::KeyedListPair {
-                key,
-                left_value,
-                right_value,
-            } => StreamEdge::keyed_edge(
-                key.struct_name(),
-                format!(
-                    "(Vec<{}>,Vec<{}>)",
-                    left_value.struct_name(),
-                    right_value.struct_name()
-                ),
-                self.edge_type.clone(),
-            ),
-            PlanType::KeyedLiteralTypeValue { key, value } => {
-                StreamEdge::keyed_edge(key.struct_name(), value.clone(), self.edge_type.clone())
-            }
-            PlanType::UnkeyedList(value_struct) => StreamEdge::unkeyed_edge(
-                format!("Vec<{}>", value_struct.struct_name()),
-                self.edge_type.clone(),
-            ),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -796,6 +962,7 @@ pub enum PlanType {
         key: StructDef,
         left_value: StructDef,
         right_value: StructDef,
+        join_type: JoinType,
     },
     KeyedListPair {
         key: StructDef,
@@ -803,9 +970,10 @@ pub enum PlanType {
         right_value: StructDef,
     },
     KeyedLiteralTypeValue {
-        key: StructDef,
+        key: Option<StructDef>,
         value: String,
     },
+    Updating(Box<PlanType>),
 }
 
 impl PlanType {
@@ -816,10 +984,22 @@ impl PlanType {
                 key: _,
                 left_value,
                 right_value,
+                join_type,
             } => {
                 let left_type = left_value.get_type();
                 let right_type = right_value.get_type();
-                parse_quote!((#left_type,#right_type))
+                match join_type {
+                    JoinType::Inner => parse_quote!((#left_type,#right_type)),
+                    JoinType::Left => {
+                        parse_quote!(arroyo_types::UpdatingData<(#left_type,Option<#right_type>)>)
+                    }
+                    JoinType::Right => {
+                        parse_quote!(arroyo_types::UpdatingData<(Option<#left_type>,#right_type)>)
+                    }
+                    JoinType::Full => {
+                        parse_quote!(arroyo_types::UpdatingData<(Option<#left_type>,Option<#right_type>)>)
+                    }
+                }
             }
             PlanType::KeyedListPair {
                 key: _,
@@ -835,16 +1015,26 @@ impl PlanType {
                 let value_type = value.get_type();
                 parse_quote!(Vec<#value_type>)
             }
+            PlanType::Updating(inner_type) => {
+                let inner_type = inner_type.as_syn_type();
+                parse_quote!(arroyo_types::UpdatingData<#inner_type>)
+            }
         }
     }
 
     fn key_type(&self) -> syn::Type {
         match self {
-            PlanType::Unkeyed(_) | PlanType::UnkeyedList(_) => parse_quote!(()),
+            PlanType::Unkeyed(_)
+            | PlanType::UnkeyedList(_)
+            | PlanType::KeyedLiteralTypeValue {
+                key: None,
+                value: _,
+            } => parse_quote!(()),
             PlanType::Keyed { key, .. }
             | PlanType::KeyedPair { key, .. }
-            | PlanType::KeyedLiteralTypeValue { key, .. }
+            | PlanType::KeyedLiteralTypeValue { key: Some(key), .. }
             | PlanType::KeyedListPair { key, .. } => key.get_type(),
+            PlanType::Updating(inner) => inner.key_type(),
         }
     }
 
@@ -856,11 +1046,17 @@ impl PlanType {
 
     fn get_key_struct_names(&self) -> Vec<String> {
         match self {
-            PlanType::Unkeyed(_) | PlanType::UnkeyedList(_) => vec![],
+            PlanType::Unkeyed(_)
+            | PlanType::UnkeyedList(_)
+            | PlanType::KeyedLiteralTypeValue {
+                key: None,
+                value: _,
+            } => vec![],
             PlanType::Keyed { key, .. }
             | PlanType::KeyedPair { key, .. }
-            | PlanType::KeyedLiteralTypeValue { key, .. }
+            | PlanType::KeyedLiteralTypeValue { key: Some(key), .. }
             | PlanType::KeyedListPair { key, .. } => key.all_names(),
+            PlanType::Updating(inner) => inner.get_key_struct_names(),
         }
     }
 
@@ -878,6 +1074,7 @@ impl PlanType {
                 key,
                 left_value,
                 right_value,
+                join_type: _,
             }
             | PlanType::KeyedListPair {
                 key,
@@ -889,10 +1086,84 @@ impl PlanType {
                 result.extend(right_value.all_structs());
                 result.into_iter().collect()
             }
-            PlanType::KeyedLiteralTypeValue { key, value: _ } => {
-                key.all_structs().into_iter().collect()
-            }
+            PlanType::KeyedLiteralTypeValue { key, value: _ } => match key {
+                Some(key) => key.all_structs().into_iter().collect(),
+                None => HashSet::new(),
+            },
+            PlanType::Updating(inner) => inner.get_all_types(),
         }
+    }
+
+    fn get_stream_edge(&self, edge_type: EdgeType) -> StreamEdge {
+        let key_type = self.key_type();
+        let value_type = self.as_syn_type();
+        let key = quote!(#key_type).to_string();
+        let value = quote!(#value_type).to_string();
+        StreamEdge {
+            key,
+            value,
+            typ: edge_type,
+        }
+    }
+
+    fn with_key(&self, key: StructDef) -> Self {
+        match self {
+            PlanType::Unkeyed(value) | PlanType::Keyed { key: _, value } => PlanType::Keyed {
+                key,
+                value: value.clone(),
+            },
+            PlanType::UnkeyedList(_) => unreachable!(),
+            PlanType::KeyedPair {
+                key: _,
+                left_value,
+                right_value,
+                join_type,
+            } => PlanType::KeyedPair {
+                key,
+                left_value: left_value.clone(),
+                right_value: right_value.clone(),
+                join_type: join_type.clone(),
+            },
+            PlanType::KeyedListPair {
+                key: _,
+                left_value,
+                right_value,
+            } => PlanType::KeyedListPair {
+                key,
+                left_value: left_value.clone(),
+                right_value: right_value.clone(),
+            },
+            PlanType::KeyedLiteralTypeValue { key: _, value } => PlanType::KeyedLiteralTypeValue {
+                key: Some(key),
+                value: value.clone(),
+            },
+            PlanType::Updating(inner) => PlanType::Updating(Box::new(inner.with_key(key))),
+        }
+    }
+
+    fn with_value(&self, value: StructDef) -> PlanType {
+        match self {
+            PlanType::Unkeyed(_) => PlanType::Unkeyed(value),
+            PlanType::UnkeyedList(_) => PlanType::UnkeyedList(value),
+            PlanType::Keyed { key: _, value: _ } => PlanType::Unkeyed(value),
+            PlanType::KeyedPair {
+                key: _,
+                left_value: _,
+                right_value: _,
+                join_type: _,
+            } => unreachable!(),
+            PlanType::KeyedListPair {
+                key: _,
+                left_value: _,
+                right_value: _,
+            } => unreachable!(),
+            PlanType::KeyedLiteralTypeValue { key: _, value: _ } => unreachable!(),
+            PlanType::Updating(inner) => PlanType::Updating(Box::new(inner.with_value(value))),
+        }
+    }
+
+    pub(crate) fn is_updating(&self) -> bool {
+        matches!(self, PlanType::Updating(_))
     }
 }
 
@@ -946,6 +1217,32 @@ impl PlanGraph {
         }
     }
 
+    fn add_debezium_source(&mut self, source_operator: &SourceOperator) -> NodeIndex {
+        let value_type = source_operator.source.struct_def.get_type();
+        let debezium_type = PlanType::KeyedLiteralTypeValue {
+            key: None,
+            value: quote!(arroyo_types::Debezium<#value_type>).to_string(),
+        };
+        let source_node = self.insert_operator(
+            PlanOperator::Source(source_operator.name.clone(), source_operator.source.clone()),
+            debezium_type,
+        );
+
+        let debezium_edge = PlanEdge {
+            edge_type: EdgeType::Forward,
+        };
+
+        let from_debezium_node = self.insert_operator(
+            PlanOperator::FromDebezium,
+            PlanType::Updating(Box::new(PlanType::Unkeyed(
+                source_operator.source.struct_def.clone(),
+            ))),
+        );
+        self.graph
+            .add_edge(source_node, from_debezium_node, debezium_edge);
+        from_debezium_node
+    }
+
     fn add_sql_source(&mut self, source_operator: SourceOperator) -> NodeIndex {
         if let Some(node_index) = self.sources.get(&source_operator.name) {
             return *node_index;
@@ -953,25 +1250,25 @@ impl PlanGraph {
         if let Some(source_id) = source_operator.source.id {
             self.saved_sources_used.push(source_id);
         }
-        let mut current_type = PlanType::Unkeyed(source_operator.source.struct_def.clone());
-        let mut current_index = self.insert_operator(
-            PlanOperator::Source(source_operator.name.clone(), source_operator.source.clone()),
-            current_type.clone(),
-        );
+        let mut current_index = match source_operator.source.serialization_mode {
+            SerializationMode::DebeziumJson => self.add_debezium_source(&source_operator),
+            _ => self.insert_operator(
+                PlanOperator::Source(source_operator.name.clone(), source_operator.source.clone()),
+                PlanType::Unkeyed(source_operator.source.struct_def.clone()),
+            ),
+        };
         if let Some(virtual_projection) = source_operator.virtual_field_projection {
             let virtual_plan_type = PlanType::Unkeyed(virtual_projection.output_struct());
             let virtual_index = self.insert_operator(
                 PlanOperator::RecordTransform(RecordTransform::ValueProjection(virtual_projection)),
-                virtual_plan_type.clone(),
+                virtual_plan_type,
             );
             let virtual_edge = PlanEdge {
-                edge_data_type: current_type.clone(),
                 edge_type: EdgeType::Forward,
             };
             self.graph
                 .add_edge(current_index, virtual_index, virtual_edge);
             current_index = virtual_index;
-            current_type = virtual_plan_type;
         }
 
         if let Some(timestamp_expression) = source_operator.timestamp_override {
@@ -979,10 +1276,9 @@ impl PlanGraph {
                 PlanOperator::RecordTransform(RecordTransform::TimestampAssignment(
                     timestamp_expression,
                 )),
-                current_type.clone(),
+                self.get_plan_node(current_index).output_type.clone(),
             );
             let timestamp_edge = PlanEdge {
-                edge_data_type: current_type.clone(),
                 edge_type: EdgeType::Forward,
             };
             self.graph
@@ -1012,9 +1308,11 @@ impl PlanGraph {
             }
         };
         let watermark_operator = PlanOperator::Watermark(watermark);
-        let watermark_index = self.insert_operator(watermark_operator, current_type.clone());
+        let watermark_index = self.insert_operator(
+            watermark_operator,
+            self.get_plan_node(current_index).output_type.clone(),
+        );
         let watermark_edge = PlanEdge {
-            edge_data_type: current_type,
             edge_type: EdgeType::Forward,
         };
         self.graph
@@ -1036,21 +1334,22 @@ impl PlanGraph {
         input: Box<SqlOperator>,
         aggregate: crate::pipeline::AggregateOperator,
     ) -> NodeIndex {
-        let input_type = input.return_type();
+        if !input.has_window() && matches!(aggregate.window, WindowType::Instant) {
+            return self.add_updating_aggregator(input, aggregate);
+        }
+        let input_index = self.add_sql_operator(*input);
+
         let output_type = aggregate.output_struct();
         let key_struct = aggregate.key.output_struct();
-        let input_index = self.add_sql_operator(*input);
         let key_operator =
             PlanOperator::RecordTransform(RecordTransform::KeyProjection(aggregate.key));
         let key_index = self.insert_operator(
             key_operator,
-            PlanType::Keyed {
-                key: key_struct.clone(),
-                value: input_type.clone(),
-            },
+            self.get_plan_node(input_index)
+                .output_type
+                .with_key(key_struct.clone()),
         );
         let key_edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(input_type.clone()),
             edge_type: EdgeType::Forward,
         };
         self.graph.add_edge(input_index, key_index, key_edge);
@@ -1068,31 +1367,23 @@ impl PlanGraph {
             },
         );
         let aggregate_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct.clone(),
-                value: input_type,
-            },
             edge_type: EdgeType::Shuffle,
         };
         self.graph
             .add_edge(key_index, aggregate_index, aggregate_edge);
         let merge_node = PlanOperator::WindowMerge {
             key_struct: key_struct.clone(),
-            value_struct: aggregate_struct.clone(),
+            value_struct: aggregate_struct,
             group_by_kind: aggregate.merge,
         };
         let merge_index = self.insert_operator(
             merge_node,
             PlanType::Keyed {
-                key: key_struct.clone(),
+                key: key_struct,
                 value: output_type,
             },
         );
         let merge_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct,
-                value: aggregate_struct,
-            },
             edge_type: EdgeType::Forward,
         };
         self.graph
@@ -1138,11 +1429,9 @@ impl PlanGraph {
         );
 
         let left_key_edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(left_type.clone()),
             edge_type: EdgeType::Forward,
         };
         let right_key_edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(right_type.clone()),
             edge_type: EdgeType::Forward,
         };
 
@@ -1182,24 +1471,16 @@ impl PlanGraph {
     ) -> NodeIndex {
         let join_node = PlanOperator::InstantJoin;
         let join_node_output_type = PlanType::KeyedListPair {
-            key: key_struct.clone(),
+            key: key_struct,
             left_value: left_struct.clone(),
             right_value: right_struct.clone(),
         };
-        let join_node_index = self.insert_operator(join_node, join_node_output_type.clone());
+        let join_node_index = self.insert_operator(join_node, join_node_output_type);
 
         let left_join_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct.clone(),
-                value: left_struct.clone(),
-            },
             edge_type: EdgeType::ShuffleJoin(0),
         };
         let right_join_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct,
-                value: right_struct.clone(),
-            },
             edge_type: EdgeType::ShuffleJoin(1),
         };
         self.graph
@@ -1219,7 +1500,6 @@ impl PlanGraph {
             self.insert_operator(merge_operator, PlanType::UnkeyedList(merge_type.clone()));
 
         let merge_edge = PlanEdge {
-            edge_data_type: join_node_output_type,
             edge_type: EdgeType::Forward,
         };
 
@@ -1227,10 +1507,8 @@ impl PlanGraph {
             .add_edge(join_node_index, merge_index, merge_edge);
 
         let flatten_operator = PlanOperator::Flatten;
-        let flatten_index =
-            self.insert_operator(flatten_operator, PlanType::Unkeyed(merge_type.clone()));
+        let flatten_index = self.insert_operator(flatten_operator, PlanType::Unkeyed(merge_type));
         let flatten_edge = PlanEdge {
-            edge_data_type: PlanType::UnkeyedList(merge_type),
             edge_type: EdgeType::Forward,
         };
         self.graph
@@ -1250,27 +1528,20 @@ impl PlanGraph {
         let join_node = PlanOperator::JoinWithExpiration {
             left_expiration: Duration::from_secs(24 * 60 * 60),
             right_expiration: Duration::from_secs(24 * 60 * 60),
-            join_type: JoinType::Inner,
+            join_type: join_type.clone(),
         };
         let join_node_output_type = PlanType::KeyedPair {
             key: key_struct.clone(),
             left_value: left_struct.clone(),
             right_value: right_struct.clone(),
+            join_type: join_type.clone(),
         };
-        let join_node_index = self.insert_operator(join_node, join_node_output_type.clone());
+        let join_node_index = self.insert_operator(join_node, join_node_output_type);
 
         let left_join_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct.clone(),
-                value: left_struct.clone(),
-            },
             edge_type: EdgeType::ShuffleJoin(0),
         };
         let right_join_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: key_struct,
-                value: right_struct.clone(),
-            },
             edge_type: EdgeType::ShuffleJoin(1),
         };
         self.graph
@@ -1280,16 +1551,24 @@ impl PlanGraph {
 
         let merge_type = join_type.output_struct(&left_struct, &right_struct);
         let merge_operator = PlanOperator::JoinPairMerge(
-            join_type,
+            join_type.clone(),
             StructPair {
                 left: left_struct,
                 right: right_struct,
             },
         );
-        let merge_index = self.insert_operator(merge_operator, PlanType::Unkeyed(merge_type));
+        let merge_output_type = match join_type {
+            JoinType::Inner => PlanType::Unkeyed(merge_type),
+            JoinType::Left | JoinType::Right | JoinType::Full => {
+                PlanType::Updating(Box::new(PlanType::Keyed {
+                    key: key_struct,
+                    value: merge_type,
+                }))
+            }
+        };
+        let merge_index = self.insert_operator(merge_operator, merge_output_type);
 
         let merge_edge = PlanEdge {
-            edge_data_type: join_node_output_type,
             edge_type: EdgeType::Forward,
         };
 
@@ -1320,11 +1599,10 @@ impl PlanGraph {
             partition_key_node,
             PlanType::Keyed {
                 key: partition_struct.clone(),
-                value: input_type.clone(),
+                value: input_type,
             },
         );
         let partition_key_edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(input_type.clone()),
             edge_type: EdgeType::Forward,
         };
 
@@ -1341,15 +1619,11 @@ impl PlanGraph {
         let window_function_index = self.insert_operator(
             window_function_node,
             PlanType::Keyed {
-                key: partition_struct.clone(),
+                key: partition_struct,
                 value: result_type.clone(),
             },
         );
         let window_function_edge = PlanEdge {
-            edge_data_type: PlanType::Keyed {
-                key: partition_struct.clone(),
-                value: input_type,
-            },
             edge_type: EdgeType::Shuffle,
         };
         self.graph.add_edge(
@@ -1363,10 +1637,6 @@ impl PlanGraph {
             window_function_index,
             unkey_index,
             PlanEdge {
-                edge_data_type: PlanType::Keyed {
-                    key: partition_struct,
-                    value: result_type.clone(),
-                },
                 edge_type: EdgeType::Forward,
             },
         );
@@ -1378,17 +1648,20 @@ impl PlanGraph {
         input: Box<SqlOperator>,
         transform: RecordTransform,
     ) -> NodeIndex {
-        let input_type = input.return_type();
-        let return_type = transform.output_struct(input_type.clone());
         let input_index = self.add_sql_operator(*input);
-        let plan_node = PlanOperator::RecordTransform(transform);
-        let plan_node_index = self.insert_operator(plan_node, PlanType::Unkeyed(return_type));
+
+        let plan_node = PlanNode::from_record_transform(transform, self.get_plan_node(input_index));
+
+        let plan_node_index = self.graph.add_node(plan_node);
         let edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(input_type),
             edge_type: EdgeType::Forward,
         };
         self.graph.add_edge(input_index, plan_node_index, edge);
         plan_node_index
+    }
+
+    fn get_plan_node(&self, node_index: NodeIndex) -> &PlanNode {
+        self.graph.node_weight(node_index).unwrap()
     }
 
     fn add_sql_sink(
@@ -1397,17 +1670,126 @@ impl PlanGraph {
         sql_sink: crate::external::SqlSink,
         input: Box<SqlOperator>,
     ) -> NodeIndex {
-        let input_type = input.return_type();
         let input_index = self.add_sql_operator(*input);
-        let plan_node = PlanOperator::Sink(name, sql_sink);
-        let plan_node_index =
-            self.insert_operator(plan_node, PlanType::Unkeyed(input_type.clone()));
-        let edge = PlanEdge {
-            edge_data_type: PlanType::Unkeyed(input_type),
+        let input_node = self.get_plan_node(input_index);
+        if let PlanType::Updating(inner) = &input_node.output_type {
+            let value_type = inner.as_syn_type();
+            let debezium_type = PlanType::KeyedLiteralTypeValue {
+                key: None,
+                value: quote!(arroyo_types::Debezium<#value_type>).to_string(),
+            };
+            let debezium_index =
+                self.insert_operator(PlanOperator::ToDebezium, debezium_type.clone());
+
+            let edge = PlanEdge {
+                edge_type: EdgeType::Forward,
+            };
+            self.graph.add_edge(input_index, debezium_index, edge);
+
+            let plan_node = PlanOperator::Sink(name, sql_sink);
+            let plan_node_index = self.insert_operator(plan_node, debezium_type);
+
+            let debezium_edge = PlanEdge {
+                edge_type: EdgeType::Forward,
+            };
+
+            self.graph
+                .add_edge(debezium_index, plan_node_index, debezium_edge);
+            plan_node_index
+        } else if matches!(sql_sink.updating_type, SinkUpdateType::Force) {
+            let value_type = input_node.output_type.as_syn_type();
+            let debezium_type = PlanType::KeyedLiteralTypeValue {
+                key: None,
+                value: quote!(arroyo_types::Debezium<#value_type>).to_string(),
+            };
+            let debezium_index =
+                self.insert_operator(PlanOperator::ToDebezium, debezium_type.clone());
+            let edge = PlanEdge {
+                edge_type: EdgeType::Forward,
+            };
+            self.graph.add_edge(input_index, debezium_index, edge);
+
+            let plan_node = PlanOperator::Sink(name, sql_sink);
+            let plan_node_index = self.insert_operator(plan_node, debezium_type);
+
+            let debezium_edge = PlanEdge {
+                edge_type: EdgeType::Forward,
+            };
+
+            self.graph
+                .add_edge(debezium_index, plan_node_index, debezium_edge);
+            plan_node_index
+        } else {
+            let plan_node = PlanOperator::Sink(name, sql_sink);
+            let plan_node_index = self.insert_operator(plan_node, input_node.output_type.clone());
+            let edge = PlanEdge {
+                edge_type: EdgeType::Forward,
+            };
+            self.graph.add_edge(input_index, plan_node_index, edge);
+            plan_node_index
+        }
+    }
+
+    fn add_updating_aggregator(
+        &mut self,
+        input: Box<SqlOperator>,
+        aggregate: crate::pipeline::AggregateOperator,
+    ) -> NodeIndex {
+        let input_index = self.add_sql_operator(*input);
+
+        let input_node = self.get_plan_node(input_index);
+        let input_updating = input_node.output_type.is_updating();
+
+        let output_type = aggregate.output_struct();
+        let key_struct = aggregate.key.output_struct();
+        let key_operator =
+            PlanOperator::RecordTransform(RecordTransform::KeyProjection(aggregate.key));
+        let key_index = self.insert_operator(
+            key_operator,
+            self.get_plan_node(input_index)
+                .output_type
+                .with_key(key_struct.clone()),
+        );
+        let key_edge = PlanEdge {
             edge_type: EdgeType::Forward,
         };
-        self.graph.add_edge(input_index, plan_node_index, edge);
-        plan_node_index
+        self.graph.add_edge(input_index, key_index, key_edge);
+        let aggregate_projection = aggregate.aggregating;
+        let aggregate_struct = aggregate_projection.output_struct();
+        let aggregate_operator = PlanOperator::NonWindowAggregate {
+            input_is_update: input_updating,
+            expiration: Duration::from_secs(60 * 60 * 24),
+            projection: aggregate_projection.try_into().unwrap(),
+        };
+
+        let aggregate_index = self.insert_operator(
+            aggregate_operator,
+            PlanType::Updating(Box::new(PlanType::Keyed {
+                key: key_struct.clone(),
+                value: aggregate_struct.clone(),
+            })),
+        );
+        let aggregate_edge = PlanEdge {
+            edge_type: EdgeType::Shuffle,
+        };
+        self.graph
+            .add_edge(key_index, aggregate_index, aggregate_edge);
+        let merge_node = PlanOperator::WindowMerge {
+            key_struct,
+            value_struct: aggregate_struct,
+            group_by_kind: aggregate.merge,
+        };
+        let merge_index = self.insert_operator(
+            merge_node,
+            PlanType::Updating(Box::new(PlanType::Unkeyed(output_type))),
+        );
+        let merge_edge = PlanEdge {
+            edge_type: EdgeType::Forward,
+        };
+        self.graph
+            .add_edge(aggregate_index, merge_index, merge_edge);
+
+        merge_index
     }
 }
 
@@ -1415,7 +1797,13 @@ impl From<PlanGraph> for DiGraph<StreamNode, StreamEdge> {
     fn from(val: PlanGraph) -> Self {
         val.graph.map(
             |index: NodeIndex, node| node.into_stream_node(index.index(), &val.sql_config),
-            |_index, edge| edge.into_stream_edge(),
+            |index, edge| {
+                let source_index = val.graph.edge_endpoints(index).unwrap().0;
+                let source_node = val.graph.node_weight(source_index).unwrap();
+                source_node
+                    .output_type
+                    .get_stream_edge(edge.edge_type.clone())
+            },
         )
     }
 }

--- a/arroyo-sql/src/test.rs
+++ b/arroyo-sql/src/test.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use arrow_schema::{DataType, TimeUnit};
 use arroyo_datastream::SerializationMode;
+use arroyo_rpc::grpc::api::{Connection, KafkaAuthConfig, KafkaConnection};
 
 use crate::{
     parse_and_get_program,
@@ -66,6 +67,8 @@ fn test_schema() -> Vec<StructField> {
 
 #[tokio::test]
 async fn test_parse() {
+    let schema_provider = get_test_schema_provider();
+
     let sql = "
   WITH bids as (SELECT bid.auction as auction, bid.datetime as datetime
     FROM (select bid from  nexmark) where bid is not null)
@@ -98,19 +101,6 @@ async fn test_parse() {
        AuctionBids.num = MaxBids.maxn
        and AuctionBids.window = MaxBids.window;";
 
-    let mut schema_provider = ArroyoSchemaProvider::new();
-    schema_provider.add_saved_source_with_type(
-        1,
-        "nexmark".to_string(),
-        test_schema(),
-        Some("arroyo_types::nexmark::NexmarkEvent".to_string()),
-        arroyo_datastream::SourceConfig::NexmarkSource {
-            event_rate: 10,
-            runtime: Some(Duration::from_secs(10)),
-        },
-        SerializationMode::Json,
-    );
-
     parse_and_get_program(sql, schema_provider, SqlConfig::default())
         .await
         .unwrap();
@@ -118,18 +108,7 @@ async fn test_parse() {
 
 #[tokio::test]
 async fn test_program_compilation() {
-    let mut schema_provider = ArroyoSchemaProvider::new();
-    schema_provider.add_saved_source_with_type(
-        1,
-        "nexmark".to_string(),
-        test_schema(),
-        Some("arroyo_types::nexmark::NexmarkEvent".to_string()),
-        arroyo_datastream::SourceConfig::NexmarkSource {
-            event_rate: 10,
-            runtime: Some(Duration::from_secs(10)),
-        },
-        SerializationMode::Json,
-    );
+    let schema_provider = get_test_schema_provider();
 
     let sql = "
     SELECT * FROM (
@@ -149,18 +128,7 @@ async fn test_program_compilation() {
 
 #[tokio::test]
 async fn test_table_alias() {
-    let mut schema_provider = ArroyoSchemaProvider::new();
-    schema_provider.add_saved_source_with_type(
-        1,
-        "nexmark".to_string(),
-        test_schema(),
-        Some("arroyo_types::nexmark::NexmarkEvent".to_string()),
-        arroyo_datastream::SourceConfig::NexmarkSource {
-            event_rate: 10,
-            runtime: Some(Duration::from_secs(10)),
-        },
-        SerializationMode::Json,
-    );
+    let schema_provider = get_test_schema_provider();
 
     let sql = "SELECT P1.bid FROM nexmark as P1";
 
@@ -169,8 +137,7 @@ async fn test_table_alias() {
         .unwrap();
 }
 
-#[tokio::test]
-async fn test_window_function() {
+fn get_test_schema_provider() -> ArroyoSchemaProvider {
     let mut schema_provider = ArroyoSchemaProvider::new();
     schema_provider.add_saved_source_with_type(
         1,
@@ -183,6 +150,27 @@ async fn test_window_function() {
         },
         SerializationMode::Json,
     );
+    schema_provider.add_connection(Connection {
+        name: "local".to_string(),
+        sources: 0,
+        sinks: 0,
+        connection_type: Some(arroyo_rpc::grpc::api::connection::ConnectionType::Kafka(
+            KafkaConnection {
+                bootstrap_servers: "localhost:9090".to_string(),
+                auth_config: Some(KafkaAuthConfig {
+                    auth_type: Some(arroyo_rpc::grpc::api::kafka_auth_config::AuthType::NoAuth(
+                        arroyo_rpc::grpc::api::NoAuth {},
+                    )),
+                }),
+            },
+        )),
+    });
+    schema_provider
+}
+
+#[tokio::test]
+async fn test_window_function() {
+    let schema_provider = get_test_schema_provider();
 
     let sql = "SELECT * FROM (
     SELECT *, ROW_NUMBER() OVER (
@@ -196,6 +184,46 @@ async fn test_window_function() {
     parse_and_get_program(sql, schema_provider, SqlConfig::default())
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_no_updating_window_functions() {
+    let schema_provider = get_test_schema_provider();
+    let sql = "SELECT *, row_number() OVER (partition by bid.auction order by bid.datetime desc) as row_num
+     FROM nexmark where bid is not null";
+    let err = parse_and_get_program(sql, schema_provider, SqlConfig::default())
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "window functions have to be partitioned by a time window"
+    );
+}
+
+#[tokio::test]
+async fn test_no_virtual_fields_updating() {
+    let schema_provider = get_test_schema_provider();
+    let sql =  "CREATE table debezium_source (
+        bids_auction int,
+        price int,
+        auctions_id int,
+        initial_bid int,
+        date_string text,
+        datetime datetime GENERATED ALWAYS AS (CAST(date_string as timestamp)),
+        watermark datetime GENERATED ALWAYS AS (CAST(date_string as timestamp) - interval '1 second')
+      ) WITH (
+        connection = 'local',
+        topic = 'updating',
+        serialization_mode = 'debezium_json'
+      );
+      SELECT * FROM debezium_source";
+    let err = parse_and_get_program(sql, schema_provider, SqlConfig::default())
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "can't read from a source with virtual fields and update mode."
+    );
 }
 
 #[tokio::test]

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -211,7 +211,7 @@ impl TryFrom<&Type> for TypeDef {
         match typ {
             Type::Path(pat) => {
                 let last = pat.path.segments.last().unwrap();
-                if last.ident.to_string() == "Option" {
+                if last.ident == "Option" {
                     let AngleBracketed(args) = &last.arguments else {
                         return Err(())
                     };

--- a/arroyo-state/src/tables.rs
+++ b/arroyo-state/src/tables.rs
@@ -4,7 +4,7 @@ use arroyo_rpc::grpc::{CheckpointMetadata, TableDescriptor, TableType};
 use arroyo_types::{from_micros, Data, Key, TaskInfo};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, SystemTime};
-use tracing::warn;
+use tracing::{info, warn};
 
 pub struct TimeKeyMap<'a, K: Key, V: Data, S: BackingStore> {
     table: char,
@@ -452,6 +452,84 @@ impl<K: Key, V: Data> GlobalKeyedStateCache<K, V> {
 }
 
 impl<K: Key, V: Data> Default for GlobalKeyedStateCache<K, V> {
+    fn default() -> Self {
+        Self {
+            values: Default::default(),
+        }
+    }
+}
+
+pub struct KeyedState<'a, K: Key, V: Data, S: BackingStore> {
+    table: char,
+    backing_state: &'a mut S,
+    cache: &'a mut KeyedStateCache<K, V>,
+}
+
+impl<'a, K: Key, V: Data, S: BackingStore> KeyedState<'a, K, V, S> {
+    pub fn new(
+        table: char,
+        backing_store: &'a mut S,
+        cache: &'a mut KeyedStateCache<K, V>,
+    ) -> Self {
+        Self {
+            table,
+            backing_state: backing_store,
+            cache,
+        }
+    }
+
+    pub async fn insert(&mut self, timestamp: SystemTime, mut key: K, value: V) {
+        let mut wrapped = Some(value);
+        self.backing_state
+            .write_data_triple(
+                self.table,
+                TableType::TimeKeyMap,
+                timestamp,
+                &mut key,
+                &mut wrapped,
+            )
+            .await;
+        self.cache.insert(key, wrapped.unwrap());
+    }
+
+    pub async fn remove(&mut self, mut key: K) {
+        self.cache.remove(&key);
+        self.backing_state
+            .write_key_value::<K, Option<V>>(self.table, &mut key, &mut None)
+            .await;
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.cache.values.get(key)
+    }
+}
+
+pub struct KeyedStateCache<K: Key, V: Data> {
+    values: HashMap<K, V>,
+}
+
+impl<K: Key, V: Data> KeyedStateCache<K, V> {
+    pub async fn from_checkpoint<S: BackingStore>(backing_store: &S, table: char) -> Self {
+        let mut values = HashMap::new();
+        for (key, value) in backing_store.get_key_values(table).await {
+            info!("Loaded key: {:?} value: {:?}", key, value);
+            match value {
+                Some(value) => values.insert(key, value),
+                None => values.remove(&key),
+            };
+        }
+        Self { values }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.values.insert(key, value);
+    }
+    pub fn remove(&mut self, key: &K) {
+        self.values.remove(key);
+    }
+}
+
+impl<K: Key, V: Data> Default for KeyedStateCache<K, V> {
     fn default() -> Self {
         Self {
             values: Default::default(),

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -242,6 +242,176 @@ pub struct Record<K: Key, T: Data> {
     pub value: T,
 }
 
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Serialize, Deserialize)]
+pub enum UpdatingData<T: Data> {
+    Retract(T),
+    Update { old: T, new: T },
+    Append(T),
+}
+
+#[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Debezium<T: Data> {
+    before: Option<T>,
+    after: Option<T>,
+    op: DebeziumOp,
+}
+
+//Debezium ops with single character serialization
+#[derive(Clone, Encode, Decode, Debug, PartialEq)]
+pub enum DebeziumOp {
+    Create,
+    Update,
+    Delete,
+}
+
+impl<'de> Deserialize<'de> for DebeziumOp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "c" => Ok(DebeziumOp::Create),
+            "u" => Ok(DebeziumOp::Update),
+            "d" => Ok(DebeziumOp::Delete),
+            _ => Err(serde::de::Error::custom(format!(
+                "Invalid DebeziumOp {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for DebeziumOp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            DebeziumOp::Create => serializer.serialize_str("c"),
+            DebeziumOp::Update => serializer.serialize_str("u"),
+            DebeziumOp::Delete => serializer.serialize_str("d"),
+        }
+    }
+}
+
+impl<T: Data> UpdatingData<T> {
+    // Applies a function to the inner data,
+    // returning the result unless the Update becomes a no-op.
+    pub fn map_over_inner<F, R: Data>(&self, f: F) -> Option<UpdatingData<R>>
+    where
+        F: Fn(&T) -> R,
+    {
+        match self {
+            UpdatingData::Retract(before) => Some(UpdatingData::Retract(f(before))),
+            UpdatingData::Update { old, new } => {
+                let old = f(old);
+                let new = f(new);
+                if old == new {
+                    None
+                } else {
+                    Some(UpdatingData::Update { old, new })
+                }
+            }
+            UpdatingData::Append(after) => Some(UpdatingData::Append(f(after))),
+        }
+    }
+
+    // Applies a filter to the inner data,
+    // returning None if no inner data passes the filter.
+    pub fn filter<F>(&self, f: F) -> Option<UpdatingData<T>>
+    where
+        F: Fn(&T) -> bool,
+    {
+        match self {
+            UpdatingData::Retract(before) => {
+                if f(before) {
+                    Some(UpdatingData::Retract(before.clone()))
+                } else {
+                    None
+                }
+            }
+            UpdatingData::Update { old, new } => {
+                let old_passes = f(old);
+                let new_passes = f(new);
+                match (old_passes, new_passes) {
+                    (true, true) => Some(UpdatingData::Update {
+                        old: old.clone(),
+                        new: new.clone(),
+                    }),
+                    (true, false) => Some(UpdatingData::Retract(old.clone())),
+                    (false, true) => Some(UpdatingData::Append(new.clone())),
+                    (false, false) => None,
+                }
+            }
+            UpdatingData::Append(after) => {
+                if f(after) {
+                    Some(UpdatingData::Append(after.clone()))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl<T: Data> From<UpdatingData<T>> for Debezium<T> {
+    fn from(value: UpdatingData<T>) -> Self {
+        match value {
+            UpdatingData::Retract(before) => Debezium {
+                before: Some(before),
+                after: None,
+                op: DebeziumOp::Delete,
+            },
+            UpdatingData::Update { old, new } => Debezium {
+                before: Some(old),
+                after: Some(new),
+                op: DebeziumOp::Update,
+            },
+            UpdatingData::Append(after) => Debezium {
+                before: None,
+                after: Some(after),
+                op: DebeziumOp::Create,
+            },
+        }
+    }
+}
+
+impl<T: Data> From<T> for Debezium<T> {
+    fn from(value: T) -> Self {
+        Debezium {
+            before: None,
+            after: Some(value),
+            op: DebeziumOp::Create,
+        }
+    }
+}
+
+impl<T: Data> From<Debezium<T>> for UpdatingData<T> {
+    fn from(value: Debezium<T>) -> Self {
+        match value.op {
+            DebeziumOp::Delete => UpdatingData::Retract(value.before.unwrap()),
+            DebeziumOp::Update => UpdatingData::Update {
+                old: value.before.unwrap(),
+                new: value.after.unwrap(),
+            },
+            DebeziumOp::Create => UpdatingData::Append(value.after.unwrap()),
+        }
+    }
+}
+
+#[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]
+pub enum JoinType {
+    /// Inner Join
+    Inner,
+    /// Left Join
+    Left,
+    /// Right Join
+    Right,
+    /// Full Join
+    Full,
+}
+
 unsafe impl<K: Key, T: Data> Sync for Record<K, T> {}
 
 impl<K: Key, T: Data> Record<K, T> {

--- a/arroyo-worker/src/operators/aggregating_window.rs
+++ b/arroyo-worker/src/operators/aggregating_window.rs
@@ -426,6 +426,13 @@ pub fn non_nullable_min_heap_aggregate<T: Ord + Clone>(memory: BTreeMap<T, usize
         .unwrap()
 }
 
+pub fn non_nullable_max_heap_aggregate<T: Ord + Clone>(memory: &BTreeMap<T, usize>) -> T {
+    memory
+        .last_key_value()
+        .map(|(key, _value)| key.clone())
+        .unwrap()
+}
+
 pub fn nullable_average_add<T: Add<Output = T>>(
     current: Option<(i64, i64, Option<(i64, T)>)>,
     bin_value: Option<(i64, T)>,

--- a/arroyo-worker/src/operators/join_with_expiration.rs
+++ b/arroyo-worker/src/operators/join_with_expiration.rs
@@ -1,4 +1,7 @@
-use std::{marker::PhantomData, time::Duration};
+use std::{
+    marker::PhantomData,
+    time::{Duration, SystemTime},
+};
 
 use arroyo_macro::{co_process_fn, StreamNode};
 use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableType, TableWriteBehavior};
@@ -8,22 +11,323 @@ use arroyo_types::*;
 use crate::engine::Context;
 
 #[derive(StreamNode)]
-pub struct JoinWithExpiration<K: Key, T1: Data, T2: Data> {
+pub struct JoinWithExpiration<
+    K: Key,
+    T1: Data,
+    T2: Data,
+    Output: Data,
+    P: JoinProcessor<K, T1, T2, Output>,
+> {
     left_expiration: Duration,
     right_expiration: Duration,
+    processor: P,
+    _t: PhantomData<(K, T1, T2, Output)>,
+}
+
+pub trait JoinProcessor<K: Key, T1: Data, T2: Data, Output: Data>: Send + 'static {
+    fn left_join(
+        &self,
+        key: K,
+        left_timestamp: SystemTime,
+        left_value: T1,
+        right: Option<(SystemTime, &T2)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, Output)>;
+    fn right_join(
+        &self,
+        key: K,
+        right_timestamp: SystemTime,
+        right_value: T2,
+        left: Option<(SystemTime, &T1)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, Output)>;
+}
+
+pub struct LeftJoinProcessor<K: Key, T1: Data, T2: Data> {
     _t: PhantomData<(K, T1, T2)>,
 }
 
-#[co_process_fn(in_k1=K, in_t1=T1, in_k2=K, in_t2=T2, out_k=K, out_t=(T1,T2))]
-impl<K: Key, T1: Data, T2: Data> JoinWithExpiration<K, T1, T2> {
-    fn name(&self) -> String {
-        "JoinWithExperiation".to_string()
+impl<K: Key, T1: Data, T2: Data> JoinProcessor<K, T1, T2, UpdatingData<(T1, Option<T2>)>>
+    for LeftJoinProcessor<K, T1, T2>
+{
+    fn left_join(
+        &self,
+        _key: K,
+        left_timestamp: SystemTime,
+        left_value: T1,
+        right: Option<(SystemTime, &T2)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(T1, Option<T2>)>)> {
+        match right {
+            Some((right_timestamp, right_value)) => {
+                if evict_prior {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Update {
+                            old: (left_value.clone(), None),
+                            new: (left_value, Some(right_value.clone())),
+                        },
+                    ))
+                } else {
+                    Some((
+                        left_timestamp,
+                        UpdatingData::Append((left_value, Some(right_value.clone()))),
+                    ))
+                }
+            }
+            None => Some((left_timestamp, UpdatingData::Append((left_value, None)))),
+        }
     }
 
-    pub fn new(left_expiration: Duration, right_expiration: Duration) -> Self {
+    fn right_join(
+        &self,
+        _key: K,
+        right_timestamp: SystemTime,
+        right_value: T2,
+        left: Option<(SystemTime, &T1)>,
+        _evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(T1, Option<T2>)>)> {
+        left.map(|(left_timestamp, left_value)| {
+            (
+                right_timestamp.max(left_timestamp),
+                UpdatingData::Append((left_value.clone(), Some(right_value))),
+            )
+        })
+    }
+}
+
+pub struct RightJoinProcessor<K: Key, T1: Data, T2: Data> {
+    _t: PhantomData<(K, T1, T2)>,
+}
+
+impl<K: Key, T1: Data, T2: Data> JoinProcessor<K, T1, T2, UpdatingData<(Option<T1>, T2)>>
+    for RightJoinProcessor<K, T1, T2>
+{
+    fn left_join(
+        &self,
+        _key: K,
+        left_timestamp: SystemTime,
+        left_value: T1,
+        right: Option<(SystemTime, &T2)>,
+        _evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(Option<T1>, T2)>)> {
+        right.map(|(right_timestamp, right_value)| {
+            (
+                left_timestamp.max(right_timestamp),
+                UpdatingData::Append((Some(left_value), right_value.clone())),
+            )
+        })
+    }
+
+    fn right_join(
+        &self,
+        _key: K,
+        right_timestamp: SystemTime,
+        right_value: T2,
+        left: Option<(SystemTime, &T1)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(Option<T1>, T2)>)> {
+        match left {
+            Some((left_timestamp, left_value)) => {
+                if evict_prior {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Update {
+                            old: (Some(left_value.clone()), right_value.clone()),
+                            new: (None, right_value),
+                        },
+                    ))
+                } else {
+                    Some((
+                        right_timestamp,
+                        UpdatingData::Append((Some(left_value.clone()), right_value)),
+                    ))
+                }
+            }
+            None => Some((right_timestamp, UpdatingData::Append((None, right_value)))),
+        }
+    }
+}
+
+pub struct FullJoinProcessor<K: Key, T1: Data, T2: Data> {
+    _t: PhantomData<(K, T1, T2)>,
+}
+
+impl<K: Key, T1: Data, T2: Data> JoinProcessor<K, T1, T2, UpdatingData<(Option<T1>, Option<T2>)>>
+    for FullJoinProcessor<K, T1, T2>
+{
+    fn left_join(
+        &self,
+        _key: K,
+        left_timestamp: SystemTime,
+        left_value: T1,
+        right: Option<(SystemTime, &T2)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(Option<T1>, Option<T2>)>)> {
+        match right {
+            Some((right_timestamp, right_value)) => {
+                if evict_prior {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Update {
+                            old: (Some(left_value.clone()), None),
+                            new: (Some(left_value), Some(right_value.clone())),
+                        },
+                    ))
+                } else {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Append((Some(left_value), Some(right_value.clone()))),
+                    ))
+                }
+            }
+            None => Some((
+                left_timestamp,
+                UpdatingData::Append((Some(left_value), None)),
+            )),
+        }
+    }
+
+    fn right_join(
+        &self,
+        _key: K,
+        right_timestamp: SystemTime,
+        right_value: T2,
+        left: Option<(SystemTime, &T1)>,
+        evict_prior: bool,
+    ) -> Option<(SystemTime, UpdatingData<(Option<T1>, Option<T2>)>)> {
+        match left {
+            Some((left_timestamp, left_value)) => {
+                if evict_prior {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Update {
+                            old: (None, Some(right_value.clone())),
+                            new: (Some(left_value.clone()), Some(right_value)),
+                        },
+                    ))
+                } else {
+                    Some((
+                        left_timestamp.max(right_timestamp),
+                        UpdatingData::Append((Some(left_value.clone()), Some(right_value))),
+                    ))
+                }
+            }
+            None => Some((
+                right_timestamp,
+                UpdatingData::Append((None, Some(right_value))),
+            )),
+        }
+    }
+}
+
+pub struct InnerJoinProcessor<K: Key, T1: Data, T2: Data> {
+    _t: PhantomData<(K, T1, T2)>,
+}
+
+impl<K: Key, T1: Data, T2: Data> JoinProcessor<K, T1, T2, (T1, T2)>
+    for InnerJoinProcessor<K, T1, T2>
+{
+    fn left_join(
+        &self,
+        _key: K,
+        left_timestamp: SystemTime,
+        left_value: T1,
+        right: Option<(SystemTime, &T2)>,
+        _evict_prior: bool,
+    ) -> Option<(SystemTime, (T1, T2))> {
+        right.map(|(right_timestamp, right_value)| {
+            (
+                left_timestamp.max(right_timestamp),
+                (left_value, right_value.clone()),
+            )
+        })
+    }
+
+    fn right_join(
+        &self,
+        _key: K,
+        right_timestamp: SystemTime,
+        right_value: T2,
+        left: Option<(SystemTime, &T1)>,
+        _evict_prior: bool,
+    ) -> Option<(SystemTime, (T1, T2))> {
+        left.map(|(left_timestamp, left_value)| {
+            (
+                left_timestamp.max(right_timestamp),
+                (left_value.clone(), right_value),
+            )
+        })
+    }
+}
+
+// Return left JoinWithExpiration
+pub fn left_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<K, T1, T2, UpdatingData<(T1, Option<T2>)>, LeftJoinProcessor<K, T1, T2>> {
+    JoinWithExpiration::new(
+        left_expiration,
+        right_expiration,
+        LeftJoinProcessor { _t: PhantomData },
+    )
+}
+
+// Return right JoinWithExpiration
+pub fn right_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<K, T1, T2, UpdatingData<(Option<T1>, T2)>, RightJoinProcessor<K, T1, T2>> {
+    JoinWithExpiration::new(
+        left_expiration,
+        right_expiration,
+        RightJoinProcessor { _t: PhantomData },
+    )
+}
+
+// Return full JoinWithExpiration
+pub fn full_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, Option<T2>)>,
+    FullJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(
+        left_expiration,
+        right_expiration,
+        FullJoinProcessor { _t: PhantomData },
+    )
+}
+
+// return inner JoinWithExpiration
+pub fn inner_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<K, T1, T2, (T1, T2), InnerJoinProcessor<K, T1, T2>> {
+    JoinWithExpiration::new(
+        left_expiration,
+        right_expiration,
+        InnerJoinProcessor { _t: PhantomData },
+    )
+}
+
+#[co_process_fn(in_k1=K, in_t1=T1, in_k2=K, in_t2=T2, out_k=K, out_t=Output)]
+impl<K: Key, T1: Data, T2: Data, Output: Data, P: JoinProcessor<K, T1, T2, Output>>
+    JoinWithExpiration<K, T1, T2, Output, P>
+{
+    fn name(&self) -> String {
+        "JoinWithExpiration".to_string()
+    }
+
+    pub fn new(left_expiration: Duration, right_expiration: Duration, processor: P) -> Self {
         Self {
             left_expiration,
             right_expiration,
+            processor,
             _t: PhantomData,
         }
     }
@@ -49,26 +353,49 @@ impl<K: Key, T1: Data, T2: Data> JoinWithExpiration<K, T1, T2> {
         ]
     }
 
-    async fn process_left(&mut self, record: &Record<K, T1>, ctx: &mut Context<K, (T1, T2)>) {
+    async fn process_left(&mut self, record: &Record<K, T1>, ctx: &mut Context<K, Output>) {
         if let Some(watermark) = ctx.watermark() {
             if record.timestamp < watermark {
                 return;
             }
         };
-        let mut right_state: KeyTimeMultiMap<K, T2, _> =
-            ctx.state.get_key_time_multi_map('r').await;
         let mut key = record.key.clone().unwrap();
         let value = record.value.clone();
+
+        let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;
+        let evict = left_state
+            .get_all_values_with_timestamps(&mut key)
+            .await
+            .is_none();
+        let mut right_state: KeyTimeMultiMap<K, T2, _> =
+            ctx.state.get_key_time_multi_map('r').await;
         let records = {
             let mut records = vec![];
             if let Some(right_rows) = right_state.get_all_values_with_timestamps(&mut key).await {
-                for (timestamp, right_value) in right_rows {
-                    records.push(Record {
-                        timestamp: record.timestamp.max(timestamp),
-                        key: Some(key.clone()),
-                        value: (value.clone(), right_value.clone()),
-                    });
+                for right in right_rows {
+                    if let Some((timestamp, value)) = self.processor.left_join(
+                        key.clone(),
+                        record.timestamp,
+                        value.clone(),
+                        Some(right),
+                        evict,
+                    ) {
+                        records.push(Record {
+                            timestamp,
+                            key: Some(key.clone()),
+                            value,
+                        });
+                    }
                 }
+            } else if let Some((timestamp, value)) =
+                self.processor
+                    .left_join(key.clone(), record.timestamp, value.clone(), None, evict)
+            {
+                records.push(Record {
+                    timestamp,
+                    key: Some(key.clone()),
+                    value,
+                });
             }
             records
         };
@@ -79,40 +406,65 @@ impl<K: Key, T1: Data, T2: Data> JoinWithExpiration<K, T1, T2> {
         left_state.insert(record.timestamp, key, value).await;
     }
 
-    async fn process_right(&mut self, record: &Record<K, T2>, ctx: &mut Context<K, (T1, T2)>) {
+    async fn process_right(&mut self, record: &Record<K, T2>, ctx: &mut Context<K, Output>) {
         if let Some(watermark) = ctx.watermark() {
             if record.timestamp < watermark {
                 return;
             }
         };
-
-        let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;
         let mut key = record.key.clone().unwrap();
         let value = record.value.clone();
+        let mut right_state = ctx.state.get_key_time_multi_map('r').await;
+        let evict = right_state
+            .get_all_values_with_timestamps(&mut key)
+            .await
+            .is_none();
+        let key_to_insert = key.clone();
+        let value_to_insert = value.clone();
+        right_state
+            .insert(record.timestamp, key_to_insert, value_to_insert)
+            .await;
+
+        let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;
         let records = {
             let mut records = vec![];
             if let Some(left_rows) = left_state.get_all_values_with_timestamps(&mut key).await {
-                for (timestamp, left_value) in left_rows {
-                    records.push(Record {
-                        timestamp: record.timestamp.max(timestamp),
-                        key: Some(key.clone()),
-                        value: (left_value.clone(), value.clone()),
-                    });
+                for left in left_rows {
+                    if let Some((timestamp, value)) = self.processor.right_join(
+                        key.clone(),
+                        record.timestamp,
+                        value.clone(),
+                        Some(left),
+                        evict,
+                    ) {
+                        records.push(Record {
+                            timestamp,
+                            key: Some(key.clone()),
+                            value,
+                        });
+                    }
                 }
+            } else if let Some((timestamp, value)) =
+                self.processor
+                    .right_join(key.clone(), record.timestamp, value.clone(), None, evict)
+            {
+                records.push(Record {
+                    timestamp,
+                    key: Some(key.clone()),
+                    value,
+                });
             }
             records
         };
         for record in records {
             ctx.collect(record).await;
         }
-        let mut right_state = ctx.state.get_key_time_multi_map('r').await;
-        right_state.insert(record.timestamp, key, value).await;
     }
 
     async fn handle_watermark(
         &mut self,
         _watermark: std::time::SystemTime,
-        ctx: &mut Context<K, (T1, T2)>,
+        ctx: &mut Context<K, Output>,
     ) {
         let Some(watermark) = ctx.watermark() else {return};
         let mut left_state: KeyTimeMultiMap<K, T1, _> = ctx.state.get_key_time_multi_map('l').await;

--- a/arroyo-worker/src/operators/tumbling_aggregating_window.rs
+++ b/arroyo-worker/src/operators/tumbling_aggregating_window.rs
@@ -15,6 +15,7 @@ pub struct TumblingAggregatingWindowFunc<K: Key, T: Data, BinA: Data, OutT: Data
     state: TumblingWindowState,
     _t: PhantomData<K>,
 }
+
 #[derive(Debug)]
 enum TumblingWindowState {
     // We haven't received any data.

--- a/arroyo-worker/src/operators/updating_aggregate.rs
+++ b/arroyo-worker/src/operators/updating_aggregate.rs
@@ -1,0 +1,149 @@
+use std::marker::PhantomData;
+
+use crate::engine::{Context, StreamNode};
+use arroyo_macro::process_fn;
+use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableType, TableWriteBehavior};
+use arroyo_state::tables::KeyedState;
+use arroyo_types::*;
+use std::time::Duration;
+
+#[derive(StreamNode)]
+pub struct UpdatingAggregateOperator<K: Key, T: Data, BinA: Data, OutT: Data> {
+    expiration: Duration,
+    aggregator: fn(&BinA) -> OutT,
+    bin_merger: fn(&T, Option<&BinA>) -> Option<BinA>,
+    _t: PhantomData<K>,
+}
+
+enum StateOp<T: Data> {
+    Set(T),
+    Delete,
+    #[allow(dead_code)]
+    Update {
+        new: T,
+        old: T,
+    },
+}
+
+#[process_fn(in_k = K, in_t = T, out_k = K, out_t = UpdatingData<OutT>)]
+impl<K: Key, T: Data, BinA: Data, OutT: Data> UpdatingAggregateOperator<K, T, BinA, OutT> {
+    fn name(&self) -> String {
+        "KeyWindow".to_string()
+    }
+
+    pub fn new(
+        expiration: Duration,
+        // TODO: this can consume the bin, as we drop it right after.
+        aggregator: fn(&BinA) -> OutT,
+        bin_merger: fn(&T, Option<&BinA>) -> Option<BinA>,
+    ) -> Self {
+        UpdatingAggregateOperator {
+            expiration,
+            aggregator,
+            bin_merger,
+            _t: PhantomData,
+        }
+    }
+
+    fn tables(&self) -> Vec<TableDescriptor> {
+        vec![TableDescriptor {
+            name: "a".to_string(),
+            description: "window state".to_string(),
+            table_type: TableType::TimeKeyMap as i32,
+            delete_behavior: TableDeleteBehavior::NoReadsBeforeWatermark as i32,
+            write_behavior: TableWriteBehavior::NoWritesBeforeWatermark as i32,
+            retention_micros: self.expiration.as_micros() as u64,
+        }]
+    }
+
+    async fn process_element(
+        &mut self,
+        record: &Record<K, T>,
+        ctx: &mut Context<K, UpdatingData<OutT>>,
+    ) {
+        if let Some(watermark) = ctx.watermark() {
+            if record.timestamp < watermark {
+                return;
+            }
+        }
+        let mut aggregating_map: KeyedState<K, BinA, _> = ctx.state.get_key_state('a').await;
+        let mut mut_key = record.key.clone().unwrap();
+        let key = mut_key.clone();
+        let (new_value, state_op) = {
+            let bin_aggregate = aggregating_map.get(&mut mut_key);
+            match bin_aggregate {
+                Some(bin_aggregate) => {
+                    let old_aggregate = (self.aggregator)(bin_aggregate);
+                    let new_bin = (self.bin_merger)(&record.value, Some(bin_aggregate));
+                    match new_bin {
+                        Some(new_bin) => {
+                            let new_aggregate = (self.aggregator)(&new_bin);
+                            if new_aggregate != old_aggregate {
+                                (
+                                    Some(UpdatingData::Update {
+                                        old: old_aggregate,
+                                        new: new_aggregate,
+                                    }),
+                                    Some(StateOp::Update {
+                                        new: new_bin,
+                                        old: bin_aggregate.clone(),
+                                    }),
+                                )
+                            } else if new_bin != *bin_aggregate {
+                                (
+                                    None,
+                                    Some(StateOp::Update {
+                                        new: new_bin,
+                                        old: bin_aggregate.clone(),
+                                    }),
+                                )
+                            } else {
+                                (None, None)
+                            }
+                        }
+                        None => (
+                            Some(UpdatingData::Retract(old_aggregate)),
+                            Some(StateOp::Delete),
+                        ),
+                    }
+                }
+                None => {
+                    let new_bin = (self.bin_merger)(&record.value, None);
+                    match new_bin {
+                        Some(new_bin) => {
+                            let new_aggregate = (self.aggregator)(&new_bin);
+                            (
+                                Some(UpdatingData::Append(new_aggregate)),
+                                Some(StateOp::Set(new_bin)),
+                            )
+                        }
+                        None => (None, None),
+                    }
+                }
+            }
+        };
+        if let Some(state_op) = state_op {
+            match state_op {
+                StateOp::Set(new_bin) => {
+                    aggregating_map
+                        .insert(record.timestamp, mut_key, new_bin)
+                        .await;
+                }
+                StateOp::Delete => {
+                    aggregating_map.remove(mut_key).await;
+                }
+                StateOp::Update { new, old: _ } => {
+                    aggregating_map.insert(record.timestamp, mut_key, new).await;
+                }
+            }
+        }
+        if let Some(value) = new_value {
+            ctx.collect(Record {
+                timestamp: record.timestamp,
+                key: Some(key),
+                value,
+            })
+            .await;
+        }
+    }
+}


### PR DESCRIPTION
This adds updating queries to the SQL frontend. This allows Arroyo to read Debezium sources, write Debezium to sinks, and build new types of pipelines that intelligently compute how a record has changed, if it in fact has. This is rather large PR, so I'd recommend reviewing it in the following sections:

## UpdatingData
This is the central struct for handling updates inside the dataflow. The `map()` method lets us cleanly apply map functions, potentially eliminating the record entirely if the values are the same. Similarly, `filter()` applies a predicate to the update and determines if downstream requires an update. 

We also have DebeziumData, which wraps updates into the debezium format, similar to what Flink does when `format = 'debezium-json`. 

## New Operators
Handling Updates requires new operators:
### UpdatingAggregateOperator
This operator is for non-windowed aggregates. Every incoming record is aggregated into a single intermediate value according to the key. There are checks for if either the outgoing value or the internal state has changed, and work is only done when necessary. It supports both Updating and Append inputs, with the SQL layer providing different methods in each case. Currently SQL only supports aggregates that have compact intermediate forms (everything except count distinct). Because DataFusion currently unrolls single `count(distinct field)` computations into two non-distinct aggregates, this doesn't happen very often.

This is the only new operator that requires state. We reuse the KeyTimeMap backend, where the time is the record timestamp. Similar to flink, this functions as an expiration, with a default expiration of 24 hours. There is not currently any eviction of stale data within the running processor, although expired data will be compacted away and not restored from a checkpoint.

### KeyMapUpdatingOperator
This operator is necessary to recompute the key on an UpdatingData input. Because the key could be different between the old and new field, we may need to split a UpdatingData::Update into a UpdatingData::Retract and UpdatingData::Append and collect both of them.

### UpdatingData
This is only an addition to datastream::Operator, as it ends up being compiled to an OptionMapOperator, but it applies an optional function on T to UpdatingData<T> via the `map()` method mentioned above.

### JoinWithExpiration
This operator already supported inner joins with expirations. It is now extended to the four main join types, with everything except inner joins emitting an update stream. In particular, the first record on a side that was allowed to be null by the join type will now retract any previously emitted records.


## SQL
The majority of the implementation is within arroyo-sql, in particular the portions concerned with SqlOperator and PlanOperators.

#### Remove PlanType from PlanEdge
In order to convert a PlanNode to a datastream::Operator the node generally needed to have type information. Introducing updates increased this need, as the operators can be quite different depending on whether the node produces updating data. Having this duplicated on the edges and node of the PlanGraph only complicated things, so it was removed. When converting to the Program graph we just look at the source node's type.

#### PlanType::UpdatingData
Nodes can now have a return type that is updating data, with an inner PlanType giving more details. These will be converted to UpdatingData<T> types in the datastream:Program, and the compiler is, except for a few of the specific operators, unaware of Updatingdata.

#### Sources and Sinks
Sources and sinks can support updating data, currently through the "debezium_json" serialization mode. 


### Known Issues
#### Query LImitations
Updating tables only support a subset of queries. In particular, the following are not supported

* SQL Window functions (e.g. `row_number()`) can't have updating data as an input.
* Joins can't have updating data as inputs.
* Window aggregates can't have updating data as an input.
* Updating sources can't have virtual columns or override the watermark or timestamp.
* COUNT DISTINCT on updating inputs is not supported.

#### Out of order retractions
For any forward sequence of nodes a retraction should always occur after the record it is retracting. However, I think that there is a sequence of shuffles that could result in a retraction arriving at a downstream node.

#### State Performance
The state works but is not highly optimized. In particular there are two main performance inefficiencies:
1. There is no buffering of the intermediate aggregate representation. This means if you run `select count(*) from input` then there will be a state entry for every row. Because we only rely on expiration for compaction, recovering from this checkpoint will be slow.
2. Inefficient Max and Min implementations when the input is updating. The aggregation logic when your input is itself updating uses the memory representations from the sliding window aggregator work, with every row behaving as a time bucket. This is fine for most of the aggregates, as they are still fixed size, but max and min are backed by a BTree. Combined with the former point `SELECT max(bid.price) from input` will write increasingly large records with every incoming record.


Despite these limitations, I still think this is worth trying to merge so we can continue to iterate in this direction.