### PR TITLE
Show operator checkpoint sizes

### DIFF
--- a/arroyo-console/src/components/CheckpointDetails.tsx
+++ b/arroyo-console/src/components/CheckpointDetails.tsx
@@ -1,0 +1,65 @@
+import { Table, TableContainer, Tbody, Td, Th, Thead, Tr, Text } from '@chakra-ui/react';
+import {
+  CheckpointDetailsResp,
+  OperatorCheckpointDetail,
+  TaskCheckpointDetail,
+} from '../gen/api_pb';
+import React from 'react';
+import OperatorCheckpointTimeline from './OperatorCheckpointTimeline';
+import { dataFormat } from '../lib/util';
+
+export interface CheckpointDetailsProps {
+  checkpoint: CheckpointDetailsResp;
+  ops:
+    | { id: string; name: string; parallelism: number; checkpoint: OperatorCheckpointDetail }[]
+    | undefined;
+  scale: (x: number) => number;
+  w: number;
+}
+
+const bytes = (tasks: TaskCheckpointDetail[]) => {
+  return tasks.map(t => (t.bytes == null ? 0 : Number(t.bytes))).reduce((a, b) => a + b, 0);
+};
+
+const row = (operator: string, timeline: React.ReactElement, totalBytes: number) => {
+  return (
+    <Tr>
+      <Td>
+        <Text maxW={400} whiteSpace={'normal'}>
+          {operator}
+        </Text>
+      </Td>
+      <Td>{dataFormat(totalBytes)}</Td>
+      <Td>{timeline}</Td>
+    </Tr>
+  );
+};
+
+const CheckpointDetails: React.FC<CheckpointDetailsProps> = ({ checkpoint, ops, scale, w }) => {
+  const tableBody = (
+    <Tbody>
+      {ops?.map(op => {
+        const size = bytes(Object.values(op.checkpoint.tasks));
+        const timeline = <OperatorCheckpointTimeline op={op} scale={scale} w={w} />;
+        return row(op.name, timeline, size);
+      })}
+    </Tbody>
+  );
+
+  return (
+    <TableContainer paddingTop={10} paddingBottom={10}>
+      <Table size={'sm'} variant="striped">
+        <Thead>
+          <Tr>
+            <Th>Operator</Th>
+            <Th>Size</Th>
+            <Th>Timeline</Th>
+          </Tr>
+        </Thead>
+        {tableBody}
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default CheckpointDetails;

--- a/arroyo-console/src/components/Checkpoints.tsx
+++ b/arroyo-console/src/components/Checkpoints.tsx
@@ -15,9 +15,9 @@ import {
   UnorderedList,
 } from '@chakra-ui/react';
 import * as util from '../lib/util';
-import OperatorCheckpoint from './OperatorCheckpoint';
 import { useCheckpointDetails } from '../lib/data_fetching';
 import { ApiClient } from '../main';
+import CheckpointDetails from './CheckpointDetails';
 
 export interface CheckpointsProps {
   client: ApiClient;
@@ -78,49 +78,48 @@ const Checkpoints: React.FC<CheckpointsProps> = ({ client, job, checkpoints }) =
       .flatMap(op => Object.values(op.tasks).map(t => (t.bytes == null ? 0 : Number(t.bytes))))
       .reduce((a, b) => a + b, 0);
 
+    const checkpointStats = (
+      <StatGroup width={718} border="1px solid #666" borderRadius="5px" marginTop={5} padding={3}>
+        <Stat>
+          <StatLabel>Started</StatLabel>
+          <StatNumber>
+            {new Intl.DateTimeFormat('en-us', {
+              dateStyle: undefined,
+              timeStyle: 'medium',
+            }).format(new Date(Number(checkpoint.overview?.startTime) / 1000))}
+          </StatNumber>
+        </Stat>
+        <Stat marginLeft={10}>
+          <StatLabel>Finished</StatLabel>
+          <StatNumber>
+            {checkpoint.overview?.finishTime != null
+              ? new Intl.DateTimeFormat('en-us', {
+                  dateStyle: undefined,
+                  timeStyle: 'medium',
+                }).format(new Date(Number(checkpoint.overview?.finishTime) / 1000))
+              : '-'}
+          </StatNumber>
+        </Stat>
+        <Stat marginLeft={10}>
+          <StatLabel>Duration</StatLabel>
+          <StatNumber>{formatDurationHMS(end - start)}</StatNumber>
+        </Stat>
+        <Stat marginLeft={10}>
+          <StatLabel>Total Size</StatLabel>
+          <StatNumber> {util.dataFormat(checkpointBytes)} </StatNumber>
+        </Stat>
+      </StatGroup>
+    );
+
     details = (
-      <Box>
+      <Flex flexDirection={'column'} flexGrow={1}>
         <Heading size="md">
           Checkpoint {epoch}
           <Badge marginLeft={2}>{checkpoint.overview?.backend}</Badge>
         </Heading>
-        <StatGroup width={718} border="1px solid #666" borderRadius="5px" marginTop={5} padding={3}>
-          <Stat>
-            <StatLabel>Started</StatLabel>
-            <StatNumber>
-              {new Intl.DateTimeFormat('en-us', {
-                dateStyle: undefined,
-                timeStyle: 'medium',
-              }).format(new Date(Number(checkpoint.overview?.startTime) / 1000))}
-            </StatNumber>
-          </Stat>
-          <Stat marginLeft={10}>
-            <StatLabel>Finished</StatLabel>
-            <StatNumber>
-              {checkpoint.overview?.finishTime != null
-                ? new Intl.DateTimeFormat('en-us', {
-                    dateStyle: undefined,
-                    timeStyle: 'medium',
-                  }).format(new Date(Number(checkpoint.overview?.finishTime) / 1000))
-                : '-'}
-            </StatNumber>
-          </Stat>
-          <Stat marginLeft={10}>
-            <StatLabel>Duration</StatLabel>
-            <StatNumber>{formatDurationHMS(end - start)}</StatNumber>
-          </Stat>
-          <Stat marginLeft={10}>
-            <StatLabel>Size</StatLabel>
-            <StatNumber> {util.dataFormat(checkpointBytes)} </StatNumber>
-          </Stat>
-        </StatGroup>
-
-        <Box marginTop={5}>
-          {ops?.map(op => (
-            <OperatorCheckpoint key={op.id} op={op} scale={scale} w={w} />
-          ))}
-        </Box>
-      </Box>
+        {checkpointStats}
+        <CheckpointDetails checkpoint={checkpoint} ops={ops} scale={scale} w={w} />
+      </Flex>
     );
   }
 
@@ -143,7 +142,7 @@ const Checkpoints: React.FC<CheckpointsProps> = ({ client, job, checkpoints }) =
             })}
         </UnorderedList>
       </Box>
-      <Box>{details}</Box>
+      <Flex flexGrow={1}>{details}</Flex>
     </Flex>
   );
 };

--- a/arroyo-console/src/components/OperatorCheckpointTimeline.tsx
+++ b/arroyo-console/src/components/OperatorCheckpointTimeline.tsx
@@ -1,15 +1,19 @@
 import { OperatorCheckpointDetail, TaskCheckpointEventType } from '../gen/api_pb';
 import React, { ReactNode, useState } from 'react';
-import { Box, Flex, Text, theme } from '@chakra-ui/react';
+import { Box, Flex, theme } from '@chakra-ui/react';
 import * as util from '../lib/util';
 
-export interface OperatorCheckpointProps {
+export interface OperatorCheckpointTimelineProps {
   op: { id: string; name: string; parallelism: number; checkpoint?: OperatorCheckpointDetail };
   scale: (x: number) => number;
   w: number;
 }
 
-const OperatorCheckpoint: React.FC<OperatorCheckpointProps> = ({ op, scale, w }) => {
+const OperatorCheckpointTimeline: React.FC<OperatorCheckpointTimelineProps> = ({
+  op,
+  scale,
+  w,
+}) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   let now = new Date().getTime() * 1000;
@@ -54,16 +58,8 @@ const OperatorCheckpoint: React.FC<OperatorCheckpointProps> = ({ op, scale, w })
               let width = Math.max(scale(finishTime) - left, 1);
 
               inner = [
-                <Box
-                  h={1}
-                  className={className}
-                  position="relative"
-                  left={left}
-                  width={width}
-                ></Box>,
+                <Box h={1} className={className} position="relative" left={left} width={width} />,
               ];
-
-              //console.log(syncLeft, scale(now), alignmentLeft);
 
               inner.push(
                 <Box
@@ -98,38 +94,31 @@ const OperatorCheckpoint: React.FC<OperatorCheckpointProps> = ({ op, scale, w })
     );
   }
 
-  return (
-    <Flex
-      marginTop="10px"
-      textAlign="right"
-      className="operator-checkpoint"
-      onClick={() => setExpanded(!expanded)}
-    >
-      <Box width={200} marginRight="10px">
-        <Text
-          fontSize="sm"
-          textOverflow="ellipsis"
-          overflow="hidden"
-          whiteSpace="nowrap"
-          title={op.name}
-        >
-          {op.name}
-        </Text>
-      </Box>
-      <Box width={w + 8} padding={0} position="relative" backgroundColor="#333">
-        <Box
-          className={className}
-          title={util.durationFormat(finishTime - Number(op.checkpoint?.startTime))}
-          position="absolute"
-          margin={1}
-          height={3}
-          left={left}
-          width={width}
-        ></Box>
-        {tasks}
-      </Box>
-    </Flex>
+  const timeline = (
+    <>
+      <Flex
+        marginTop="10px"
+        textAlign="right"
+        className="operator-checkpoint"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Box width={w + 8} height={10} padding={0} position="relative" backgroundColor="#333">
+          <Box
+            className={className}
+            title={util.durationFormat(finishTime - Number(op.checkpoint?.startTime))}
+            position="absolute"
+            margin={1}
+            height={3}
+            left={left}
+            width={width}
+          ></Box>
+          {tasks}
+        </Box>
+      </Flex>
+    </>
   );
+
+  return <>{timeline}</>;
 };
 
-export default OperatorCheckpoint;
+export default OperatorCheckpointTimeline;

--- a/arroyo-console/src/routes/pipelines/JobDetail.tsx
+++ b/arroyo-console/src/routes/pipelines/JobDetail.tsx
@@ -143,7 +143,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
     );
 
     const outputsTab = (
-      <TabPanel>
+      <TabPanel w={'100%'}>
         {outputs.length == 0 ? (
           job?.jobGraph?.nodes.find(n => n.operator.includes('GrpcSink')) != null ? (
             <Button isLoading={subscribed} onClick={subscribe} width={150} size="sm">
@@ -165,7 +165,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
     );
 
     const queryTab = (
-      <TabPanel>
+      <TabPanel w={'100%'}>
         <Box>
           <CodeEditor query={job?.jobStatus?.definition!} readOnly={true} />
         </Box>
@@ -173,7 +173,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
     );
 
     const udfsTab = (
-      <TabPanel>
+      <TabPanel w={'100%'}>
         <Box>
           <CodeEditor
             query={(job?.jobStatus?.udfs || [{ definition: '' }])[0].definition}
@@ -185,22 +185,26 @@ export function JobDetail({ client }: { client: ApiClient }) {
     );
 
     inner = (
-      <Tabs h="100%">
-        <TabList>
-          <Tab>Operators</Tab>
-          <Tab>Outputs</Tab>
-          <Tab>Checkpoints</Tab>
-          <Tab>Query</Tab>
-          <Tab>UDFs</Tab>
-        </TabList>
-        <TabPanels h="100%">
-          {operatorsTab}
-          {outputsTab}
-          {checkpointsTab}
-          {queryTab}
-          {udfsTab}
-        </TabPanels>
-      </Tabs>
+      <Flex direction={'column'} minH={0}>
+        <Tabs display={'flex'} flexDirection={'column'} overflow={'scroll'}>
+          <div>
+            <TabList>
+              <Tab>Operators</Tab>
+              <Tab>Outputs</Tab>
+              <Tab>Checkpoints</Tab>
+              <Tab>Query</Tab>
+              <Tab>UDFs</Tab>
+            </TabList>
+          </div>
+          <TabPanels display={'flex'} flexDirection={'column'} flexGrow={1} overflowY={'scroll'}>
+            {operatorsTab}
+            {outputsTab}
+            {checkpointsTab}
+            {queryTab}
+            {udfsTab}
+          </TabPanels>
+        </Tabs>
+      </Flex>
     );
   }
 
@@ -238,7 +242,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
   }
 
   return (
-    <Box top={0} bottom={0} right={0} left={200} position="absolute" overflowY="hidden">
+    <Flex direction={'column'} height={'100vh'}>
       <Flex>
         <Box p={5}>
           <Text fontSize={20}>
@@ -255,6 +259,6 @@ export function JobDetail({ client }: { client: ApiClient }) {
       </Flex>
       {inner}
       {configModal}
-    </Box>
+    </Flex>
   );
 }

--- a/arroyo-console/src/routes/pipelines/JobGraph.tsx
+++ b/arroyo-console/src/routes/pipelines/JobGraph.tsx
@@ -99,7 +99,7 @@ export function PipelineGraph({
   });
 
   return (
-    <Box className="pipelineGraph">
+    <Box height={'70vh'} className="pipelineGraph">
       <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes}>
         <Background />
       </ReactFlow>


### PR DESCRIPTION
Add a table to the Checkpoints tab to display the operators with their sizes and timelines.

Also change some of the styling in the other tabs to make the sizes and scrolling work better.

---

<img width="1582" alt="image" src="https://github.com/ArroyoSystems/arroyo/assets/8881183/1bf7613d-af26-4899-ae39-8534d63abf70">
