### PR TITLE
Create REST api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,8 @@ dependencies = [
  "tower-http 0.4.0",
  "tracing",
  "typify",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -1125,6 +1127,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -2262,6 +2265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2281,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2773,6 +2796,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -5183,6 +5231,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73e721f488c353141288f223b599b4ae9303ecf3e62923f40a492f0634a4dc3"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22ce362f5561923889196595504317a4372b84210e6e335da529a65ea5452b5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
+dependencies = [
+ "sha2 0.10.6",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5632,6 +5715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,6 +5766,15 @@ checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -6789,6 +6892,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utoipa"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ae74ef183fae36d650f063ae7bde1cacbe1cd7e72b617cbe1e985551878b98"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea8ac818da7e746a63285594cce8a96f5e00ee31994e655bd827569cb8b137b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062bba5a3568e126ac72049a63254f4cb1da2eb713db0c1ab2a4c76be191db8c"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7500,6 +7643,18 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
 
 [[package]]
 name = "zstd"

--- a/arroyo-api/Cargo.toml
+++ b/arroyo-api/Cargo.toml
@@ -35,7 +35,9 @@ petgraph = {version = "0.6", features = ["serde-1"]}
 
 http = "0.2"
 tower-http = {version = "0.4", features = ["trace", "fs", "cors"]}
-axum = "0.6.12"
+axum = {version = "0.6.12", features = ["headers"]}
+utoipa = "3"
+utoipa-swagger-ui = { version = "3", features = ["axum"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/arroyo-api/src/cloud.rs
+++ b/arroyo-api/src/cloud.rs
@@ -1,4 +1,7 @@
+use crate::rest::ErrorResp;
 use crate::{AuthData, OrgMetadata};
+use axum::headers::authorization::{Authorization, Bearer};
+use axum::TypedHeader;
 use cornucopia_async::GenericClient;
 use tonic::{Request, Status};
 
@@ -23,4 +26,24 @@ pub(crate) async fn authenticate<T>(
             },
         },
     ))
+}
+
+pub(crate) async fn authenticate_rest(
+    _client: impl GenericClient,
+    _bearer_auth: Option<TypedHeader<Authorization<Bearer>>>,
+) -> Result<AuthData, ErrorResp> {
+    Ok(AuthData {
+        user_id: "user".to_string(),
+        organization_id: "org".to_string(),
+        role: "admin".to_string(),
+        org_metadata: OrgMetadata {
+            can_create_programs: true,
+            max_nexmark_qps: f64::MAX,
+            max_impulse_qps: f64::MAX,
+            max_parallelism: u32::MAX,
+            max_operators: u32::MAX,
+            max_running_jobs: u32::MAX,
+            kafka_qps: u32::MAX,
+        },
+    })
 }

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -1,0 +1,102 @@
+use arroyo_server_common::log_event;
+use axum::extract::State;
+use axum::headers::authorization::{Authorization, Bearer};
+use axum::response::{IntoResponse, Response};
+use axum::{http::StatusCode, routing::post, Json, Router, TypedHeader};
+use deadpool_postgres::{Object, Pool};
+use serde_json::json;
+use tracing::error;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+use crate::connections::{
+    ConnectionTypes, HttpConnection, KafkaAuthConfig, KafkaConnection, PostConnections, SaslAuth,
+};
+use crate::{cloud, connections, AuthData};
+
+type BearerAuth = Option<TypedHeader<Authorization<Bearer>>>;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(title = "Arroyo REST API", version = "1.0.0"),
+    paths(create_connection),
+    components(schemas(
+        PostConnections,
+        ConnectionTypes,
+        KafkaConnection,
+        KafkaAuthConfig,
+        SaslAuth,
+        HttpConnection
+    )),
+    tags(
+        (name = "connection", description = "Connections management API")
+    )
+)]
+struct ApiDoc;
+
+#[derive(Clone)]
+struct AppState {
+    pool: Pool,
+}
+
+pub struct ErrorResp {
+    pub(crate) status_code: StatusCode,
+    pub(crate) message: String,
+}
+
+pub fn log_and_map_rest<E>(err: E) -> ErrorResp
+where
+    E: core::fmt::Debug,
+{
+    error!("Error while handling: {:?}", err);
+    log_event("api_error", json!({ "error": format!("{:?}", err) }));
+    ErrorResp {
+        status_code: StatusCode::INTERNAL_SERVER_ERROR,
+        message: "Something went wrong".to_string(),
+    }
+}
+
+impl IntoResponse for ErrorResp {
+    fn into_response(self) -> Response {
+        let body = Json(json!({
+            "error": self.message,
+        }));
+        (self.status_code, body).into_response()
+    }
+}
+
+async fn client(pool: &Pool) -> Result<Object, ErrorResp> {
+    pool.get().await.map_err(log_and_map_rest)
+}
+
+async fn authenticate(pool: &Pool, bearer_auth: BearerAuth) -> Result<AuthData, ErrorResp> {
+    let client = client(pool).await?;
+    cloud::authenticate_rest(client, bearer_auth).await
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/connections",
+    tag = "connection",
+    request_body = PostConnections,
+    responses(
+        (status = 200, description = "Connection created successfully", body = PostConnections),
+    ),
+)]
+async fn create_connection(
+    State(state): State<AppState>,
+    bearer_auth: BearerAuth,
+    Json(payload): Json<PostConnections>,
+) -> Result<(), ErrorResp> {
+    let auth_data = authenticate(&state.pool, bearer_auth).await?;
+    let client = client(&state.pool).await?;
+    let connection = payload.clone().into();
+    connections::create_connection(connection, auth_data, client).await
+}
+
+pub(crate) fn create_rest_app(pool: Pool) -> Router {
+    Router::new()
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .route("/v1/connections", post(create_connection))
+        .with_state(AppState { pool })
+}


### PR DESCRIPTION
Expose a REST api on port 8003 and implement the POST /v1/connections endpoint. This uses the utoipa library to generate the openapi spec and expose a swagger UI at /swagger-ui.

---

Before merging this I still need to update the console to use the new API. This will also involve adding tooling to generate Typescript types from the OpenAPI schema, and making the `CreateConnection` component's form dynamic based on the schema.