### PR TITLE
cut 0.3.0 release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,8 +46,7 @@ jobs:
       # Get the repository's code
       - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -75,6 +74,8 @@ jobs:
             type=sha
           flavor: |
             prefix=${{ matrix.prom_arch }}-
+      - name: Set env
+        run: echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -85,6 +86,7 @@ jobs:
             MOLD_ARCH=${{ matrix.mold_arch }}
             PROTO_ARCH=${{ matrix.proto_arch }}
             PROM_ARCH=${{ matrix.prom_arch }}
+            GIT_SHA=${{ env.GIT_SHA }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.arroyo-docker.outputs.tags }}
           labels: ${{ steps.arroyo-docker.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-compiler-service"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-rpc",
  "arroyo-server-common",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-controller"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow-schema",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-datastream"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arroyo-macro",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-metrics"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "prometheus",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-rpc",
  "arroyo-server-common",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-rpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "bincode 2.0.0-rc.3",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-server-common"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "axum",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-sql"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-sql-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-controller",
  "arroyo-datastream",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-state"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.21.0",
  "bincode 2.0.0-rc.3",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-worker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arroyo-macro",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "integ"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arroyo-rpc",

--- a/arroyo-api/Cargo.toml
+++ b/arroyo-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-api"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [features]

--- a/arroyo-compiler-service/Cargo.toml
+++ b/arroyo-compiler-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-compiler-service"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-controller/Cargo.toml
+++ b/arroyo-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-controller"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [features]

--- a/arroyo-datastream/Cargo.toml
+++ b/arroyo-datastream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-datastream"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 

--- a/arroyo-macro/Cargo.toml
+++ b/arroyo-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-macro"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/arroyo-metrics/Cargo.toml
+++ b/arroyo-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-metrics"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-node/Cargo.toml
+++ b/arroyo-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-node"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-rpc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/arroyo-server-common/Cargo.toml
+++ b/arroyo-server-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-server-common"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-sql-macro/Cargo.toml
+++ b/arroyo-sql-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql-macro"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/arroyo-sql-testing/Cargo.toml
+++ b/arroyo-sql-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql-testing"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 

--- a/arroyo-sql/Cargo.toml
+++ b/arroyo-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 

--- a/arroyo-state/Cargo.toml
+++ b/arroyo-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-state"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/arroyo-types/Cargo.toml
+++ b/arroyo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-types"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-worker"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [features]

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arrayvec"
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-macro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-metrics"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "prometheus",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-rpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "bincode 2.0.0-rc.3",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-server-common"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "axum",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-state"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.21.0",
  "bincode 2.0.0-rc.3",
@@ -401,8 +401,9 @@ dependencies = [
 
 [[package]]
 name = "arroyo-worker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "anyhow",
  "arroyo-macro",
  "arroyo-metrics",
  "arroyo-rpc",

--- a/build_dir/wasm-fns/Cargo.lock
+++ b/build_dir/wasm-fns/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "arroyo-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bincode",

--- a/docker/cluster/compiler/Dockerfile
+++ b/docker/cluster/compiler/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /opt/arroyo
 
 ARG PROTO_ARCH
 ARG MOLD_ARCH
+ARG GIT_SHA
 
 RUN apt-get update && \
     apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl cmake clang wget && \
@@ -46,6 +47,8 @@ COPY integ src/integ
 COPY Cargo.toml src/Cargo.toml
 COPY Cargo.lock src/Cargo.lock
 
+# set git hash
+ENV VERGEN_GIT_SHA=$GIT_SHA
 # build the compiler service
 RUN cd src && cargo build --release -p arroyo-compiler-service && mv target/release/arroyo-compiler-service /usr/bin
 

--- a/docker/cluster/services/Dockerfile
+++ b/docker/cluster/services/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1-bookworm AS builder
 WORKDIR /app
 ARG PROTO_ARCH
+ARG GIT_SHA
 
 RUN apt-get update && \
     apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl \
@@ -38,6 +39,8 @@ COPY docker/refinery.toml refinery.toml
 
 COPY integ integ
 
+# set git hash
+ENV VERGEN_GIT_SHA=$GIT_SHA
 RUN service postgresql start && \
     sudo -u postgres psql -c "CREATE USER arroyo WITH PASSWORD 'arroyo' SUPERUSER;" && \
     sudo -u postgres createdb arroyo && \

--- a/docker/cluster/worker/Dockerfile
+++ b/docker/cluster/worker/Dockerfile
@@ -1,7 +1,12 @@
 FROM rust:1-slim-bookworm as builder
+ARG GIT_SHA
+
 WORKDIR /build_dir
 
 COPY docker/cluster/worker/copy_artifacts .
+
+# set git sha
+ENV VERGEN_GIT_SHA=$GIT_SHA
 RUN cargo build --release
 
 FROM debian:bookworm-slim as runner

--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /opt/arroyo/src
 ARG MOLD_ARCH
 ARG PROTO_ARCH
 ARG PROM_ARCH
+ARG GIT_SHA
 
 RUN apt-get update
 RUN apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl \
@@ -77,6 +78,9 @@ RUN service postgresql start && \
     sudo -u postgres psql -c "CREATE USER arroyo WITH PASSWORD 'arroyo' SUPERUSER;" && \
     sudo -u postgres createdb arroyo && \
     refinery migrate -c refinery.toml -p arroyo-api/migrations
+
+# set git hash
+ENV VERGEN_GIT_SHA=$GIT_SHA
 
 # Build Arroyo
 RUN service postgresql start && \

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integ"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/k8s/arroyo/Chart.yaml
+++ b/k8s/arroyo/Chart.yaml
@@ -3,8 +3,8 @@ name: arroyo
 description: Helm chart for the Arroyo stream processing engine
 
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 
 keywords:
   - stream-processing

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -60,6 +60,8 @@ spec:
               fieldPath: metadata.namespace
         - name: K8S_WORKER_NAME
           value: "{{ include "arroyo.fullname" . }}"
+        - name: K8S_IMAGE
+          value: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
         - name: K8S_WORKER_LABELS
           value: {{ include "arroyo.labels" . | quote }}
         - name: K8S_WORKER_ANNOTATIONS

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -15,7 +15,7 @@ api:
   image:
     repository: ghcr.io/arroyosystems/arroyo-services
     pullPolicy: IfNotPresent
-    tag: "amd64"
+    tag: "0.3.0"
 
 controller:
   resources:
@@ -26,7 +26,7 @@ controller:
   image:
     repository: ghcr.io/arroyosystems/arroyo-services
     pullPolicy: IfNotPresent
-    tag: "amd64"
+    tag: "0.3.0"
 
 compiler:
   replicas: 1
@@ -38,7 +38,7 @@ compiler:
   image:
     repository: ghcr.io/arroyosystems/arroyo-compiler
     pullPolicy: IfNotPresent
-    tag: "amd64"
+    tag: "0.3.0"
 
 worker:
   resources:
@@ -50,7 +50,7 @@ worker:
   image:
     repository: ghcr.io/arroyosystems/arroyo-worker
     pullPolicy: IfNotPresent
-    tag: "amd64"
+    tag: "0.3.0"
 
 postgresql:
   # set to true to deploy a postgres instance in-cluster


### PR DESCRIPTION
This includes all the changes necessary for us to release 0.3.0. This includes inserting git_sha into the docker containers, bumping versions to 0.3.0 and the necessary changes to the docker.yaml workflow.