### PR TITLE
Write eventsource and kafka source errors to db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,25 +651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arroyo-sql-testing"
-version = "0.2.0"
-dependencies = [
- "arroyo-sql",
- "arroyo-sql-macro",
- "arroyo-types",
- "arroyo-worker",
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "chrono",
- "hex",
- "petgraph",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "arroyo-state"
 version = "0.2.0"
 dependencies = [
@@ -713,6 +694,7 @@ dependencies = [
 name = "arroyo-worker"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "arroyo-macro",
  "arroyo-metrics",
  "arroyo-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "arroyo-server-common",
     "arroyo-sql",
     "arroyo-sql-macro",
-    "arroyo-sql-testing",
+    # "arroyo-sql-testing",
     "arroyo-state",
     "arroyo-types",
     "arroyo-worker",

--- a/arroyo-api/migrations/V7__add_job_log_messages.sql
+++ b/arroyo-api/migrations/V7__add_job_log_messages.sql
@@ -1,0 +1,12 @@
+create type log_level as ENUM ('info', 'warn', 'error');
+
+CREATE TABLE job_log_messages (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    job_id VARCHAR(8) REFERENCES job_configs(id) ON DELETE CASCADE,
+    operator_id TEXT,
+    task_index BIGINT,
+    log_level log_level DEFAULT 'info',
+    message TEXT NOT NULL,
+    details TEXT
+);

--- a/arroyo-controller/queries/controller_queries.sql
+++ b/arroyo-controller/queries/controller_queries.sql
@@ -73,3 +73,8 @@ FROM checkpoints
 WHERE job_id = :job_id AND state = 'ready'
 ORDER BY epoch DESC
 LIMIT 1;
+
+--! create_job_log_message
+INSERT INTO job_log_messages (job_id, operator_id, task_index, log_level, message, details)
+VALUES (:job_id, :operator_id, :task_index, :log_level, :message, :details)
+RETURNING id;

--- a/arroyo-rpc/proto/rpc.proto
+++ b/arroyo-rpc/proto/rpc.proto
@@ -154,6 +154,17 @@ message OutputData {
   bool done = 5;
 }
 
+message WorkerErrorReq {
+  string job_id = 1;
+  string operator_id = 2;
+  uint32 task_index = 3;
+  string message = 4;
+  string details = 5;
+}
+
+message WorkerErrorRes {
+}
+
 
 service ControllerGrpc {
   rpc RegisterNode(RegisterNodeReq) returns (RegisterNodeResp);
@@ -170,6 +181,7 @@ service ControllerGrpc {
   rpc WorkerFinished(WorkerFinishedReq) returns (WorkerFinishedResp);
 
   rpc SubscribeToOutput(GrpcOutputSubscription) returns (stream OutputData);
+  rpc WorkerError(WorkerErrorReq) returns (WorkerErrorRes);
 }
 
 message ParquetStoreData {

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -58,6 +58,12 @@ pub enum ControlResp {
         task_index: usize,
         error: String,
     },
+    Error {
+        operator_id: String,
+        task_index: usize,
+        message: String,
+        details: String,
+    },
 }
 
 pub struct FileAuthInterceptor {

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -53,6 +53,7 @@ rdkafka = { version = "0.28", features = ["cmake-build"] }
 rdkafka-sys = "=4.2.0"
 eventsource-client = "0.11.0"
 regex = "1.8.1"
+anyhow = "1.0.71"
 
 [dev-dependencies]
 test-case = "2.2"

--- a/arroyo-worker/src/operators/sources/eventsource.rs
+++ b/arroyo-worker/src/operators/sources/eventsource.rs
@@ -2,7 +2,7 @@ use crate::engine::Context;
 use crate::SourceFinishType;
 use arroyo_macro::{source_fn, StreamNode};
 use arroyo_rpc::grpc::{StopMode, TableDescriptor};
-use arroyo_rpc::ControlMessage;
+use arroyo_rpc::{ControlMessage, ControlResp};
 use arroyo_state::tables::GlobalKeyedState;
 use arroyo_types::{Data, Record};
 use bincode::{Decode, Encode};
@@ -157,6 +157,13 @@ where
                                 }
                             }
                             Some(Err(e)) => {
+                                ctx.control_tx.send(
+                                    ControlResp::Error {
+                                        operator_id: ctx.task_info.operator_id.clone(),
+                                        task_index: ctx.task_info.task_index.clone(),
+                                        message: "Error while reading from EventSource".to_string(),
+                                        details: format!("{:?}", e)}
+                                ).await.unwrap();
                                 panic!("Error while reading from EventSource: {:?}", e);
                             }
                             None => {

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990dfa1a9328504aa135820da1c95066537b69ad94c04881b785f64328e0fa6b"
+checksum = "218ca81dd088b102c0fd6687c72e73fad1ba93d2ef7b3cf9a1043b04b2c39dbf"
 dependencies = [
  "ahash 0.8.3",
  "arrow-arith",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b2e52de0ab54173f9b08232b7184c26af82ee7ab4ac77c83396633c90199fa"
+checksum = "d49309fa2299ec34a709cfc9f487c41ecaead96d1ab70e21857466346bbbd690"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10849b60c17dbabb334be1f4ef7550701aa58082b71335ce1ed586601b2f423"
+checksum = "e7a27466d897d99654357a6d95dc0a26931d9e4306e60c14fc31a894edb86579"
 dependencies = [
  "ahash 0.8.3",
  "arrow-buffer",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0746ae991b186be39933147117f8339eb1c4bbbea1c8ad37e7bf5851a1a06ba"
+checksum = "9405b78106a9d767c7b97c78a70ee1b23ee51a74f5188a821a716d9a85d1af2b"
 dependencies = [
  "half",
  "num",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88897802515d7b193e38b27ddd9d9e43923d410a9e46307582d756959ee9595"
+checksum = "be0ec5a79a87783dc828b7ff8f89f62880b3f553bc5f5b932a82f4a1035024b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8220d9741fc37961262710ceebd8451a5b393de57c464f0267ffdda1775c0a"
+checksum = "350d8e55c3b2d602a0a04389bcc1da40167657143a9922a7103190603e7b7692"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f937efa1aaad9dc86f6a0e382c2fa736a4943e2090c946138079bdf060cef"
+checksum = "c6f710d98964d2c069b8baf566130045e79e11baa105623f038a6c942f805681"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b75296ff01833f602552dff26a423fc213db8e5049b540ca4a00b1c957e41c"
+checksum = "9c99787cb8fabc187285da9e7182d22f2b80ecfac61ca0a42c4299e9eecdf903"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e501d3de4d612c90677594896ca6c0fa075665a7ff980dc4189bb531c17e19f6"
+checksum = "91c95a58ce63f60d80d7a3a1222d65df0bc060b71d31353c34a8118c2a6eae7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -235,14 +235,15 @@ dependencies = [
  "indexmap",
  "lexical-core",
  "num",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d2671eb3793f9410230ac3efb0e6d36307be8a2dac5fad58ac9abde8e9f01e"
+checksum = "4141e6488610cc144e841da3de5f5371488f3cf5bc6bc7b3e752c64e7639c31b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -255,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc11fa039338cebbf4e29cf709c8ac1d6a65c7540063d4a25f991ab255ca85c8"
+checksum = "940191a3c636c111c41e816325b0941484bf904c46de72cd9553acd1afd24d33"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",
@@ -270,15 +271,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04f17f7b86ded0b5baf98fe6123391c4343e031acc3ccc5fa604cc180bff220"
+checksum = "18c41d058b2895a12f46dfafc306ee3529ad9660406be0ab8a7967d5e27c417e"
 
 [[package]]
 name = "arrow-select"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163e35de698098ff5f5f672ada9dc1f82533f10407c7a11e2cd09f3bcf31d18a"
+checksum = "9fcbdda2772b7e712e77444f3a71f4ee517095aceb993b35de71de41c70d9b4f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -289,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdfbed1b10209f0dc68e6aa4c43dc76079af65880965c7c3b73f641f23d4aba"
+checksum = "7081c34f4b534ad320a03db79d58e38972041bb7c65686b98bbcc2f9a67a9cee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -299,7 +300,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -356,6 +357,7 @@ dependencies = [
  "tracing-appender",
  "tracing-logfmt",
  "tracing-subscriber",
+ "vergen",
 ]
 
 [[package]]
@@ -2514,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "36.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321a15f8332645759f29875b07f8233d16ed8ec1b3582223de81625a9f8506b7"
+checksum = "b0a1e6fa27f09ebddba280f5966ef435f3ac4d74cfc3ffe370fd3fd59c2e004d"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",
@@ -4224,6 +4226,17 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time 0.3.20",
+]
 
 [[package]]
 name = "version_check"


### PR DESCRIPTION
Create a job_log_messages table in the database. When an eventsource or
kafka source encounters an error, call the WorkerError rpc method on the
controller, which logs the error to the database.
