### PR TITLE
use DateTime<UTC> serde for SQL types.

### DIFF
--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -376,6 +376,20 @@ impl StructField {
     fn def(&self) -> TokenStream {
         let name: Ident = self.field_ident();
         let type_string = self.get_type();
+        // special case time fields
+        if let TypeDef::DataType(DataType::Timestamp(_, _), nullable) = self.data_type {
+            if nullable {
+                return quote!(
+                #[serde(default)]
+                #[serde(deserialize_with = "arroyo_worker::deserialize_rfc3339_datetime_opt")]
+                pub #name: #type_string
+                );
+            } else {
+                return quote!(
+                #[serde(deserialize_with = "arroyo_worker::deserialize_rfc3339_datetime")]
+                pub #name: #type_string);
+            }
+        }
         quote!(pub #name: #type_string)
     }
 

--- a/arroyo-worker/src/lib.rs
+++ b/arroyo-worker/src/lib.rs
@@ -86,8 +86,8 @@ pub fn deserialize_rfc3339_datetime_opt<'de, D>(f: D) -> Result<Option<SystemTim
 where
     D: Deserializer<'de>,
 {
-    let raw: chrono::DateTime<Utc> = DateTime::deserialize(f)?;
-    Ok(Some(from_nanos(raw.timestamp_nanos() as u128)))
+    let raw = Option::<DateTime<Utc>>::deserialize(f)?;
+    Ok(raw.map(|raw| from_nanos(raw.timestamp_nanos() as u128)))
 }
 
 pub static TIMER_TABLE: char = '[';


### PR DESCRIPTION
This also modifies the Option<SystemTime> serde to correctly deserialize when the value `null`.