### PR TITLE
Improve single image postgres reliability, and migrate on every run

### DIFF
--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -69,8 +69,6 @@ COPY arroyo-console arroyo-console
 COPY integ integ
 COPY docker/refinery.toml refinery.toml
 
-COPY .git .git
-
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 
@@ -99,6 +97,7 @@ COPY docker/build_base pipeline/
 RUN cd pipeline && cargo build --release && cargo build --release
 RUN cd pipeline/wasm-fns && wasm-pack build
 COPY docker/single/supervisord.conf /opt/arroyo/src/docker/single/supervisord.conf
+COPY docker/single/entrypoint.sh /entrypoint.sh
 EXPOSE 8000 8001 9000 9190 9191
 RUN mkdir -p /tmp/arroyo/build
-CMD ["/usr/bin/supervisord", "-c", "/opt/arroyo/src/docker/single/supervisord.conf"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/single/entrypoint.sh
+++ b/docker/single/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Start Postgres
+
+echo "Starting Postgres"
+sudo -u postgres /usr/lib/postgresql/14/bin/postgres -c config_file=/etc/postgresql/14/main/postgresql.conf \
+    > /var/log/postgres.log 2>&1 &
+
+# Wait for postgres to become available
+
+echo "Waiting for Postgres to become available"
+until /usr/lib/postgresql/14/bin/pg_isready -q -h localhost -p 5432 -U postgres; do
+    sleep 0.2
+    echo "."
+done
+
+echo "Postgres is ready"
+
+# Run the migrations
+
+echo "Running migrations"
+
+sudo -u postgres /usr/lib/postgresql/14/bin/dropdb arroyo
+sudo -u postgres /usr/lib/postgresql/14/bin/createdb arroyo
+refinery migrate -c /opt/arroyo/src/refinery.toml -p /opt/arroyo/src/arroyo-api/migrations
+
+# start the services
+
+echo "Starting Arroyo services"
+
+exec /usr/bin/supervisord -n -c /opt/arroyo/src/docker/single/supervisord.conf

--- a/docker/single/supervisord.conf
+++ b/docker/single/supervisord.conf
@@ -1,14 +1,6 @@
 [supervisord]
 nodaemon=true
 
-[program:postgres]
-command=/usr/lib/postgresql/14/bin/postgres -c config_file=/etc/postgresql/14/main/postgresql.conf
-user=postgres
-priority=1
-startsecs=10
-autostart=true
-autorestart=true
-
 [program:prometheus]
 command=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
 autostart=true
@@ -29,8 +21,7 @@ stdout_logfile_maxbytes=0
 environment=ASSET_DIR="/opt/arroyo/src/arroyo-console/dist"
 
 [program:controller]
-# wait until postgres has hopefully started
-command=bash -c "sleep 10; /usr/bin/arroyo-controller"
+command=/usr/bin/arroyo-controller
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/controller.err.log


### PR DESCRIPTION
This updates the arroyo-single docker image to start postgres before the other services, and runs a fresh migration on startup instead of baking it into the image.