### PR TITLE
Websocket source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "test-case",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tonic",
  "tracing",
  "typify",
@@ -2023,6 +2024,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "datafusion"
@@ -5683,6 +5690,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6344,6 +6362,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6683,6 +6715,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6832,6 +6884,12 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tonic",
  "tracing",
  "typify",

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -31,3 +31,4 @@ tracing = "0.1.37"
 regress = "0.6.0"
 eventsource-client = "0.11.0"
 futures = "0.3.28"
+tokio-tungstenite = { version = "0.19", features = ["native-tls"] }

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -20,6 +20,7 @@ use sse::SSEConnector;
 use tokio::sync::mpsc::Sender;
 use tonic::Status;
 use typify::import_types;
+use websocket::WebsocketConnector;
 
 use self::kafka::KafkaConnector;
 
@@ -28,6 +29,7 @@ pub mod impulse;
 pub mod kafka;
 pub mod nexmark;
 pub mod sse;
+pub mod websocket;
 
 import_types!(schema = "../connector-schemas/common.json",);
 
@@ -38,7 +40,7 @@ pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
     m.insert("nexmark", Box::new(NexmarkConnector {}));
     m.insert("impulse", Box::new(ImpulseConnector {}));
     m.insert("blackhole", Box::new(BlackholeConnector {}));
-
+    m.insert("websocket", Box::new(WebsocketConnector {}));
     m
 }
 

--- a/arroyo-connectors/src/websocket.rs
+++ b/arroyo-connectors/src/websocket.rs
@@ -1,0 +1,117 @@
+use anyhow::{anyhow};
+use arroyo_rpc::grpc::{
+    self,
+    api::{ConnectionSchema, TestSourceMessage},
+};
+use tokio::sync::mpsc::Sender;
+use tonic::Status;
+use typify::import_types;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    pull_opt, serialization_mode, Connection, ConnectionType, EmptyConfig, OperatorConfig,
+};
+
+use super::Connector;
+
+const TABLE_SCHEMA: &str = include_str!("../../connector-schemas/websocket/table.json");
+
+import_types!(schema = "../connector-schemas/websocket/table.json");
+const ICON: &str = include_str!("../resources/sse.svg");
+
+pub struct WebsocketConnector {}
+
+impl Connector for WebsocketConnector {
+    type ConfigT = EmptyConfig;
+
+    type TableT = WebsocketTable;
+
+    fn name(&self) -> &'static str {
+        "websocket"
+    }
+
+    fn metadata(&self) -> grpc::api::Connector {
+        grpc::api::Connector {
+            id: "websocket".to_string(),
+            name: "Websocket".to_string(),
+            icon: ICON.to_string(),
+            description: "Connect to a Websocket server".to_string(),
+            enabled: true,
+            source: true,
+            sink: false,
+            testing: true,
+            custom_schemas: true,
+            connection_config: None,
+            table_config: TABLE_SCHEMA.to_owned(),
+        }
+    }
+
+    fn test(
+        &self,
+        _: &str,
+        _: Self::ConfigT,
+        _: Self::TableT,
+        _: Option<&ConnectionSchema>,
+        tx: Sender<Result<TestSourceMessage, Status>>,
+    ) {
+        tokio::task::spawn(async move {
+            tx.send(Ok(TestSourceMessage { error: false, done: true, message: "Yay".to_string() })).await.unwrap();
+        });
+    }
+
+    fn table_type(&self, _: Self::ConfigT, _: Self::TableT) -> grpc::api::TableType {
+        return grpc::api::TableType::Source;
+    }
+
+    fn from_config(
+        &self,
+        id: Option<i64>,
+        name: &str,
+        config: Self::ConfigT,
+        table: Self::TableT,
+        schema: Option<&ConnectionSchema>,
+    ) -> anyhow::Result<crate::Connection> {
+        let description = format!("WebsocketSource<{}>", table.endpoint);
+
+        let config = OperatorConfig {
+            connection: serde_json::to_value(config).unwrap(),
+            table: serde_json::to_value(table).unwrap(),
+            rate_limit: None,
+            serialization_mode: Some(serialization_mode(schema.as_ref().unwrap())),
+        };
+
+        Ok(Connection {
+            id,
+            name: name.to_string(),
+            connection_type: ConnectionType::Source,
+            schema: schema
+                .map(|s| s.to_owned())
+                .ok_or_else(|| anyhow!("No schema defined for Websocket source"))?,
+            operator: "connectors::websocket::WebsocketSourceFunc".to_string(),
+            config: serde_json::to_string(&config).unwrap(),
+            description,
+        })
+    }
+
+    fn from_options(
+        &self,
+        name: &str,
+        opts: &mut std::collections::HashMap<String, String>,
+        schema: Option<&ConnectionSchema>,
+    ) -> anyhow::Result<crate::Connection> {
+        let endpoint = pull_opt("endpoint", opts)?;
+        let subscription_message = opts.remove("subscription_message");
+
+        self.from_config(
+            None,
+            name,
+            EmptyConfig {},
+            WebsocketTable {
+                endpoint,
+                subscription_message
+            },
+            schema,
+        )
+    }
+}

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -10,6 +10,7 @@ import {
   Input,
   Select,
   Stack,
+  Textarea,
 } from '@chakra-ui/react';
 import { JSONSchema7 } from 'json-schema';
 import { useFormik } from 'formik';
@@ -24,6 +25,7 @@ function StringWidget({
   description,
   placeholder,
   required,
+  maxLength,
   value,
   errors,
   onChange,
@@ -32,6 +34,7 @@ function StringWidget({
   title: string;
   description?: string;
   placeholder?: string;
+  maxLength?: number;
   required?: boolean;
   value: string;
   errors: any;
@@ -40,13 +43,24 @@ function StringWidget({
   return (
     <FormControl isRequired={required} isInvalid={errors[path]}>
       <FormLabel>{title}</FormLabel>
-      <Input
-        name={path}
-        type="text"
-        placeholder={placeholder}
-        value={value || ''}
-        onChange={e => onChange(e)}
-      />
+      {maxLength == null || maxLength < 100 ? (
+        <Input
+          name={path}
+          type="text"
+          placeholder={placeholder}
+          value={value || ''}
+          onChange={e => onChange(e)}
+        />
+      ) : (
+        <Textarea
+          name={path}
+          placeholder={placeholder}
+          value={value || ''}
+          onChange={e => onChange(e)}
+          resize={'vertical'}
+          size={'md'}
+        />
+      )}
       {errors[path] ? (
         <FormErrorMessage>{errors[path]}</FormErrorMessage>
       ) : (
@@ -195,6 +209,7 @@ export function FormInner({
                     title={property.title || key}
                     description={property.description}
                     required={schema.required?.includes(key)}
+                    maxLength={property.maxLength}
                     // @ts-ignore
                     placeholder={property.examples ? (property.examples[0] as string) : undefined}
                     value={values[key]}

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -56,6 +56,7 @@ regex = "1.8.1"
 anyhow = "1.0.71"
 typify = "0.0.13"
 regress = "0.6.0"
+tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
 
 [dev-dependencies]
 test-case = "2.2"

--- a/arroyo-worker/src/connectors/mod.rs
+++ b/arroyo-worker/src/connectors/mod.rs
@@ -6,5 +6,6 @@ pub mod impulse;
 pub mod kafka;
 pub mod nexmark;
 pub mod sse;
+pub mod websocket;
 
 import_types!(schema = "../connector-schemas/common.json",);

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -1,0 +1,231 @@
+use std::{
+    marker::PhantomData,
+    time::{Duration, Instant, SystemTime},
+};
+
+use arroyo_macro::source_fn;
+use arroyo_rpc::{
+    grpc::{StopMode, TableDescriptor},
+    ControlMessage,
+};
+use arroyo_state::tables::GlobalKeyedState;
+use arroyo_types::{Data, Record};
+use bincode::{Decode, Encode};
+use futures::{SinkExt, StreamExt};
+use serde::de::DeserializeOwned;
+use tokio::select;
+use tokio_tungstenite::{connect_async, tungstenite};
+use tracing::{debug, info};
+use typify::import_types;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    engine::{Context, StreamNode},
+    operators::{SerializationMode, UserError},
+    SourceFinishType,
+};
+
+use super::{OperatorConfig, OperatorConfigSerializationMode};
+
+import_types!(schema = "../connector-schemas/websocket/table.json");
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, PartialOrd, Default)]
+pub struct WebsocketSourceState {}
+
+#[derive(StreamNode, Clone)]
+pub struct WebsocketSourceFunc<K, T>
+where
+    K: DeserializeOwned + Data,
+    T: DeserializeOwned + Data,
+{
+    url: String,
+    subscription_message: Option<String>,
+    serialization_mode: SerializationMode,
+    state: WebsocketSourceState,
+    _t: PhantomData<(K, T)>,
+}
+
+#[source_fn(out_k = (), out_t = T)]
+impl<K, T> WebsocketSourceFunc<K, T>
+where
+    K: DeserializeOwned + Data,
+    T: DeserializeOwned + Data,
+{
+    pub fn from_config(config: &str) -> Self {
+        let config: OperatorConfig =
+            serde_json::from_str(config).expect("Invalid config for WebsocketSource");
+        let table: WebsocketTable =
+            serde_json::from_value(config.table).expect("Invalid table config for WebsocketSource");
+
+        Self {
+            url: table.endpoint,
+            subscription_message: table.subscription_message,
+            serialization_mode: match config.serialization_mode.unwrap() {
+                OperatorConfigSerializationMode::Json => SerializationMode::Json,
+                OperatorConfigSerializationMode::JsonSchemaRegistry => {
+                    SerializationMode::JsonSchemaRegistry
+                }
+                OperatorConfigSerializationMode::RawJson => SerializationMode::RawJson,
+                OperatorConfigSerializationMode::DebeziumJson => todo!(),
+            },
+            state: WebsocketSourceState::default(),
+            _t: PhantomData,
+        }
+    }
+
+
+    fn name(&self) -> String {
+        "WebsocketSource".to_string()
+    }
+
+    fn tables(&self) -> Vec<TableDescriptor> {
+        vec![arroyo_state::global_table("e", "sse source state")]
+    }
+
+    async fn on_start(&mut self, ctx: &mut Context<(), T>) {
+        let s: GlobalKeyedState<(), WebsocketSourceState, _> =
+            ctx.state.get_global_keyed_state('e').await;
+
+        if let Some(state) = s.get(&()) {
+            self.state = state.clone();
+        }
+    }
+
+    async fn our_handle_control_message(
+        &mut self,
+        ctx: &mut Context<(), T>,
+        msg: Option<ControlMessage>,
+    ) -> Option<SourceFinishType> {
+        match msg? {
+            ControlMessage::Checkpoint(c) => {
+                debug!("starting checkpointing {}", ctx.task_info.task_index);
+                let mut s: GlobalKeyedState<(), WebsocketSourceState, _> =
+                    ctx.state.get_global_keyed_state('e').await;
+                s.insert((), self.state.clone()).await;
+
+                if self.checkpoint(c, ctx).await {
+                    return Some(SourceFinishType::Immediate);
+                }
+            }
+            ControlMessage::Stop { mode } => {
+                info!("Stopping websocket source: {:?}", mode);
+
+                match mode {
+                    StopMode::Graceful => {
+                        return Some(SourceFinishType::Graceful);
+                    }
+                    StopMode::Immediate => {
+                        return Some(SourceFinishType::Immediate);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    async fn run(&mut self, ctx: &mut Context<(), T>) -> SourceFinishType {
+        let ws_stream = match connect_async(&self.url).await {
+            Ok((ws_stream, _)) => ws_stream,
+            Err(e) => {
+                ctx.report_error(
+                    "Failed to connect to websocket server".to_string(),
+                    e.to_string(),
+                )
+                .await;
+                panic!("{}", e);
+            }
+        };
+
+        let mut last_reported_error = Instant::now();
+        let mut errors = 0;
+
+        let (mut tx, mut rx) = ws_stream.split();
+
+        if let Some(msg) = &self.subscription_message {
+            if let Err(e) = tx.send(tungstenite::Message::Text(msg.clone())).await {
+                ctx.report_error("Failed to send subscription message to websocket server".to_string(), e.to_string()).await;
+                panic!("Failed to send subscription message to websocket server: {:?}", e);
+            }
+        }
+
+        // since there's no way to partition across a websocket source, only read on the first task
+        if ctx.task_info.task_index == 0 {
+            loop {
+                select! {
+                    message = rx.next()  => {
+                        match message {
+                            Some(Ok(msg)) => {
+                                let data = match msg {
+                                    tungstenite::Message::Text(t) => {
+                                        self.serialization_mode.deserialize_str(&t).map(|t| Some(t))
+                                    },
+                                    tungstenite::Message::Binary(bs) => {
+                                        self.serialization_mode.deserialize_slice(&bs).map(|t| Some(t))
+                                    },
+                                    tungstenite::Message::Ping(d) => {
+                                        tx.send(tungstenite::Message::Pong(d)).await
+                                            .map(|_| None)
+                                            .map_err(|e| UserError::new("Failed to sned pong to websocket server", e.to_string()))
+                                    },
+                                    tungstenite::Message::Pong(_) => {
+                                        // ignore
+                                        Ok(None)
+                                    },
+                                    tungstenite::Message::Close(_) => {
+                                        ctx.report_error("Received close frame from server".to_string(), "".to_string()).await;
+                                        return SourceFinishType::Final;
+                                    },
+                                    tungstenite::Message::Frame(_) => {
+                                        // this should be captured by tungstenite
+                                        Ok(None)
+                                    },
+                                };
+
+                                match data {
+                                    Ok(Some(t)) => {
+                                        ctx.collector.collect(Record {
+                                            timestamp: SystemTime::now(),
+                                            key: None,
+                                            value: t,
+                                        }).await;
+                                    }
+                                    Ok(None) => {}
+                                    Err(e) => {
+                                        errors += 1;
+                                        if last_reported_error.elapsed() > Duration::from_secs(30) {
+                                            ctx.report_error(format!("{} x {}", e.name, errors),
+                                                e.details).await;
+                                            errors = 0;
+                                            last_reported_error = Instant::now();
+                                        }
+                                    }
+                                };
+                            }
+                        Some(Err(e)) => {
+                            ctx.report_error("Error while reading from websocket".to_string(), format!("{:?}", e)).await;
+                            panic!("Error while reading from websocket: {:?}", e);
+                        }
+                        None => {
+                            info!("Socket closed");
+                            return SourceFinishType::Final;
+                        }
+                    }
+                    }
+                    control_message = ctx.control_rx.recv() => {
+                        if let Some(r) = self.our_handle_control_message(ctx, control_message).await {
+                            return r;
+                        }
+                    }
+                }
+            }
+        } else {
+            // otherwise just process control messages
+            loop {
+                let msg = ctx.control_rx.recv().await;
+                if let Some(r) = self.our_handle_control_message(ctx, msg).await {
+                    return r;
+                }
+            }
+        }
+    }
+}

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -171,7 +171,7 @@ where
                                     tungstenite::Message::Ping(d) => {
                                         tx.send(tungstenite::Message::Pong(d)).await
                                             .map(|_| None)
-                                            .map_err(|e| UserError::new("Failed to sned pong to websocket server", e.to_string()))
+                                            .map_err(|e| UserError::new("Failed to send pong to websocket server", e.to_string()))
                                     },
                                     tungstenite::Message::Pong(_) => {
                                         // ignore

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -467,6 +467,17 @@ impl<K: Key, T: Data> Context<K, T> {
     pub async fn broadcast(&mut self, message: Message<K, T>) {
         self.collector.broadcast(message).await;
     }
+
+    pub async fn report_error(&mut self, message: String, details: String) {
+        self.control_tx.send(
+            ControlResp::Error {
+                operator_id: self.task_info.operator_id.clone(),
+                task_index: self.task_info.task_index,
+                message,
+                details,
+            }
+        ).await.unwrap();
+    }
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -469,14 +469,15 @@ impl<K: Key, T: Data> Context<K, T> {
     }
 
     pub async fn report_error(&mut self, message: String, details: String) {
-        self.control_tx.send(
-            ControlResp::Error {
+        self.control_tx
+            .send(ControlResp::Error {
                 operator_id: self.task_info.operator_id.clone(),
                 task_index: self.task_info.task_index,
                 message,
                 details,
-            }
-        ).await.unwrap();
+            })
+            .await
+            .unwrap();
     }
 }
 

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "stacker",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tonic",
  "tracing",
  "typify",
@@ -1116,6 +1117,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "debugid"
@@ -3549,6 +3556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3947,6 +3965,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,6 +4237,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4325,6 +4377,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/connector-schemas/websocket/table.json
+++ b/connector-schemas/websocket/table.json
@@ -14,6 +14,7 @@
         "subscription_message": {
             "title": "Subscription Message",
             "type": "string",
+            "maxLength": 2048,
             "description": "An optional message to send after the socket is opened",
             "examples": [
                 "{\"type\":\"subscribe\",\"channels\":[\"updates\"]}"

--- a/connector-schemas/websocket/table.json
+++ b/connector-schemas/websocket/table.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "title": "WebsocketTable",
+    "properties": {
+        "endpoint": {
+            "title": "Endpoint",
+            "type": "string",
+            "description": "The endpoint to connect to",
+            "examples": [
+                "wss://example.com:8080/ws"
+            ],
+            "format": "uri"
+        },
+        "subscription_message": {
+            "title": "Subscription Message",
+            "type": "string",
+            "description": "An optional message to send after the socket is opened",
+            "examples": [
+                "{\"type\":\"subscribe\",\"channels\":[\"updates\"]}"
+            ]
+        }
+    },
+    "required": [
+        "endpoint"
+    ]
+}


### PR DESCRIPTION
This PR introduces a POC websocket connector.

This allows interacting with many websocket APIs, for example coinbase:

```sql
CREATE TABLE coinbase (
    type TEXT,
    price TEXT,
) WITH (
    connector = 'websocket',
    endpoint = 'wss://ws-feed.exchange.coinbase.com',
    subscription_message = '{
    "type": "subscribe",
    "product_ids": [
        "ETH-USD",
        "BTC-USD"
    ],
    "channels": ["ticker"]
}',
    format = 'json'
);

SELECT CAST(price as FLOAT) from coinbase
WHERE type = 'ticker';
```

Websocket is a very open-ended protocol, which makes it challenging to target from a configuration approach. This initial POC allows a single subscription message to be configured, but doesn't support any complex behavior around tracking consumed messages / reporting consumption on reconnection / etc.

It is currently functional enough to support easy exploration of many real-world websocket APIs.