### PR TITLE
Add Errors tab to job details page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arroyo-sql-testing"
+version = "0.2.0"
+dependencies = [
+ "arroyo-sql",
+ "arroyo-sql-macro",
+ "arroyo-types",
+ "arroyo-worker",
+ "bincode 2.0.0-rc.3",
+ "bincode_derive",
+ "chrono",
+ "hex",
+ "petgraph",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "arroyo-state"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "arroyo-server-common",
     "arroyo-sql",
     "arroyo-sql-macro",
-    # "arroyo-sql-testing",
+    "arroyo-sql-testing",
     "arroyo-state",
     "arroyo-types",
     "arroyo-worker",

--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -180,3 +180,15 @@ DELETE FROM pipelines WHERE pipelines.id = (
     INNER JOIN pipeline_definitions as pd ON job_configs.pipeline_definition = pd.id
     INNER JOIN pipelines ON pipelines.id = pd.pipeline_id
     WHERE job_configs.id = :job_id AND job_configs.organization_id = :organization_id);
+
+--! get_operator_errors
+SELECT jlm.job_id, jlm.operator_id, jlm.task_index, jlm.created_at, jlm.log_level, jlm.message, jlm.details
+FROM job_log_messages jlm
+INNER JOIN (
+    SELECT operator_id, task_index, MAX(created_at) AS max_created_at
+    FROM job_log_messages
+    WHERE job_id = :job_id
+    GROUP BY operator_id, task_index
+) jlm_max ON jlm.operator_id = jlm_max.operator_id AND jlm.task_index = jlm_max.task_index AND jlm.created_at = jlm_max.max_created_at
+WHERE jlm.job_id = :job_id
+  AND jlm.log_level = 'error';

--- a/arroyo-api/src/job_log.rs
+++ b/arroyo-api/src/job_log.rs
@@ -1,0 +1,38 @@
+use arroyo_rpc::grpc::api::{JobLogLevel, JobLogMessage};
+use cornucopia_async::GenericClient;
+use tonic::Status;
+
+use crate::queries::api_queries;
+use crate::types::public::LogLevel;
+use crate::{log_and_map, to_micros};
+
+pub(crate) async fn get_operator_errors(
+    job_id: &str,
+    client: &impl GenericClient,
+) -> Result<Vec<JobLogMessage>, Status> {
+    let messages = api_queries::get_operator_errors()
+        .bind(client, &job_id)
+        .all()
+        .await
+        .map_err(log_and_map)?;
+
+    Ok(messages
+        .into_iter()
+        .map(|message| {
+            let level = match message.log_level {
+                LogLevel::info => JobLogLevel::Info,
+                LogLevel::warn => JobLogLevel::Warn,
+                LogLevel::error => JobLogLevel::Error,
+            };
+
+            JobLogMessage {
+                operator_id: Some(message.operator_id),
+                task_index: Some(message.task_index),
+                created_at: to_micros(message.created_at),
+                level: i32::from(level),
+                message: message.message,
+                details: message.details,
+            }
+        })
+        .collect())
+}

--- a/arroyo-api/src/metrics.rs
+++ b/arroyo-api/src/metrics.rs
@@ -71,7 +71,9 @@ pub(crate) async fn get_metrics(
                 "{}{{job_id=\"{}\",run_id=\"{}\"}}",
                 TX_QUEUE_REM, job_id, run_id
             );
-            format!("({} - {}) / {}", tx_queue_size, tx_queue_rem, tx_queue_size)
+            // add 1 to each value to account for uninitialized values (which report 0); this can happen when a task
+            // never reads any data
+            format!("1 - (({} + 1) / ({} + 1))", tx_queue_rem, tx_queue_size)
         }
 
         fn get_query(&self, job_id: &str, run_id: u64, rate: &str) -> String {

--- a/arroyo-console/src/components/CheckpointDetails.tsx
+++ b/arroyo-console/src/components/CheckpointDetails.tsx
@@ -39,7 +39,7 @@ const CheckpointDetails: React.FC<CheckpointDetailsProps> = ({ checkpoint, ops, 
   const tableBody = (
     <Tbody>
       {ops?.map(op => {
-        const size = bytes(Object.values(op.checkpoint.tasks));
+        const size = bytes(Object.values(op.checkpoint?.tasks || []));
         const timeline = <OperatorCheckpointTimeline op={op} scale={scale} w={w} />;
         return row(op.name, timeline, size);
       })}

--- a/arroyo-console/src/components/Loading.tsx
+++ b/arroyo-console/src/components/Loading.tsx
@@ -7,8 +7,8 @@ export interface LoadingProps {
 
 const Loading: React.FC<LoadingProps> = ({ size = 'xl' }) => {
   return (
-    <Flex border={'1px solid blue'} justify={'center'} height={'75%'}>
-      <Spinner speed="0.65s" emptyColor="gray.200" color="blue.500" size={size} />
+    <Flex border={'blue.900'} borderWidth={'1px'} justify={'center'} height={'75%'} p={8}>
+      <Spinner speed="0.65s" emptyColor="gray.200" color="blue.900" size={size} />
     </Flex>
   );
 };

--- a/arroyo-console/src/components/Loading.tsx
+++ b/arroyo-console/src/components/Loading.tsx
@@ -1,4 +1,4 @@
-import { Spinner, VStack } from '@chakra-ui/react';
+import { Flex, Spinner } from '@chakra-ui/react';
 import React from 'react';
 
 export interface LoadingProps {
@@ -7,9 +7,9 @@ export interface LoadingProps {
 
 const Loading: React.FC<LoadingProps> = ({ size = 'xl' }) => {
   return (
-    <VStack justify={'center'} height={'75%'} spacing={30}>
+    <Flex border={'1px solid blue'} justify={'center'} height={'75%'}>
       <Spinner speed="0.65s" emptyColor="gray.200" color="blue.500" size={size} />
-    </VStack>
+    </Flex>
   );
 };
 

--- a/arroyo-console/src/components/OperatorErrors.tsx
+++ b/arroyo-console/src/components/OperatorErrors.tsx
@@ -1,0 +1,60 @@
+import { useOperatorErrors } from '../lib/data_fetching';
+import { ApiClient } from '../main';
+import Loading from './Loading';
+import { Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
+import React from 'react';
+import { formatDate } from '../lib/util';
+
+export interface OperatorErrorsProps {
+  client: ApiClient;
+  jobId?: string;
+}
+
+const OperatorErrors: React.FC<OperatorErrorsProps> = ({ client, jobId }) => {
+  const { operatorErrors } = useOperatorErrors(client, jobId);
+
+  if (!operatorErrors) {
+    return <Loading />;
+  }
+
+  const tableBody = (
+    <Tbody>
+      {operatorErrors.messages.map(m => {
+        return (
+          <Tr>
+            <Td>{formatDate(m.createdAt)}</Td>
+            <Td>{m.operatorId}</Td>
+            <Td>{m.taskIndex?.toString()}</Td>
+            <Td>{m.message}</Td>
+            <Td>{m.details}</Td>
+          </Tr>
+        );
+      })}
+    </Tbody>
+  );
+
+  const table = (
+    <TableContainer width={'100%'} padding={5}>
+      <Table variant="striped">
+        <Thead>
+          <Tr>
+            <Th>Time</Th>
+            <Th>Operator</Th>
+            <Th>Task Index</Th>
+            <Th>Message</Th>
+            <Th>Details</Th>
+          </Tr>
+        </Thead>
+        {tableBody}
+      </Table>
+    </TableContainer>
+  );
+
+  if (operatorErrors && operatorErrors.messages.length == 0) {
+    return <>No errors to display</>;
+  }
+
+  return <>{table}</>;
+};
+
+export default OperatorErrors;

--- a/arroyo-console/src/components/OperatorErrors.tsx
+++ b/arroyo-console/src/components/OperatorErrors.tsx
@@ -1,18 +1,14 @@
-import { useOperatorErrors } from '../lib/data_fetching';
-import { ApiClient } from '../main';
 import Loading from './Loading';
 import { Table, TableContainer, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import React from 'react';
 import { formatDate } from '../lib/util';
+import { OperatorErrorsRes } from '../gen/api_pb';
 
 export interface OperatorErrorsProps {
-  client: ApiClient;
-  jobId?: string;
+  operatorErrors?: OperatorErrorsRes;
 }
 
-const OperatorErrors: React.FC<OperatorErrorsProps> = ({ client, jobId }) => {
-  const { operatorErrors } = useOperatorErrors(client, jobId);
-
+const OperatorErrors: React.FC<OperatorErrorsProps> = ({ operatorErrors }) => {
   if (!operatorErrors) {
     return <Loading />;
   }
@@ -21,7 +17,7 @@ const OperatorErrors: React.FC<OperatorErrorsProps> = ({ client, jobId }) => {
     <Tbody>
       {operatorErrors.messages.map(m => {
         return (
-          <Tr>
+          <Tr key={String(m.createdAt)}>
             <Td>{formatDate(m.createdAt)}</Td>
             <Td>{m.operatorId}</Td>
             <Td>{m.taskIndex?.toString()}</Td>
@@ -34,8 +30,8 @@ const OperatorErrors: React.FC<OperatorErrorsProps> = ({ client, jobId }) => {
   );
 
   const table = (
-    <TableContainer width={'100%'} padding={5}>
-      <Table variant="striped">
+    <TableContainer padding={5}>
+      <Table variant="striped" w={'100%'}>
         <Thead>
           <Tr>
             <Th>Time</Th>

--- a/arroyo-console/src/gen/api_connectweb.ts
+++ b/arroyo-console/src/gen/api_connectweb.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 /* @ts-nocheck */
 
-import {CheckpointDetailsReq, CheckpointDetailsResp, ConfluentSchemaReq, ConfluentSchemaResp, CreateConnectionReq, CreateConnectionResp, CreateJobReq, CreateJobResp, CreatePipelineReq, CreatePipelineResp, CreateSinkReq, CreateSinkResp, CreateSourceReq, CreateSourceResp, DeleteConnectionReq, DeleteConnectionResp, DeleteJobReq, DeleteJobResp, DeleteSinkReq, DeleteSinkResp, DeleteSourceReq, DeleteSourceResp, GetConnectionsReq, GetConnectionsResp, GetJobsReq, GetJobsResp, GetPipelineReq, GetSinksReq, GetSinksResp, GetSourcesReq, GetSourcesResp, GrpcOutputSubscription, JobCheckpointsReq, JobCheckpointsResp, JobDetailsReq, JobDetailsResp, JobMetricsReq, JobMetricsResp, OutputData, PipelineDef, PipelineGraphReq, PipelineGraphResp, SourceMetadataResp, TestSchemaResp, TestSourceMessage, UpdateJobReq, UpdateJobResp} from "./api_pb.js";
+import {CheckpointDetailsReq, CheckpointDetailsResp, ConfluentSchemaReq, ConfluentSchemaResp, CreateConnectionReq, CreateConnectionResp, CreateJobReq, CreateJobResp, CreatePipelineReq, CreatePipelineResp, CreateSinkReq, CreateSinkResp, CreateSourceReq, CreateSourceResp, DeleteConnectionReq, DeleteConnectionResp, DeleteJobReq, DeleteJobResp, DeleteSinkReq, DeleteSinkResp, DeleteSourceReq, DeleteSourceResp, GetConnectionsReq, GetConnectionsResp, GetJobsReq, GetJobsResp, GetPipelineReq, GetSinksReq, GetSinksResp, GetSourcesReq, GetSourcesResp, GrpcOutputSubscription, JobCheckpointsReq, JobCheckpointsResp, JobDetailsReq, JobDetailsResp, JobMetricsReq, JobMetricsResp, OperatorErrorsReq, OperatorErrorsRes, OutputData, PipelineDef, PipelineGraphReq, PipelineGraphResp, SourceMetadataResp, TestSchemaResp, TestSourceMessage, UpdateJobReq, UpdateJobResp} from "./api_pb.js";
 import {MethodKind} from "@bufbuild/protobuf";
 
 /**
@@ -235,6 +235,15 @@ export const ApiGrpc = {
       name: "GetCheckpointDetail",
       I: CheckpointDetailsReq,
       O: CheckpointDetailsResp,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc arroyo_api.ApiGrpc.GetOperatorErrors
+     */
+    getOperatorErrors: {
+      name: "GetOperatorErrors",
+      I: OperatorErrorsReq,
+      O: OperatorErrorsRes,
       kind: MethodKind.Unary,
     },
     /**

--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -277,6 +277,32 @@ proto3.util.setEnumType(EdgeType, "arroyo_api.EdgeType", [
 ]);
 
 /**
+ * @generated from enum arroyo_api.JobLogLevel
+ */
+export enum JobLogLevel {
+  /**
+   * @generated from enum value: INFO = 0;
+   */
+  INFO = 0,
+
+  /**
+   * @generated from enum value: WARN = 1;
+   */
+  WARN = 1,
+
+  /**
+   * @generated from enum value: ERROR = 2;
+   */
+  ERROR = 2,
+}
+// Retrieve enum metadata with: proto3.getEnumType(JobLogLevel)
+proto3.util.setEnumType(JobLogLevel, "arroyo_api.JobLogLevel", [
+  { no: 0, name: "INFO" },
+  { no: 1, name: "WARN" },
+  { no: 2, name: "ERROR" },
+]);
+
+/**
  * @generated from enum arroyo_api.TaskCheckpointEventType
  */
 export enum TaskCheckpointEventType {
@@ -1464,6 +1490,12 @@ export class Operator extends Message<Operator> {
      */
     value: JoinWithExpiration;
     case: "joinWithExpiration";
+  } | {
+    /**
+     * @generated from field: arroyo_api.ExpressionWatermark expression_watermark = 23;
+     */
+    value: ExpressionWatermark;
+    case: "expressionWatermark";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<Operator>) {
@@ -1495,6 +1527,7 @@ export class Operator extends Message<Operator> {
     { no: 19, name: "tumbling_top_n", kind: "message", T: TumblingTopN, oneof: "operator" },
     { no: 20, name: "sliding_aggregating_top_n", kind: "message", T: SlidingAggregatingTopN, oneof: "operator" },
     { no: 21, name: "join_with_expiration", kind: "message", T: JoinWithExpiration, oneof: "operator" },
+    { no: 23, name: "expression_watermark", kind: "message", T: ExpressionWatermark, oneof: "operator" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Operator {
@@ -1715,7 +1748,7 @@ export class EventSourceSource extends Message<EventSourceSource> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime: typeof proto3 = proto3;
+  static readonly runtime = proto3;
   static readonly typeName = "arroyo_api.EventSourceSource";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -2169,6 +2202,49 @@ export class PeriodicWatermark extends Message<PeriodicWatermark> {
 
   static equals(a: PeriodicWatermark | PlainMessage<PeriodicWatermark> | undefined, b: PeriodicWatermark | PlainMessage<PeriodicWatermark> | undefined): boolean {
     return proto3.util.equals(PeriodicWatermark, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.ExpressionWatermark
+ */
+export class ExpressionWatermark extends Message<ExpressionWatermark> {
+  /**
+   * @generated from field: uint64 period_micros = 1;
+   */
+  periodMicros = protoInt64.zero;
+
+  /**
+   * @generated from field: string expression = 2;
+   */
+  expression = "";
+
+  constructor(data?: PartialMessage<ExpressionWatermark>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.ExpressionWatermark";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "period_micros", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 2, name: "expression", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ExpressionWatermark {
+    return new ExpressionWatermark().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ExpressionWatermark {
+    return new ExpressionWatermark().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ExpressionWatermark {
+    return new ExpressionWatermark().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ExpressionWatermark | PlainMessage<ExpressionWatermark> | undefined, b: ExpressionWatermark | PlainMessage<ExpressionWatermark> | undefined): boolean {
+    return proto3.util.equals(ExpressionWatermark, a, b);
   }
 }
 
@@ -3278,6 +3354,147 @@ export class JobGraph extends Message<JobGraph> {
 
   static equals(a: JobGraph | PlainMessage<JobGraph> | undefined, b: JobGraph | PlainMessage<JobGraph> | undefined): boolean {
     return proto3.util.equals(JobGraph, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.OperatorErrorsReq
+ */
+export class OperatorErrorsReq extends Message<OperatorErrorsReq> {
+  /**
+   * @generated from field: string job_id = 1;
+   */
+  jobId = "";
+
+  constructor(data?: PartialMessage<OperatorErrorsReq>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.OperatorErrorsReq";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "job_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OperatorErrorsReq {
+    return new OperatorErrorsReq().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OperatorErrorsReq {
+    return new OperatorErrorsReq().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OperatorErrorsReq {
+    return new OperatorErrorsReq().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OperatorErrorsReq | PlainMessage<OperatorErrorsReq> | undefined, b: OperatorErrorsReq | PlainMessage<OperatorErrorsReq> | undefined): boolean {
+    return proto3.util.equals(OperatorErrorsReq, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.JobLogMessage
+ */
+export class JobLogMessage extends Message<JobLogMessage> {
+  /**
+   * @generated from field: uint64 created_at = 1;
+   */
+  createdAt = protoInt64.zero;
+
+  /**
+   * @generated from field: optional string operator_id = 2;
+   */
+  operatorId?: string;
+
+  /**
+   * @generated from field: optional int64 task_index = 3;
+   */
+  taskIndex?: bigint;
+
+  /**
+   * @generated from field: arroyo_api.JobLogLevel level = 4;
+   */
+  level = JobLogLevel.INFO;
+
+  /**
+   * @generated from field: string message = 5;
+   */
+  message = "";
+
+  /**
+   * @generated from field: string details = 6;
+   */
+  details = "";
+
+  constructor(data?: PartialMessage<JobLogMessage>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.JobLogMessage";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "created_at", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 2, name: "operator_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 3, name: "task_index", kind: "scalar", T: 3 /* ScalarType.INT64 */, opt: true },
+    { no: 4, name: "level", kind: "enum", T: proto3.getEnumType(JobLogLevel) },
+    { no: 5, name: "message", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 6, name: "details", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): JobLogMessage {
+    return new JobLogMessage().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): JobLogMessage {
+    return new JobLogMessage().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): JobLogMessage {
+    return new JobLogMessage().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: JobLogMessage | PlainMessage<JobLogMessage> | undefined, b: JobLogMessage | PlainMessage<JobLogMessage> | undefined): boolean {
+    return proto3.util.equals(JobLogMessage, a, b);
+  }
+}
+
+/**
+ * @generated from message arroyo_api.OperatorErrorsRes
+ */
+export class OperatorErrorsRes extends Message<OperatorErrorsRes> {
+  /**
+   * @generated from field: repeated arroyo_api.JobLogMessage messages = 1;
+   */
+  messages: JobLogMessage[] = [];
+
+  constructor(data?: PartialMessage<OperatorErrorsRes>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime = proto3;
+  static readonly typeName = "arroyo_api.OperatorErrorsRes";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "messages", kind: "message", T: JobLogMessage, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OperatorErrorsRes {
+    return new OperatorErrorsRes().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OperatorErrorsRes {
+    return new OperatorErrorsRes().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OperatorErrorsRes {
+    return new OperatorErrorsRes().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OperatorErrorsRes | PlainMessage<OperatorErrorsRes> | undefined, b: OperatorErrorsRes | PlainMessage<OperatorErrorsRes> | undefined): boolean {
+    return proto3.util.equals(OperatorErrorsRes, a, b);
   }
 }
 
@@ -5019,7 +5236,7 @@ export class EventSourceSourceConfig extends Message<EventSourceSourceConfig> {
     proto3.util.initPartial(data, this);
   }
 
-  static readonly runtime: typeof proto3 = proto3;
+  static readonly runtime = proto3;
   static readonly typeName = "arroyo_api.EventSourceSourceConfig";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "connection", kind: "scalar", T: 9 /* ScalarType.STRING */ },

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -3,6 +3,7 @@ import {
   JobCheckpointsReq,
   JobDetailsReq,
   JobMetricsReq,
+  OperatorErrorsReq,
   StopType,
 } from '../gen/api_pb';
 import { ApiClient } from '../main';
@@ -25,6 +26,10 @@ const jobCheckpointsKey = (jobId?: string) => {
 
 const checkpointDetailsKey = (jobId?: string, epoch?: number) => {
   return jobId ? { key: 'CheckpointDetails', jobId, epoch } : null;
+};
+
+const operatorErrorsKey = (jobId?: string) => {
+  return jobId ? { key: 'JobEvents', jobId } : null;
 };
 
 // JobDetailsReq
@@ -147,5 +152,31 @@ export const useCheckpointDetails = (client: ApiClient, jobId?: string, epoch?: 
 
   return {
     checkpoint: data,
+  };
+};
+
+// OperatorErrorsReq
+
+const OperatorErrorsFetcher = (client: ApiClient) => {
+  return async (params: { key: string; jobId: string }) => {
+    return await (
+      await (
+        await client
+      )()
+    ).getOperatorErrors(
+      new OperatorErrorsReq({
+        jobId: params.jobId,
+      })
+    );
+  };
+};
+
+export const useOperatorErrors = (client: ApiClient, jobId?: string) => {
+  const { data } = useSWR(operatorErrorsKey(jobId), OperatorErrorsFetcher(client), {
+    refreshInterval: 5000,
+  });
+
+  return {
+    operatorErrors: data,
   };
 };

--- a/arroyo-console/src/lib/util.ts
+++ b/arroyo-console/src/lib/util.ts
@@ -140,7 +140,7 @@ export function getOperatorBackpressure(
 }
 
 export function formatDate(timestamp: bigint) {
-  const date = new Date(Number(timestamp));
+  const date = new Date(Number(timestamp / BigInt(1000)));
   return new Intl.DateTimeFormat('en', {
     dateStyle: 'short',
     timeStyle: 'short',

--- a/arroyo-console/src/lib/util.ts
+++ b/arroyo-console/src/lib/util.ts
@@ -138,3 +138,11 @@ export function getOperatorBackpressure(
 
   return recent.map(m => m.value).reduce((max, curr) => Math.max(max, curr));
 }
+
+export function formatDate(timestamp: bigint) {
+  const date = new Date(Number(timestamp));
+  return new Intl.DateTimeFormat('en', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date);
+}

--- a/arroyo-console/src/routes/pipelines/JobDetail.tsx
+++ b/arroyo-console/src/routes/pipelines/JobDetail.tsx
@@ -37,6 +37,7 @@ import JobNotFound from '../../components/JobNotFound';
 import Checkpoints from '../../components/Checkpoints';
 import { QuestionOutlineIcon, WarningIcon } from '@chakra-ui/icons';
 import Loading from '../../components/Loading';
+import OperatorErrors from '../../components/OperatorErrors';
 
 export function JobDetail({ client }: { client: ApiClient }) {
   const [activeOperator, setActiveOperator] = useState<string | undefined>(undefined);
@@ -184,6 +185,12 @@ export function JobDetail({ client }: { client: ApiClient }) {
       </TabPanel>
     );
 
+    const errorsTab = (
+      <TabPanel>
+        <OperatorErrors client={client} jobId={job.jobStatus.jobId} />
+      </TabPanel>
+    );
+
     inner = (
       <Flex direction={'column'} minH={0}>
         <Tabs display={'flex'} flexDirection={'column'} overflow={'scroll'}>
@@ -194,6 +201,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
               <Tab>Checkpoints</Tab>
               <Tab>Query</Tab>
               <Tab>UDFs</Tab>
+              <Tab>Errors</Tab>
             </TabList>
           </div>
           <TabPanels display={'flex'} flexDirection={'column'} flexGrow={1} overflowY={'scroll'}>
@@ -202,6 +210,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
             {checkpointsTab}
             {queryTab}
             {udfsTab}
+            {errorsTab}
           </TabPanels>
         </Tabs>
       </Flex>

--- a/arroyo-console/src/routes/pipelines/JobGraph.tsx
+++ b/arroyo-console/src/routes/pipelines/JobGraph.tsx
@@ -99,8 +99,13 @@ export function PipelineGraph({
   });
 
   return (
-    <Box height={'70vh'} className="pipelineGraph">
-      <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes}>
+    <Box className="pipelineGraph">
+      <ReactFlow
+        proOptions={{ hideAttribution: true }}
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+      >
         <Background />
       </ReactFlow>
     </Box>

--- a/arroyo-console/src/routes/pipelines/JobsIndex.tsx
+++ b/arroyo-console/src/routes/pipelines/JobsIndex.tsx
@@ -34,6 +34,7 @@ import { DeleteJobReq, GetJobsReq, JobStatus } from '../../gen/api_pb';
 import React, { useEffect, useRef, useState } from 'react';
 import { FiCopy, FiXCircle } from 'react-icons/fi';
 import { ApiClient } from '../../main';
+import { formatDate } from '../../lib/util';
 
 interface ColumnDef {
   name: string;
@@ -84,10 +85,7 @@ const columns: Array<ColumnDef> = [
       if (s.startTime == null) {
         return '-';
       } else {
-        return new Intl.DateTimeFormat('en', {
-          dateStyle: 'short',
-          timeStyle: 'short',
-        }).format(new Date(Number(s.startTime) / 1000));
+        return formatDate(s.startTime);
       }
     },
   },

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -442,6 +442,29 @@ message JobGraph {
   repeated JobEdge edges = 2;
 }
 
+enum JobLogLevel {
+  INFO = 0;
+  WARN = 1;
+  ERROR = 2;
+}
+
+message OperatorErrorsReq {
+    string job_id = 1;
+}
+
+message JobLogMessage {
+  uint64 created_at = 1;
+  optional string operator_id = 2;
+  optional int64 task_index = 3;
+  JobLogLevel level = 4;
+  string message = 5;
+  string details = 6;
+}
+
+message OperatorErrorsRes {
+  repeated JobLogMessage messages = 1;
+}
+
 // checkpoints
 
 enum TaskCheckpointEventType {
@@ -858,6 +881,7 @@ service ApiGrpc {
   rpc GetJobDetails(JobDetailsReq) returns (JobDetailsResp);
   rpc GetCheckpoints(JobCheckpointsReq) returns (JobCheckpointsResp);
   rpc GetCheckpointDetail(CheckpointDetailsReq) returns (CheckpointDetailsResp);
+  rpc GetOperatorErrors(OperatorErrorsReq) returns (OperatorErrorsRes);
 
   rpc GetJobMetrics(JobMetricsReq) returns (JobMetricsResp);
 

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -576,8 +576,6 @@ impl PlanNode {
                         sort_key_type,
                         max_elements: *max_elements,
                     });
-                println!("sliding logical plan operator {:#?}", self);
-                println!("sliding physical plan operator {:#?}", operator);
                 operator
             }
             PlanOperator::TumblingTopN {

--- a/arroyo-worker/src/operators/sources/kafka/mod.rs
+++ b/arroyo-worker/src/operators/sources/kafka/mod.rs
@@ -124,9 +124,7 @@ where
         let has_state = !state.is_empty();
 
         let state: HashMap<i32, KafkaState> = state.iter().map(|s| (s.partition, **s)).collect();
-        let metadata = consumer
-            .fetch_metadata(Some(&self.topic), Duration::from_secs(30))
-            .expect("failed to fetch kafka metadata");
+        let metadata = consumer.fetch_metadata(Some(&self.topic), Duration::from_secs(30))?;
 
         info!("Fetched metadata for topic {}", self.topic);
 


### PR DESCRIPTION
Add a tab that displays the latest error for each operator/subtask pair,
if one exists. The tab uses the OperatorErrors component, which calls
the GetOperatorErrors rpc method, which queries the job_log_messages
table to get the errors.

---

<img width="1582" alt="image" src="https://github.com/ArroyoSystems/arroyo/assets/8881183/5ba7a0b2-32ec-4f14-8a24-134aea98dbaf">
