### PR TITLE
Fix regression that prevented pipeline deletes

### DIFF
--- a/arroyo-api/migrations/V11__delete_cascade.sql
+++ b/arroyo-api/migrations/V11__delete_cascade.sql
@@ -1,0 +1,13 @@
+-- add missing ON DELETE CASCADE to connection_table_pipelines
+ALTER TABLE connection_table_pipelines RENAME COLUMN pipeline_id to pipeline_id_old;
+ALTER TABLE connection_table_pipelines
+    ADD COLUMN pipeline_id BIGINT REFERENCES pipelines(id) ON DELETE CASCADE;
+UPDATE connection_table_pipelines SET pipeline_id = pipeline_id_old;
+ALTER TABLE connection_table_pipelines DROP COLUMN pipeline_id_old;
+
+-- add missing ON DELETE CASCADE to job_configs
+ALTER TABLE job_configs RENAME COLUMN pipeline_id to pipeline_id_old;
+ALTER TABLE job_configs
+    ADD COLUMN pipeline_id BIGINT REFERENCES pipelines(id) ON DELETE CASCADE;
+UPDATE job_configs SET pipeline_id = pipeline_id_old;
+ALTER TABLE job_configs DROP COLUMN pipeline_id_old;


### PR DESCRIPTION
Fixes a regression in #196, which removed the foreign key relationships between job_configs and connection_table_pipelines to pipeline_definitions, and added to pipelines. However, it missed a necessary `ON DELETE CASCADE`, which is preventing pipeline deletions.

This PR adds another migration to add that back.