### PR TITLE
Improve state machine robustness

### DIFF
--- a/arroyo-controller/src/schedulers/kubernetes.rs
+++ b/arroyo-controller/src/schedulers/kubernetes.rs
@@ -70,7 +70,7 @@ impl KubernetesScheduler {
                         [
                             ("cpu".to_string(), serde_json::from_str("\"400m\"").unwrap()),
                             (
-                                "mem".to_string(),
+                                "memory".to_string(),
                                 serde_json::from_str("\"200Mi\"").unwrap(),
                             ),
                         ]

--- a/arroyo-controller/src/states/checkpoint_stopping.rs
+++ b/arroyo-controller/src/states/checkpoint_stopping.rs
@@ -2,7 +2,10 @@ use arroyo_rpc::grpc;
 
 use crate::{states::StateError, JobMessage};
 
-use super::{stopping::Stopping, Context, State, Stopped, Transition};
+use super::{
+    stopping::{StopBehavior, Stopping},
+    Context, State, Stopped, Transition,
+};
 
 #[derive(Debug)]
 pub struct CheckpointStopping {}
@@ -54,7 +57,7 @@ impl State for CheckpointStopping {
                             return Ok(Transition::next(
                                 *self,
                                 Stopping {
-                                    stop_mode: grpc::StopMode::Immediate,
+                                    stop_mode: StopBehavior::StopJob(grpc::StopMode::Immediate),
                                 },
                             ));
                         }

--- a/arroyo-controller/src/states/rescaling.rs
+++ b/arroyo-controller/src/states/rescaling.rs
@@ -1,8 +1,6 @@
-use arroyo_rpc::grpc;
+use crate::{states::stop_if_desired_non_running, JobMessage};
 
-use crate::JobMessage;
-
-use super::{scheduling::Scheduling, stopping::Stopping, Context, State, StateError, Transition};
+use super::{scheduling::Scheduling, Context, State, StateError, Transition};
 
 #[derive(Debug)]
 pub struct Rescaling {}
@@ -49,22 +47,7 @@ impl State for Rescaling {
                     }
                 }
                 JobMessage::ConfigUpdate(c) => {
-                    match c.stop_mode {
-                        crate::types::public::StopMode::immediate => {
-                            return Ok(Transition::next(
-                                *self,
-                                Stopping {
-                                    stop_mode: grpc::StopMode::Immediate,
-                                },
-                            ));
-                        }
-                        crate::types::public::StopMode::force => {
-                            todo!("implement force stop mode");
-                        }
-                        _ => {
-                            // do nothing
-                        }
-                    }
+                    stop_if_desired_non_running!(self, &c);
                 }
                 _ => {
                     // ignore other messages

--- a/arroyo-controller/src/states/stopping.rs
+++ b/arroyo-controller/src/states/stopping.rs
@@ -3,9 +3,15 @@ use arroyo_rpc::grpc::StopMode;
 
 use super::{Context, State, Stopped, Transition};
 
+#[derive(Copy, Clone, Debug)]
+pub enum StopBehavior {
+    StopJob(StopMode),
+    StopWorkers,
+}
+
 #[derive(Debug)]
 pub struct Stopping {
-    pub stop_mode: StopMode,
+    pub stop_mode: StopBehavior,
 }
 
 #[async_trait::async_trait]
@@ -15,24 +21,31 @@ impl State for Stopping {
     }
 
     async fn next(mut self: Box<Self>, ctx: &mut Context) -> Result<Transition, StateError> {
-        if let Err(e) = ctx
-            .job_controller
-            .as_mut()
-            .unwrap()
-            .stop_job(self.stop_mode)
-            .await
-        {
-            return Err(ctx.retryable(self, "failed while stopping job", e, 10));
-        }
+        match (ctx.job_controller.as_mut(), self.stop_mode) {
+            (Some(job_controller), StopBehavior::StopJob(stop_mode)) => {
+                if let Err(e) = job_controller.stop_job(stop_mode).await {
+                    return Err(ctx.retryable(self, "failed while stopping job", e, 10));
+                }
 
-        if let Err(e) = ctx
-            .job_controller
-            .as_mut()
-            .unwrap()
-            .wait_for_finish(ctx.rx)
-            .await
-        {
-            return Err(ctx.retryable(self, "failed while waiting for job to stop", e, 10));
+                if let Err(e) = ctx
+                    .job_controller
+                    .as_mut()
+                    .unwrap()
+                    .wait_for_finish(ctx.rx)
+                    .await
+                {
+                    return Err(ctx.retryable(self, "failed while waiting for job to stop", e, 10));
+                }
+            }
+            (_, StopBehavior::StopWorkers) | (None, _) => {
+                if let Err(e) = ctx
+                    .scheduler
+                    .stop_workers(&ctx.config.id, Some(ctx.status.run_id), true)
+                    .await
+                {
+                    return Err(ctx.retryable(self, "failed while stopping workers", e, 20));
+                }
+            }
         }
 
         Ok(Transition::next(*self, Stopped {}))


### PR DESCRIPTION
This PR improves the robustness of the controller state machine in a few ways:

* Removes a potential panic in the process scheduler, when the pipeline binaries can't be found (now, we will attempt to recompile)
* Adds support for stopping the pipeline in more states (compiling, scheduling, and rescaling)
