### PR TITLE
Unify job ids

### DIFF
--- a/arroyo-api/migrations/V14__unify_job_ids.sql
+++ b/arroyo-api/migrations/V14__unify_job_ids.sql
@@ -1,0 +1,19 @@
+-- going forward the 'id' column will be used to store the public id
+
+ALTER TABLE job_configs
+DROP COLUMN pub_id;
+
+ALTER TABLE job_configs
+ALTER COLUMN id TYPE VARCHAR;
+
+ALTER TABLE job_configs
+ADD CONSTRAINT job_configs_unique_id UNIQUE (id);
+
+ALTER TABLE checkpoints
+ALTER COLUMN job_id TYPE VARCHAR;
+
+ALTER TABLE job_statuses
+ALTER COLUMN id TYPE VARCHAR;
+
+ALTER TABLE job_log_messages
+ALTER COLUMN job_id TYPE VARCHAR;

--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -136,8 +136,8 @@ WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
-(pub_id, id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros)
-VALUES (:pub_id, :id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros);
+(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros)
+VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros);
 
 --! create_job_status
 INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :organization_id);
@@ -151,7 +151,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
 --! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, run_id?)
-SELECT job_configs.id, job_configs.pub_id, stop, start_time, finish_time, state, tasks, failure_message, run_id, checkpoint_interval_micros, job_configs.created_at
+SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, run_id, checkpoint_interval_micros, job_configs.created_at
 FROM job_configs
          LEFT JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -265,7 +265,7 @@ impl Into<Pipeline> for DbPipelineRest {
 impl Into<Job> for DbPipelineJob {
     fn into(self) -> Job {
         Job {
-            id: self.pub_id,
+            id: self.id,
             running_desired: self.stop == StopMode::none,
             state: self.state.unwrap_or_else(|| "Created".to_string()),
             run_id: self.run_id.unwrap_or(0) as u64,


### PR DESCRIPTION
Drop the 'pub_id' column of the job_configs table in favor of the 'id' column, and store the public id in that column.