### PR TITLE
Remove pipeline_definitions table and merge into pipelines

### DIFF
--- a/arroyo-api/migrations/V10__merge_definitions.sql
+++ b/arroyo-api/migrations/V10__merge_definitions.sql
@@ -1,0 +1,46 @@
+-- We have two tables, pipelines and pipeline_definitions, that are
+-- conceptually one table, and which generally have a 1-1 relationship.
+-- pipeline_definitions stores the history of pipeline definitions, and
+-- pipelines references the current version.
+--
+-- This distinction has not proved useful, and so this migration is
+-- intended to merge the two tables into one. At the end of this,
+
+ALTER TABLE pipelines ADD COLUMN textual_repr TEXT;
+ALTER TABLE pipelines ADD COLUMN program BYTEA;
+ALTER TABLE pipelines ADD COLUMN udfs JSONB NOT NULL DEFAULT '[]';
+
+-- fill in the new fields on pipelines
+UPDATE pipelines
+SET textual_repr = pipeline_definitions.textual_repr,
+    program = pipeline_definitions.program,
+    udfs = pipeline_definitions.udfs
+FROM pipeline_definitions
+WHERE pipelines.id = pipeline_definitions.pipeline_id
+AND pipelines.current_version = pipeline_definitions.version;
+
+ALTER TABLE pipelines DROP COLUMN current_version;
+ALTER TABLE pipelines ALTER COLUMN textual_repr SET NOT NULL;
+ALTER TABLE pipelines ALTER COLUMN program SET NOT NULL;
+
+-- modify connection_table_pipelines so that it references the pipeline, instead of pipeline_definition
+ALTER TABLE connection_table_pipelines RENAME COLUMN pipeline_id to pipeline_definition_id;
+ALTER TABLE connection_table_pipelines ADD COLUMN pipeline_id BIGINT REFERENCES pipelines(id);
+
+UPDATE connection_table_pipelines
+SET pipeline_id = pipeline_definition_id;
+
+ALTER TABLE connection_table_pipelines ALTER COLUMN pipeline_id SET NOT NULL;
+ALTER TABLE connection_table_pipelines DROP COLUMN pipeline_definition_id;
+
+-- modify job_configs to reference the pipeline instead of pipeline_definition
+ALTER TABLE job_configs ADD COLUMN pipeline_id BIGINT REFERENCES pipelines(id);
+
+UPDATE job_configs
+SET pipeline_id = pipeline_definition;
+
+ALTER TABLE job_configs ALTER COLUMN pipeline_id SET NOT NULL;
+ALTER TABLE job_configs DROP COLUMN pipeline_definition;
+
+-- drop pipeline_Definitions
+DROP TABLE pipeline_definitions;

--- a/arroyo-api/src/jobs.rs
+++ b/arroyo-api/src/jobs.rs
@@ -8,7 +8,7 @@ use cornucopia_async::GenericClient;
 use deadpool_postgres::{Pool, Transaction};
 use prost::Message;
 use rand::{distributions::Alphanumeric, Rng};
-use serde_json::{from_str, Value};
+use serde_json::from_str;
 use std::{collections::HashMap, time::Duration};
 use tonic::Status;
 
@@ -115,9 +115,8 @@ pub(crate) async fn get_jobs(
                 finish_time: rec.finish_time.map(to_micros),
                 tasks: rec.tasks.map(|t| t as u64),
                 definition: rec.textual_repr,
-                udfs: serde_json::from_value(rec.udfs.unwrap_or_else(|| Value::Array(vec![])))
-                    .map_err(log_and_map)?,
-                definition_id: format!("{}", rec.pipeline_definition),
+                udfs: serde_json::from_value(rec.udfs).map_err(log_and_map)?,
+                pipeline_id: format!("{}", rec.pipeline_id),
                 failure_message: rec.failure_message,
             })
         })
@@ -211,9 +210,8 @@ pub(crate) async fn get_job_details(
         finish_time: res.finish_time.map(to_micros),
         tasks: res.tasks.map(|t| t as u64),
         definition: res.textual_repr,
-        definition_id: format!("{}", res.pipeline_definition),
-        udfs: serde_json::from_value(res.udfs.unwrap_or_else(|| Value::Array(vec![])))
-            .map_err(log_and_map)?,
+        pipeline_id: format!("{}", res.pipeline_id),
+        udfs: serde_json::from_value(res.udfs).map_err(log_and_map)?,
         failure_message: res.failure_message,
     };
 

--- a/arroyo-console/src/gen/api_pb.ts
+++ b/arroyo-console/src/gen/api_pb.ts
@@ -2876,9 +2876,9 @@ export class JobStatus extends Message<JobStatus> {
   runId = protoInt64.zero;
 
   /**
-   * @generated from field: string definition_id = 9;
+   * @generated from field: string pipeline_id = 9;
    */
-  definitionId = "";
+  pipelineId = "";
 
   /**
    * @generated from field: optional uint64 start_time = 4;
@@ -2923,7 +2923,7 @@ export class JobStatus extends Message<JobStatus> {
     { no: 8, name: "running_desired", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 3, name: "state", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 11, name: "run_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
-    { no: 9, name: "definition_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 9, name: "pipeline_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "start_time", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
     { no: 5, name: "finish_time", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
     { no: 6, name: "tasks", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },

--- a/arroyo-console/src/routes/pipelines/JobDetail.tsx
+++ b/arroyo-console/src/routes/pipelines/JobDetail.tsx
@@ -184,7 +184,7 @@ export function JobDetail({ client }: { client: ApiClient }) {
       <TabPanel w={'100%'}>
         <Box>
           <CodeEditor
-            query={(job?.jobStatus?.udfs || [{ definition: '' }])[0].definition}
+            query={job?.jobStatus?.udfs[0]?.definition || ''}
             language="rust"
             readOnly={true}
           />

--- a/arroyo-console/src/routes/pipelines/JobsIndex.tsx
+++ b/arroyo-console/src/routes/pipelines/JobsIndex.tsx
@@ -200,7 +200,7 @@ function JobsTable({ client }: { client: ApiClient }) {
               ))}
               <Td textAlign="right">
                 <IconButton
-                  onClick={() => navigate('/pipelines/new?from=' + job.definitionId)}
+                  onClick={() => navigate('/pipelines/new?from=' + job.pipelineId)}
                   icon={<FiCopy fontSize="1.25rem" />}
                   variant="ghost"
                   aria-label="Duplicate"

--- a/arroyo-controller/queries/controller_queries.sql
+++ b/arroyo-controller/queries/controller_queries.sql
@@ -3,7 +3,7 @@ SELECT
     job_configs.id as id,
     job_configs.organization_id as org_id,
     pipeline_name,
-    pipeline_definition as definition_id,
+    pipeline_id,
     checkpoint_interval_micros,
     ttl_micros,
     parallelism_overrides,
@@ -34,7 +34,7 @@ SET state = :state,
 WHERE id = :job_id;
 
 --! get_program
-SELECT program FROM pipeline_definitions WHERE id = :id;
+SELECT program FROM pipelines WHERE id = :id;
 
 --! mark_checkpoints_compacted
 UPDATE checkpoints

--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -96,7 +96,7 @@ pub struct JobConfig {
     id: String,
     organization_id: String,
     pipeline_name: String,
-    definition_id: i64,
+    pipeline_id: i64,
     stop_mode: StopMode,
     checkpoint_interval: Duration,
     ttl: Option<Duration>,
@@ -571,7 +571,7 @@ impl ControllerServer {
                         id: p.id.clone(),
                         organization_id: p.org_id,
                         pipeline_name: p.pipeline_name,
-                        definition_id: p.definition_id,
+                        pipeline_id: p.pipeline_id,
                         stop_mode: p.stop,
                         checkpoint_interval: Duration::from_micros(
                             p.checkpoint_interval_micros as u64,

--- a/arroyo-controller/src/states/mod.rs
+++ b/arroyo-controller/src/states/mod.rs
@@ -503,7 +503,7 @@ pub async fn run_to_completion(
     scheduler: Arc<dyn Scheduler>,
 ) {
     let c = pool.get().await.unwrap();
-    let id = config.read().unwrap().definition_id;
+    let id = config.read().unwrap().pipeline_id;
     let mut program: Program = {
         let res = controller_queries::get_program()
             .bind(&c, &id)

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -372,7 +372,7 @@ message JobStatus {
   bool running_desired = 8;
   string state = 3;
   uint64 run_id = 11;
-  string definition_id = 9;
+  string pipeline_id = 9;
   optional uint64 start_time = 4;
   optional uint64 finish_time = 5;
   optional uint64 tasks = 6;

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -329,6 +329,7 @@ version = "0.3.0"
 dependencies = [
  "arroyo-types",
  "bincode 2.0.0-rc.3",
+ "nanoid",
  "prost",
  "serde",
  "tokio",
@@ -2225,6 +2226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d66043b25d4a6cccb23619d10c19c25304b355a7dccd4a8e11423dd2382146"
 dependencies = [
  "clap",
+ "rand",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
  "rand",
 ]
 


### PR DESCRIPTION
This PR removes the pipeline_definitions table and merges the content into the pipelines table.

In the initial schema, we split out pipelines (which had a single record for each logical pipeline) and pipeline_definitions (which had a record for each version of each pipeline), with the current version referenced by the pipelines table. This was intended to support features around managing multiple versions for rollbacks, auditing, etc.

However we have not yet built out those features, and in the meantime the distinction has been confusing and awkward for development.