### PR TITLE
build Docker image for master branch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,7 @@ name: Docker Build
 on:
   push:
     branches:
+      - master
       - '*docker*'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*' # Semver matching pattern with optional suffix
@@ -73,6 +74,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
           flavor: |
+            latest=false
             prefix=${{ matrix.prom_arch }}-
       - name: Set env
         run: echo "GIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -129,3 +131,12 @@ jobs:
           docker manifest annotate ${IMAGE}:${TAG} ${IMAGE}:arm64-${TAG} --arch arm64
           docker manifest annotate ${IMAGE}:${TAG} ${IMAGE}:amd64-${TAG} --arch amd64
           docker manifest push     ${IMAGE}:${TAG}
+      - name: Create and push Docker latest manifest
+        if: ${{is_default_branch}}
+        run: |
+          TAG=${{ steps.arroyo-docker.outputs.version }}
+          IMAGE=ghcr.io/arroyosystems/arroyo-${{ matrix.image_type }}
+          docker manifest create   ${IMAGE}:latest ${IMAGE}:arm64-${TAG} ${IMAGE}:amd64-${TAG}
+          docker manifest annotate ${IMAGE}:latest ${IMAGE}:arm64-${TAG} --arch arm64
+          docker manifest annotate ${IMAGE}:latest ${IMAGE}:amd64-${TAG} --arch amd64
+          docker manifest push     ${IMAGE}:latest


### PR DESCRIPTION
The reason is that the end users can use the latest image from the latest master branch code.