### PR TITLE
sql: implement to_timestampXX methods.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
 name = "arroyo-types"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "base64 0.21.2",
  "bincode 2.0.0-rc.3",
  "serde",

--- a/arroyo-sql-testing/src/lib.rs
+++ b/arroyo-sql-testing/src/lib.rs
@@ -1187,4 +1187,41 @@ mod tests {
         },
         None
     );
+
+    // to_timestamp methods
+    single_test_codegen!(
+        "to_timestamp",
+        "to_timestamp(1685659545809000000)",
+        arroyo_sql::TestStruct {
+            ..Default::default()
+        },
+        arroyo_types::from_nanos(1685659545809000000)
+    );
+
+    single_test_codegen!(
+        "to_timestamp_millis",
+        "to_timestamp_millis(1685659545809)",
+        arroyo_sql::TestStruct {
+            ..Default::default()
+        },
+        arroyo_types::from_millis(1685659545809)
+    );
+
+    single_test_codegen!(
+        "to_timestamp_micros",
+        "to_timestamp_micros(1685659545809000)",
+        arroyo_sql::TestStruct {
+            ..Default::default()
+        },
+        arroyo_types::from_micros(1685659545809000)
+    );
+
+    single_test_codegen!(
+        "to_timestamp_seconds",
+        "to_timestamp_seconds(168565954)",
+        arroyo_sql::TestStruct {
+            ..Default::default()
+        },
+        arroyo_types::from_millis(168565954000)
+    );
 }

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -441,11 +441,23 @@ impl<'a> ExpressionContext<'a> {
                         bail!("data structure function {:?} not implemented", fun)
                     }
 
-                    BuiltinScalarFunction::ToTimestamp
-                    | BuiltinScalarFunction::ToTimestampMillis
-                    | BuiltinScalarFunction::ToTimestampMicros
-                    | BuiltinScalarFunction::ToTimestampSeconds
-                    | BuiltinScalarFunction::DateBin
+                    BuiltinScalarFunction::ToTimestamp => CastExpression::new(
+                        Box::new(arg_expressions.remove(0)),
+                        &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    ),
+                    BuiltinScalarFunction::ToTimestampMillis => CastExpression::new(
+                        Box::new(arg_expressions.remove(0)),
+                        &DataType::Timestamp(TimeUnit::Millisecond, None),
+                    ),
+                    BuiltinScalarFunction::ToTimestampMicros => CastExpression::new(
+                        Box::new(arg_expressions.remove(0)),
+                        &DataType::Timestamp(TimeUnit::Microsecond, None),
+                    ),
+                    BuiltinScalarFunction::ToTimestampSeconds => CastExpression::new(
+                        Box::new(arg_expressions.remove(0)),
+                        &DataType::Timestamp(TimeUnit::Second, None),
+                    ),
+                    BuiltinScalarFunction::DateBin
                     | BuiltinScalarFunction::CurrentDate
                     | BuiltinScalarFunction::FromUnixtime
                     | BuiltinScalarFunction::Now
@@ -1168,6 +1180,8 @@ impl CastExpression {
         // handle timestamp casts
         } else if Self::is_date(input_data_type) && Self::is_date(output_data_type) {
             true
+        } else if *input_data_type == DataType::Int64 && Self::is_date(output_data_type) {
+            true
         } else {
             false
         }
@@ -1221,6 +1235,22 @@ impl CastExpression {
                 std::time::SystemTime::UNIX_EPOCH
                 + std::time::Duration::from_micros(datetime.with_timezone(&chrono::Utc).timestamp_micros() as u64)
             })
+        } else if *input_type == DataType::Int64 && Self::is_date(output_type) {
+            match output_type {
+                DataType::Timestamp(time_unit, None) => {
+                    let from_func: Ident = match time_unit {
+                        TimeUnit::Second => parse_quote!(from_secs),
+                        TimeUnit::Millisecond => parse_quote!(from_millis),
+                        TimeUnit::Microsecond => parse_quote!(from_micros),
+                        TimeUnit::Nanosecond => parse_quote!(from_nanos),
+                    };
+                    parse_quote!({
+                        std::time::SystemTime::UNIX_EPOCH
+                        + std::time::Duration::#from_func(#sub_expr as u64)
+                    })
+                }
+                _ => unreachable!(),
+            }
         } else {
             unreachable!("invalid cast from {:?} to {:?}", input_type, output_type)
         }

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -309,10 +309,18 @@ impl TypeDef {
                 val
             ))
             .unwrap(),
-            ScalarValue::TimestampSecond(_, _) => todo!(),
-            ScalarValue::TimestampMillisecond(_, _) => todo!(),
-            ScalarValue::TimestampMicrosecond(_, _) => todo!(),
-            ScalarValue::TimestampNanosecond(_, _) => todo!(),
+            ScalarValue::TimestampSecond(Some(secs), _) => {
+                parse_quote!(std::time::UNIX_EPOCH + std::time::Duration::from_secs(#secs as u64))
+            }
+            ScalarValue::TimestampMillisecond(Some(millis), _) => {
+                parse_quote!(std::time::UNIX_EPOCH + std::time::Duration::from_millis(#millis as u64))
+            }
+            ScalarValue::TimestampMicrosecond(Some(micros), _) => {
+                parse_quote!(std::time::UNIX_EPOCH + std::time::Duration::from_micros(#micros as u64))
+            }
+            ScalarValue::TimestampNanosecond(Some(nanos), _) => {
+                parse_quote!(std::time::UNIX_EPOCH + std::time::Duration::from_nanos(#nanos as u64))
+            }
             ScalarValue::IntervalYearMonth(_) => todo!(),
             ScalarValue::IntervalDayTime(Some(val)) => {
                 let (days, ms) = IntervalDayTimeType::to_parts(*val);

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -88,6 +88,9 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayvec"
@@ -393,6 +396,7 @@ dependencies = [
 name = "arroyo-types"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "base64 0.21.0",
  "bincode 2.0.0-rc.3",
  "serde",


### PR DESCRIPTION
These are converted to casts, relying on the timestamp's TimeUnit to determine which method to call.