### PR TITLE
Add public ids to all tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "bincode 2.0.0-rc.3",
+ "nanoid",
  "prost",
  "serde",
  "tokio",
@@ -3833,6 +3834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "clap 3.2.25",
+ "rand",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
  "rand",
 ]
 

--- a/arroyo-api/migrations/V9__add_pub_ids.sql
+++ b/arroyo-api/migrations/V9__add_pub_ids.sql
@@ -1,0 +1,35 @@
+ALTER TABLE api_keys
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE connections
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE schemas
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE pipelines
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE pipeline_definitions
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE job_configs
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE checkpoints
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE job_statuses
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE cluster_info
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE job_log_messages
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE connection_tables
+ADD COLUMN pub_id VARCHAR UNIQUE;
+
+ALTER TABLE connection_table_pipelines
+ADD COLUMN pub_id VARCHAR UNIQUE;

--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -6,8 +6,8 @@ WHERE api_key = :api_key;
 
 ----------- connections ----------------
 --! create_connection
-INSERT INTO connections (organization_id, created_by, name, type, config)
-VALUES (:organization_id, :created_by, :name, :type, :config)
+INSERT INTO connections (pub_id, organization_id, created_by, name, type, config)
+VALUES (:pub_id, :organization_id, :created_by, :name, :type, :config)
 RETURNING id;
 
 --! get_connections : DbConnection()
@@ -47,15 +47,15 @@ WHERE organization_id = :organization_id AND name = :name;
 ----------- schemas --------------------
 
 --! create_schema
-INSERT INTO schemas (organization_id, created_by, name, kafka_schema_registry, type, config)
-VALUES (:organization_id, :created_by, :name, :kafka_schema_registry, :type, :config) RETURNING id;
+INSERT INTO schemas (pub_id, organization_id, created_by, name, kafka_schema_registry, type, config)
+VALUES (:pub_id, :organization_id, :created_by, :name, :kafka_schema_registry, :type, :config) RETURNING id;
 
 
 ------- connection tables -------------
 --! create_connection_table(connection_id?, schema?)
 INSERT INTO connection_tables
-(organization_id, created_by, name, table_type, connector, connection_id, config, schema)
-VALUES (:organization_id, :created_by, :name, :table_type, :connector, :connection_id, :config, :schema);
+(pub_id, organization_id, created_by, name, table_type, connector, connection_id, config, schema)
+VALUES (:pub_id, :organization_id, :created_by, :name, :table_type, :connector, :connection_id, :config, :schema);
 
 --! get_connection_tables: (connection_id?, connection_name?, connection_type?, connection_config?, schema?)
 SELECT connection_tables.id as id,
@@ -85,13 +85,13 @@ WHERE organization_id = :organization_id AND id = :id;
 ----------- pipelines -------------------
 
 --! create_pipeline
-INSERT INTO pipelines (organization_id, created_by, name, type, current_version)
-VALUES (:organization_id, :created_by, :name, :type, :current_version)
+INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, current_version)
+VALUES (:pub_id, :organization_id, :created_by, :name, :type, :current_version)
 RETURNING id;
 
 --! create_pipeline_definition (textual_repr?, udfs?)
-INSERT INTO pipeline_definitions (organization_id, created_by, pipeline_id, version, textual_repr, udfs, program)
-VALUES  (:organization_id, :created_by, :pipeline_id, :version, :textual_repr, :udfs, :program)
+INSERT INTO pipeline_definitions (pub_id, organization_id, created_by, pipeline_id, version, textual_repr, udfs, program)
+VALUES  (:pub_id, :organization_id, :created_by, :pipeline_id, :version, :textual_repr, :udfs, :program)
 RETURNING id;
 
 --! get_pipeline: DbPipeline(textual_repr?, udfs?)
@@ -100,8 +100,8 @@ INNER JOIN pipeline_definitions as d ON pipelines.id = d.pipeline_id AND pipelin
 WHERE pipelines.id = :pipeline_id AND pipelines.organization_id = :organization_id;
 
 --! add_pipeline_connection_table
-INSERT INTO connection_table_pipelines(pipeline_id, connection_table_id)
-VALUES (:pipeline_id, :connection_table_id);
+INSERT INTO connection_table_pipelines(pub_id, pipeline_id, connection_table_id)
+VALUES (:pub_id, :pipeline_id, :connection_table_id);
 
 --! delete_pipeline
 DELETE FROM pipelines
@@ -123,11 +123,11 @@ WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
-    (id, organization_id, pipeline_name, created_by, pipeline_definition, checkpoint_interval_micros, ttl_micros)
-VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_definition, :checkpoint_interval_micros, :ttl_micros);
+(pub_id, id, organization_id, pipeline_name, created_by, pipeline_definition, checkpoint_interval_micros, ttl_micros)
+VALUES (:pub_id, :id, :organization_id, :pipeline_name, :created_by, :pipeline_definition, :checkpoint_interval_micros, :ttl_micros);
 
 --! create_job_status
-INSERT INTO job_statuses (id, organization_id) VALUES (:id, :organization_id);
+INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :organization_id);
 
 --! get_jobs: (start_time?, finish_time?, state?, tasks?, textual_repr?, failure_message?, run_id?, udfs?)
 SELECT job_configs.id as id, pipeline_name, stop, textual_repr, start_time, finish_time, state, tasks, pipeline_definition, failure_message, run_id, udfs

--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -6,6 +6,7 @@ use arroyo_rpc::grpc::api::{
     ConnectionSchema, ConnectionTable, CreateConnectionTableReq, DeleteConnectionTableReq,
     TableType, TestSchemaReq, TestSourceMessage,
 };
+use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_sql::{
     json_schema::{self, convert_json_schema},
     types::{StructField, TypeDef},
@@ -112,6 +113,7 @@ pub(crate) async fn create(
     api_queries::create_connection_table()
         .bind(
             &transaction,
+            &generate_id(IdTypes::ConnectionTable),
             &auth.organization_id,
             &auth.user_id,
             &req.name,

--- a/arroyo-api/src/connections.rs
+++ b/arroyo-api/src/connections.rs
@@ -1,6 +1,7 @@
 use arroyo_connectors::connector_for_type;
 use arroyo_rpc::grpc::api::{Connection, CreateConnectionReq};
 use arroyo_rpc::grpc::api::{CreateConnectionResp, DeleteConnectionReq};
+use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use cornucopia_async::GenericClient;
 use tonic::Status;
 use tracing::warn;
@@ -34,6 +35,7 @@ pub(crate) async fn create_connection(
     let id = api_queries::create_connection()
         .bind(
             client,
+            &generate_id(IdTypes::Connection),
             &auth.organization_id,
             &auth.user_id,
             &req.name,

--- a/arroyo-api/src/jobs.rs
+++ b/arroyo-api/src/jobs.rs
@@ -3,6 +3,7 @@ use arroyo_rpc::grpc::api::{
     CheckpointDetailsResp, CheckpointOverview, CreateJobReq, JobDetailsResp, JobStatus,
     PipelineProgram, StopType,
 };
+use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use cornucopia_async::GenericClient;
 use deadpool_postgres::{Pool, Transaction};
 use prost::Message;
@@ -63,6 +64,7 @@ pub(crate) async fn create_job<'a>(
     api_queries::create_job()
         .bind(
             client,
+            &generate_id(IdTypes::JobConfig),
             &job_id,
             &auth.organization_id,
             &pipeline.name,
@@ -79,7 +81,12 @@ pub(crate) async fn create_job<'a>(
         .map_err(log_and_map)?;
 
     api_queries::create_job_status()
-        .bind(client, &job_id, &auth.organization_id)
+        .bind(
+            client,
+            &generate_id(IdTypes::JobStatus),
+            &job_id,
+            &auth.organization_id,
+        )
         .await
         .map_err(log_and_map)?;
 

--- a/arroyo-controller/queries/controller_queries.sql
+++ b/arroyo-controller/queries/controller_queries.sql
@@ -43,8 +43,8 @@ WHERE job_id = :job_id AND epoch < :epoch;
 
 --! create_checkpoint
 INSERT INTO checkpoints
-(organization_id, job_id, state_backend, epoch, min_epoch, start_time)
-VALUES (:organization_id, :job_id, :state_backend, :epoch, :min_epoch, :start_time)
+(pub_id, organization_id, job_id, state_backend, epoch, min_epoch, start_time)
+VALUES (:pub_id, :organization_id, :job_id, :state_backend, :epoch, :min_epoch, :start_time)
 RETURNING id;
 
 --! update_checkpoint (finish_time?)
@@ -75,6 +75,6 @@ ORDER BY epoch DESC
 LIMIT 1;
 
 --! create_job_log_message
-INSERT INTO job_log_messages (job_id, operator_id, task_index, log_level, message, details)
-VALUES (:job_id, :operator_id, :task_index, :log_level, :message, :details)
+INSERT INTO job_log_messages (pub_id, job_id, operator_id, task_index, log_level, message, details)
+VALUES (:pub_id, :job_id, :operator_id, :task_index, :log_level, :message, :details)
 RETURNING id;

--- a/arroyo-controller/src/job_controller/checkpointer.rs
+++ b/arroyo-controller/src/job_controller/checkpointer.rs
@@ -12,6 +12,7 @@ use arroyo_rpc::grpc::{
     SubtaskCheckpointMetadata, TableDescriptor, TaskCheckpointCompletedReq, TaskCheckpointEventReq,
     TaskCheckpointEventType,
 };
+use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::{from_micros, to_micros};
 use deadpool_postgres::Pool;
@@ -99,6 +100,7 @@ impl CheckpointState {
             controller_queries::create_checkpoint()
                 .bind(
                     &c,
+                    &generate_id(IdTypes::Checkpoint),
                     &organization_id,
                     &job_id,
                     &StateBackend::name().to_string(),

--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -15,6 +15,7 @@ use arroyo_rpc::grpc::{
     SinkDataReq, SinkDataResp, TaskCheckpointEventReq, TaskCheckpointEventResp, WorkerErrorReq,
     WorkerErrorRes,
 };
+use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_server_common::log_event;
 use arroyo_types::{from_micros, ports, DatabaseConfig, NodeId, WorkerId};
 use deadpool_postgres::{ManagerConfig, Pool, RecyclingMethod};
@@ -430,6 +431,7 @@ impl ControllerGrpc for ControllerServer {
         match queries::controller_queries::create_job_log_message()
             .bind(
                 &client,
+                &generate_id(IdTypes::JobLogMessage),
                 &req.job_id,
                 &req.operator_id,
                 &(req.task_index as i64),

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -13,6 +13,7 @@ prost = "0.11"
 tokio = { version = "1", features = ["full"] }
 bincode = "2.0.0-rc.3"
 serde = {version = "1.0", features = ["derive"]}
+nanoid = "0.4"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod public_ids;
+
 use std::{fs, time::SystemTime};
 
 use crate::grpc::SubtaskCheckpointMetadata;

--- a/arroyo-rpc/src/public_ids.rs
+++ b/arroyo-rpc/src/public_ids.rs
@@ -1,0 +1,44 @@
+use nanoid::nanoid;
+
+const ID_LENGTH: usize = 10;
+
+const ALPHABET: [char; 62] = [
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
+    'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b',
+    'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
+    'v', 'w', 'x', 'y', 'z',
+];
+
+pub enum IdTypes {
+    ApiKey,
+    Connection,
+    Schema,
+    Pipeline,
+    PipelineDefinition,
+    JobConfig,
+    Checkpoint,
+    JobStatus,
+    ClusterInfo,
+    JobLogMessage,
+    ConnectionTable,
+    ConnectionTablePipeline,
+}
+
+pub fn generate_id(id_type: IdTypes) -> String {
+    let prefix = match id_type {
+        IdTypes::ApiKey => "ak",
+        IdTypes::Connection => "conn",
+        IdTypes::Schema => "sch",
+        IdTypes::Pipeline => "pl",
+        IdTypes::PipelineDefinition => "pld",
+        IdTypes::JobConfig => "jc",
+        IdTypes::Checkpoint => "cp",
+        IdTypes::JobStatus => "js",
+        IdTypes::ClusterInfo => "ci",
+        IdTypes::JobLogMessage => "jlm",
+        IdTypes::ConnectionTable => "ct",
+        IdTypes::ConnectionTablePipeline => "ctp",
+    };
+    let id = nanoid!(ID_LENGTH, &ALPHABET);
+    format!("{}_{}", prefix, id)
+}


### PR DESCRIPTION
Use the nanoid library to generate prefixed ids when inserting rows into
the database. These ids will be used in the REST api.

An example schema id looks like this: `sch_7jPej3XRGl`
