### PR TITLE
Wait for checkpoint to finish before issuing final checkpoint

### DIFF
--- a/arroyo-console/src/routes/pipelines/JobDetail.tsx
+++ b/arroyo-console/src/routes/pipelines/JobDetail.tsx
@@ -123,7 +123,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
             activeOperator={activeOperator}
           />
         </Flex>
-        <Stack w="500px" className="pipelineInfo" spacing={2} overflow={'scroll'}>
+        <Stack w="500px" className="pipelineInfo" spacing={2} overflow={'auto'}>
           {job?.jobStatus?.failureMessage ? (
             <Box>
               <Alert status="error" marginBottom={5}>

--- a/arroyo-controller/src/job_controller/mod.rs
+++ b/arroyo-controller/src/job_controller/mod.rs
@@ -486,10 +486,15 @@ impl JobController {
         Ok(())
     }
 
-    pub async fn checkpoint(&mut self, then_stop: bool) -> anyhow::Result<()> {
-        self.model
-            .start_checkpoint(&self.config.organization_id, &self.pool, then_stop)
-            .await
+    pub async fn checkpoint(&mut self, then_stop: bool) -> anyhow::Result<bool> {
+        if self.model.checkpoint_state.is_none() {
+            self.model
+                .start_checkpoint(&self.config.organization_id, &self.pool, then_stop)
+                .await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     pub fn finished(&self) -> bool {

--- a/arroyo-controller/src/states/checkpoint_stopping.rs
+++ b/arroyo-controller/src/states/checkpoint_stopping.rs
@@ -19,14 +19,12 @@ impl State for CheckpointStopping {
     async fn next(mut self: Box<Self>, ctx: &mut Context) -> Result<Transition, StateError> {
         let job_controller = ctx.job_controller.as_mut().unwrap();
 
-        if let Err(e) = job_controller.checkpoint(true).await {
-            return Err(ctx.retryable(self, "failed to initiate final checkpoint", e, 10));
-        }
+        let mut final_checkpoint_started = false;
 
         loop {
             match job_controller.checkpoint_finished().await {
                 Ok(done) => {
-                    if done && job_controller.finished() {
+                    if done && job_controller.finished() && final_checkpoint_started {
                         return Ok(Transition::next(*self, Stopped {}));
                     }
                 }
@@ -37,6 +35,20 @@ impl State for CheckpointStopping {
                         e,
                         10,
                     ));
+                }
+            }
+
+            if !final_checkpoint_started {
+                match job_controller.checkpoint(true).await {
+                    Ok(started) => final_checkpoint_started = started,
+                    Err(e) => {
+                        return Err(ctx.retryable(
+                            self,
+                            "failed to initiate final checkpoint",
+                            e,
+                            10,
+                        ));
+                    }
                 }
             }
 


### PR DESCRIPTION
This addresses #24 by modifying the checkpoint_stopping state to check for an existing in-progress checkpoint, and if one exists waiting for completion before issuing the final checkpoint.

In the future, it would be good to support checkpoint cancellation as well so that it isn't necessary to wait for the checkpoint to finish when we're just going to do another one.