### PR TITLE
[#204] Fix UDF nullability rules

### DIFF
--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -2458,7 +2458,8 @@ impl RustUdfExpression {
                 || self
                     .args
                     .iter()
-                    .any(|(t, e)| t.is_optional() && !e.nullable()),
+                    // nullable if there are non-null UDF params with nullable arguments
+                    .any(|(t, e)| !t.is_optional() && e.nullable()),
         )
     }
 }

--- a/arroyo-sql/src/json_schema.rs
+++ b/arroyo-sql/src/json_schema.rs
@@ -7,7 +7,7 @@ use arrow_schema::DataType;
 use quote::{format_ident, quote};
 use schemars::schema::{RootSchema, Schema};
 use syn::{parse_str, Type};
-use tracing::log::warn;
+use tracing::warn;
 use typify::{TypeDetails, TypeSpace, TypeSpaceSettings};
 
 use crate::types::{StructDef, StructField, TypeDef};

--- a/arroyo-sql/src/test.rs
+++ b/arroyo-sql/src/test.rs
@@ -1,9 +1,10 @@
+use arrow_schema::DataType;
 use arroyo_connectors::{
     nexmark::{NexmarkConnector, NexmarkTable},
     Connector, EmptyConfig,
 };
 
-use crate::{parse_and_get_program, ArroyoSchemaProvider, SqlConfig};
+use crate::{parse_and_get_program, types::TypeDef, ArroyoSchemaProvider, SqlConfig};
 
 #[tokio::test]
 async fn test_parse() {
@@ -161,6 +162,9 @@ async fn test_udf() {
     schema_provider
         .add_rust_udf("fn my_sqr(x: i64) -> i64 { x * x }")
         .unwrap();
+
+    let def = schema_provider.udf_defs.get("my_sqr").unwrap();
+    assert_eq!(def.ret, TypeDef::DataType(DataType::Int64, false));
 
     let sql = "SELECT my_sqr(bid.auction) FROM nexmark";
     parse_and_get_program(sql, schema_provider, SqlConfig::default())

--- a/build_dir/Cargo.lock
+++ b/build_dir/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-metrics"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arroyo-types",
  "prometheus",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-rpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arroyo-types",
  "bincode 2.0.0-rc.3",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-server-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arroyo-types",
  "axum",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-state"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-worker"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arroyo-macro",

--- a/build_dir/wasm-fns/Cargo.lock
+++ b/build_dir/wasm-fns/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
This fixes #204 by correctly implementing the nullability logic for UDFs. The correct logic is that a UDF return type is nullable if either

1. It's defined with an Optional return type, or
2. It has any non-optional parameters (in the Rust function) applied with nullable arguments (in SQL)

Previously, the second condition was implemented incorrectly, as "any optional parameters applied with non-nullable arguments).