### PR TITLE
Restore operator detail border

### DIFF
--- a/arroyo-console/src/components/OperatorDetail.tsx
+++ b/arroyo-console/src/components/OperatorDetail.tsx
@@ -70,7 +70,7 @@ const OperatorDetail: React.FC<OperatorDetailProps> = ({ operator_id, graph, met
     }
 
     return (
-      <Box className="operatorDetail" marginTop={10} padding="10px">
+      <Box className="operatorDetail" marginTop={10} padding="10px" border="1px solid #333">
         <HStack fontWeight="semibold">
           <Box>operator</Box>
           <Spacer />


### PR DESCRIPTION
I accidentally removed the border in commit 64e7f37.

---

<img width="496" alt="image" src="https://github.com/ArroyoSystems/arroyo/assets/8881183/d8f758e9-a991-44fb-9dec-7dbbfeaaf746">
