### PR TITLE
Fix docker build by adding git to container

### DIFF
--- a/docker/cluster/compiler/Dockerfile
+++ b/docker/cluster/compiler/Dockerfile
@@ -6,7 +6,7 @@ ARG MOLD_ARCH
 ARG GIT_SHA
 
 RUN apt-get update && \
-    apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl cmake clang wget && \
+    apt-get -y install curl git pkg-config unzip build-essential libssl-dev openssl cmake clang wget && \
     # Install mold
     wget https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-${MOLD_ARCH}-linux.tar.gz && \
     tar xvfz mold*.tar.gz && \

--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -8,7 +8,7 @@ ARG PROM_ARCH
 ARG GIT_SHA
 
 RUN apt-get update
-RUN apt-get -y install curl pkg-config unzip build-essential libssl-dev openssl \
+RUN apt-get -y install git curl pkg-config unzip build-essential libssl-dev openssl \
     cmake clang wget postgresql postgresql-client supervisor python3 python-is-python3 sudo bash
 
 RUN wget https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-${MOLD_ARCH}-linux.tar.gz && \


### PR DESCRIPTION
The build for the fluvio dependency fails if git is not available.