### PR TITLE
implement exactly-once commits to Kafka sinks and read_committed reads to Kafka sources.

### DIFF
--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -157,19 +157,19 @@ impl Connector for KafkaConnector {
                         None | Some("latest") => SourceOffset::Latest,
                         Some(other) => bail!("invalid value for source.offset '{}'", other),
                     },
-                    read_mode: match opts.remove("read_mode").as_ref().map(|f| f.as_str()) {
-                        Some("read_committed") => SourceReadMode::ReadCommitted,
-                        Some("read_uncommitted") | None => SourceReadMode::ReadUncommitted,
+                    read_mode: match opts.remove("source.read_mode").as_ref().map(|f| f.as_str()) {
+                        Some("read_committed") => Some(SourceReadMode::ReadCommitted),
+                        Some("read_uncommitted") | None => Some(SourceReadMode::ReadUncommitted),
                         Some(other) => bail!("invalid value for source.read_mode '{}'", other),
                     },
                 }
             }
             "sink" => {
-                let commit_mode = opts.remove("commit_mode");
+                let commit_mode = opts.remove("sink.commit_mode");
                 TableType::Sink {
                     commit_mode: match commit_mode.as_ref().map(|f| f.as_str()) {
-                        Some("at_least_once") | None => SinkCommitMode::AtLeastOnce,
-                        Some("exactly_once") => SinkCommitMode::ExactlyOnce,
+                        Some("at_least_once") | None => Some(SinkCommitMode::AtLeastOnce),
+                        Some("exactly_once") => Some(SinkCommitMode::ExactlyOnce),
                         Some(other) => bail!("invalid value for commit_mode '{}'", other),
                     },
                 }

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -1546,7 +1546,7 @@ impl Program {
                             quote! {
                                 |record, _| {
                                     if #expr {
-                                        Some(record)
+                                        Some(record.clone())
                                     } else {
                                         None
                                     }

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -570,6 +570,7 @@ pub fn get_test_expression(
                 topic: "test_topic".to_string(),
                 type_: arroyo_connectors::kafka::TableType::Source {
                     offset: arroyo_connectors::kafka::SourceOffset::Latest,
+                    read_mode: arroyo_connectors::kafka::SourceReadMode::ReadUncommitted,
                 },
             },
             Some(&schema),

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -570,7 +570,7 @@ pub fn get_test_expression(
                 topic: "test_topic".to_string(),
                 type_: arroyo_connectors::kafka::TableType::Source {
                     offset: arroyo_connectors::kafka::SourceOffset::Latest,
-                    read_mode: arroyo_connectors::kafka::SourceReadMode::ReadUncommitted,
+                    read_mode: Some(arroyo_connectors::kafka::SourceReadMode::ReadUncommitted),
                 },
             },
             Some(&schema),

--- a/arroyo-worker/src/connectors/fluvio/source.rs
+++ b/arroyo-worker/src/connectors/fluvio/source.rs
@@ -12,7 +12,6 @@ use fluvio::dataplane::link::ErrorCode;
 use fluvio::metadata::objects::Metadata;
 use fluvio::metadata::topic::TopicSpec;
 use fluvio::{consumer::Record as ConsumerRecord, Fluvio, FluvioConfig, Offset};
-use futures_lite::future::FutureExt;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::marker::PhantomData;

--- a/arroyo-worker/src/connectors/fluvio/source.rs
+++ b/arroyo-worker/src/connectors/fluvio/source.rs
@@ -12,6 +12,7 @@ use fluvio::dataplane::link::ErrorCode;
 use fluvio::metadata::objects::Metadata;
 use fluvio::metadata::topic::TopicSpec;
 use fluvio::{consumer::Record as ConsumerRecord, Fluvio, FluvioConfig, Offset};
+use futures_lite::future::FutureExt;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::marker::PhantomData;

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -1,13 +1,16 @@
 use crate::connectors::OperatorConfig;
 use crate::engine::{Context, StreamNode};
+use anyhow::Result;
 use arroyo_macro::process_fn;
+use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableWriteBehavior};
+use arroyo_rpc::{CheckpointEvent, ControlMessage};
 use arroyo_types::*;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use tracing::info;
+use tracing::warn;
 
-use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord};
+use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord, Producer};
 use rdkafka::util::Timeout;
 
 use rdkafka::ClientConfig;
@@ -16,9 +19,9 @@ use arroyo_types::CheckpointBarrier;
 use rdkafka::error::KafkaError;
 use rdkafka_sys::RDKafkaErrorCode;
 use serde::Serialize;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use super::{client_configs, KafkaConfig, KafkaTable, TableType};
+use super::{client_configs, KafkaConfig, KafkaTable, SinkCommitMode, TableType};
 
 #[cfg(test)]
 mod test;
@@ -27,10 +30,31 @@ mod test;
 pub struct KafkaSinkFunc<K: Key + Serialize, T: Data + Serialize> {
     topic: String,
     bootstrap_servers: String,
+    consistency_mode: ConsistencyMode,
     producer: Option<FutureProducer>,
     write_futures: Vec<DeliveryFuture>,
     client_config: HashMap<String, String>,
     _t: PhantomData<(K, T)>,
+}
+
+enum ConsistencyMode {
+    AtLeastOnce,
+    ExactlyOnce {
+        next_transaction_index: usize,
+        producer_to_complete: Option<FutureProducer>,
+    },
+}
+
+impl From<SinkCommitMode> for ConsistencyMode {
+    fn from(commit_mode: SinkCommitMode) -> Self {
+        match commit_mode {
+            SinkCommitMode::AtLeastOnce => ConsistencyMode::AtLeastOnce,
+            SinkCommitMode::ExactlyOnce => ConsistencyMode::ExactlyOnce {
+                next_transaction_index: 0,
+                producer_to_complete: None,
+            },
+        }
+    }
 }
 
 impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
@@ -39,6 +63,7 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
             topic: topic.to_string(),
             bootstrap_servers: servers.to_string(),
             producer: None,
+            consistency_mode: ConsistencyMode::AtLeastOnce,
             write_futures: vec![],
             client_config: client_config
                 .iter()
@@ -55,7 +80,7 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
             .expect("Invalid connection config for KafkaSink");
         let table: KafkaTable =
             serde_json::from_value(config.table).expect("Invalid table config for KafkaSource");
-        let TableType::Sink{ .. } = &table.type_ else {
+        let TableType::Sink{ commit_mode } = table.type_ else {
             panic!("found non-sink kafka config in sink operator");
         };
 
@@ -63,6 +88,7 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
             topic: table.topic,
             bootstrap_servers: connection.bootstrap_servers.to_string(),
             producer: None,
+            consistency_mode: commit_mode.into(),
             write_futures: vec![],
             client_config: client_configs(&connection),
             _t: PhantomData,
@@ -76,21 +102,80 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
         format!("kafka-producer-{}", self.topic)
     }
 
-    async fn on_start(&mut self, _ctx: &mut Context<(), ()>) {
-        info!("Creating kafka producer for {}", self.bootstrap_servers);
+    async fn on_start(&mut self, ctx: &mut Context<(), ()>) {
+        self.init_producer(&ctx.task_info)
+            .expect("Producer creation failed");
+    }
+
+    fn is_committing(&self) -> bool {
+        matches!(self.consistency_mode, ConsistencyMode::ExactlyOnce { .. })
+    }
+
+    fn tables(&self) -> Vec<arroyo_rpc::grpc::TableDescriptor> {
+        if self.is_committing() {
+            vec![TableDescriptor {
+                name: "i".to_string(),
+                description: "index for transactional ids".to_string(),
+                table_type: arroyo_rpc::grpc::TableType::Global as i32,
+                delete_behavior: TableDeleteBehavior::None as i32,
+                write_behavior: TableWriteBehavior::CommitWrites as i32,
+                retention_micros: 0,
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn init_producer(&mut self, task_info: &TaskInfo) -> Result<()> {
         let mut client_config = ClientConfig::new();
-
         client_config.set("bootstrap.servers", &self.bootstrap_servers);
-
         for (key, value) in &self.client_config {
             client_config.set(key, value);
         }
 
-        self.producer = Some(client_config.create().expect("Producer creation failed"));
+        match &mut self.consistency_mode {
+            ConsistencyMode::AtLeastOnce => {
+                self.producer = Some(client_config.create()?);
+            }
+            ConsistencyMode::ExactlyOnce {
+                next_transaction_index,
+                ..
+            } => {
+                client_config.set("enable.idempotence", "true");
+                let transactional_id = format!(
+                    "arroyo-id-{}-{}-{}-{}",
+                    task_info.job_id,
+                    task_info.operator_id,
+                    task_info.task_index,
+                    next_transaction_index
+                );
+                client_config.set("transactional.id", transactional_id);
+                let producer: FutureProducer = client_config.create()?;
+                producer.init_transactions(Timeout::Never)?;
+                producer.begin_transaction()?;
+                *next_transaction_index += 1;
+                self.producer = Some(producer);
+            }
+        }
+        Ok(())
     }
 
-    async fn handle_checkpoint(&mut self, _: &CheckpointBarrier, _: &mut Context<(), ()>) {
+    async fn handle_checkpoint(&mut self, _: &CheckpointBarrier, ctx: &mut Context<(), ()>) {
         self.flush().await;
+        if let ConsistencyMode::ExactlyOnce {
+            next_transaction_index,
+            producer_to_complete,
+        } = &mut self.consistency_mode
+        {
+            *producer_to_complete = self.producer.take();
+            ctx.state
+                .get_global_keyed_state('i')
+                .await
+                .insert(ctx.task_info.task_index, *next_transaction_index)
+                .await;
+            self.init_producer(&ctx.task_info)
+                .expect("creating new producer during checkpointing");
+        }
     }
 
     async fn flush(&mut self) {
@@ -149,5 +234,41 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
         let v = serde_json::to_string(&record.value).unwrap();
 
         self.publish(k, v).await;
+    }
+
+    async fn handle_commit(&mut self, epoch: u32, ctx: &mut crate::engine::Context<(), ()>) {
+        let ConsistencyMode::ExactlyOnce { next_transaction_index: _, producer_to_complete } = &mut self.consistency_mode else {
+            warn!("received commit but consistency mode is not exactly once");
+            return
+        };
+
+        let Some(committing_producer)= producer_to_complete.take() else {
+            unimplemented!("received a commit message without a producer ready to commit. Restoring from commit phase not yet implemented");
+        };
+        committing_producer
+            .commit_transaction(Timeout::Never)
+            .expect("committing producer should succeed");
+        let checkpoint_event = arroyo_rpc::ControlResp::CheckpointEvent(CheckpointEvent {
+            checkpoint_epoch: epoch,
+            operator_id: ctx.task_info.operator_id.clone(),
+            subtask_index: ctx.task_info.task_index as u32,
+            time: SystemTime::now(),
+            event_type: arroyo_rpc::grpc::TaskCheckpointEventType::FinishedCommit.into(),
+        });
+        ctx.control_tx
+            .send(checkpoint_event)
+            .await
+            .expect("sent commit event");
+    }
+
+    async fn on_close(&mut self, ctx: &mut crate::engine::Context<(), ()>) {
+        if !self.is_committing() {
+            return;
+        }
+        if let Some(ControlMessage::Commit { epoch }) = ctx.control_rx.recv().await {
+            self.handle_commit(epoch, ctx).await;
+        } else {
+            warn!("no commit message received, not committing")
+        }
     }
 }

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -88,7 +88,7 @@ impl<K: Key + Serialize, T: Data + Serialize> KafkaSinkFunc<K, T> {
             topic: table.topic,
             bootstrap_servers: connection.bootstrap_servers.to_string(),
             producer: None,
-            consistency_mode: commit_mode.into(),
+            consistency_mode: commit_mode.unwrap_or(SinkCommitMode::AtLeastOnce).into(),
             write_futures: vec![],
             client_config: client_configs(&connection),
             _t: PhantomData,

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -89,7 +89,7 @@ where
             panic!("found non-source kafka config in source operator");
         };
         let mut client_configs = client_configs(&connection);
-        if SourceReadMode::ReadCommitted == *read_mode {
+        if let Some(SourceReadMode::ReadCommitted) = read_mode {
             client_configs.insert("isolation.level".to_string(), "read_committed".to_string());
         }
 
@@ -294,7 +294,6 @@ where
 
                         }
                     }
-
                 }
             }
         }

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::operators::{SerializationMode, UserError};
 
-use super::{client_configs, KafkaConfig, KafkaTable, TableType};
+use super::{client_configs, KafkaConfig, KafkaTable, SourceReadMode, TableType};
 
 #[cfg(test)]
 mod test;
@@ -85,9 +85,13 @@ where
             .expect("Invalid connection config for KafkaSource");
         let table: KafkaTable =
             serde_json::from_value(config.table).expect("Invalid table config for KafkaSource");
-        let TableType::Source{ offset, .. } = &table.type_ else {
+        let TableType::Source{ offset, read_mode } = &table.type_ else {
             panic!("found non-source kafka config in source operator");
         };
+        let mut client_configs = client_configs(&connection);
+        if SourceReadMode::ReadCommitted == *read_mode {
+            client_configs.insert("isolation.level".to_string(), "read_committed".to_string());
+        }
 
         Self {
             topic: table.topic,
@@ -104,7 +108,7 @@ where
                     unimplemented!("parquet out of kafka source doesn't make sense")
                 }
             },
-            client_configs: client_configs(&connection),
+            client_configs,
             messages_per_second: NonZeroU32::new(
                 config
                     .rate_limit

--- a/arroyo-worker/src/connectors/two_phase_committer.rs
+++ b/arroyo-worker/src/connectors/two_phase_committer.rs
@@ -177,18 +177,4 @@ impl<K: Key, T: Data + Sync, TPC: TwoPhaseCommitter<K, T>> TwoPhaseCommitterOper
             .await
             .expect("sent commit event");
     }
-
-    async fn handle_raw_control_message(
-        &mut self,
-        control_message: arroyo_rpc::ControlMessage,
-        ctx: &mut Context<(), ()>,
-    ) {
-        match control_message {
-            arroyo_rpc::ControlMessage::Checkpoint(_) => warn!("shouldn't receive checkpoint"),
-            arroyo_rpc::ControlMessage::Stop { mode: _ } => warn!("shouldn't receive stop"),
-            arroyo_rpc::ControlMessage::Commit { epoch } => {
-                self.handle_commit(epoch, ctx).await;
-            }
-        }
-    }
 }

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -22,10 +22,19 @@
                                 "earliest",
                                 "latest"
                             ]
+                        },
+                        "read_mode": {
+                            "type": "string",
+                            "description": "Type of reading behavior for Kafka Source",
+                            "enum": [
+                                "read_committed",
+                                "read_uncommitted"
+                            ]
                         }
                     },
                     "required": [
-                        "offset"
+                        "offset",
+                        "read_mode"
                     ],
                     "additionalProperties": false
                 },
@@ -33,7 +42,18 @@
                     "type": "object",
                     "title": "Sink",
                     "properties": {
+                        "commit_mode": {
+                            "type": "string",
+                            "description": "Type of committing behavior for Kafka Sink",
+                            "enum": [
+                                "at_least_once",
+                                "exactly_once"
+                            ]
+                        }
                     },
+                    "required": [
+                        "commit_mode"
+                    ],
                     "additionalProperties": false
                 }
             ]

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -33,8 +33,7 @@
                         }
                     },
                     "required": [
-                        "offset",
-                        "read_mode"
+                        "offset"
                     ],
                     "additionalProperties": false
                 },
@@ -44,16 +43,13 @@
                     "properties": {
                         "commit_mode": {
                             "type": "string",
-                            "description": "Type of committing behavior for Kafka Sink",
+                            "description": "Committing behavior for Kafka Sink. For transactional commits, use `exactly_once`. For non-transactional commits, use `at_least_once`. ",
                             "enum": [
                                 "at_least_once",
                                 "exactly_once"
                             ]
                         }
                     },
-                    "required": [
-                        "commit_mode"
-                    ],
                     "additionalProperties": false
                 }
             ]


### PR DESCRIPTION
Using the transactional kafka APIs we now support putting writing to Kafka via transactions. For each subtask a new kafka producer is created on each checkpoint, which writes all of the data within the checkpoint for that subtask in one transaction. When a checkpoint barrier is received it will switch initialize a new producer, while keeping the old one around for a commit message.

Currently we don't support recovering if the pipeline is interrupted after the checkpoints have been created but before the checkpoint is committed. The semantics of this are pretty tricky and there are a number of approaches with various safety and reliability tradeoffs. Flink, for instance, interrogates the internal transaction state from __transaction_state and then uses reflection to rebuild internal state. I don't think this is an option given the libraries we're using. Another approach that should work is to reliably determine if the previous transaction was successfully committed and, if not, replay the data by reading the uncommitted records off of kafka into a new commit. This will require careful management of active transactions, as Kafka doesn't directly expose the commit state of prior transaction.

I've also added the ability to only have our Kafka sources read committed data, via `read_mode` values of `read_uncommitted` and `read_committed`.

I'd appreciate feedback on the naming of the parameters? For things like kafka configs, should we be using the same names as the underlying service, maybe prefixed by the service? In our case, this'd mean that instead of `read_mode` we use `kafka.isolation.level`. 
