### PR TITLE
Stream job output using server-sent events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "cornucopia_async",
  "deadpool-postgres",
  "futures",
+ "futures-util",
  "http",
  "jwt-simple",
  "once_cell",

--- a/arroyo-api/Cargo.toml
+++ b/arroyo-api/Cargo.toml
@@ -37,7 +37,7 @@ petgraph = {version = "0.6", features = ["serde-1"]}
 
 http = "0.2"
 tower-http = {version = "0.4", features = ["trace", "fs", "cors", "validate-request", "auth"]}
-axum = {version = "0.6.12", features = ["headers"]}
+axum = {version = "0.6.12", features = ["headers", "tokio"]}
 axum-extra = "0.7.4"
 thiserror = "1.0.40"
 utoipa = "3"
@@ -71,6 +71,7 @@ postgres-types = { version = "*", features = ["derive"] }
 tokio-postgres = { version = "*", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
 deadpool-postgres = { version = "0.10" }
 futures = "0.3"
+futures-util = "0.3.28"
 time = "0.3"
 cornucopia_async = { version = "0.4", features = ["with-serde_json-1"] }
 jwt-simple = "0.11.4"

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -17,7 +17,7 @@ use tower_http::services::ServeDir;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::jobs::{get_job_checkpoints, get_job_errors, get_jobs};
+use crate::jobs::{get_job_checkpoints, get_job_errors, get_job_output, get_jobs};
 use crate::pipelines::{
     delete_pipeline, get_pipeline, get_pipeline_jobs, get_pipelines, patch_pipeline, post_pipeline,
     validate_pipeline,
@@ -86,7 +86,8 @@ pub fn create_rest_app(server: ApiServer, pool: Pool) -> Router {
     let jobs_routes = Router::new()
         .route("/", get(get_pipeline_jobs))
         .route("/:job_id/errors", get(get_job_errors))
-        .route("/:job_id/checkpoints", get(get_job_checkpoints));
+        .route("/:job_id/checkpoints", get(get_job_checkpoints))
+        .route("/:job_id/output", get(get_job_output));
 
     let api_routes = Router::new()
         .route("/ping", get(ping))

--- a/arroyo-api/src/rest_types.rs
+++ b/arroyo-api/src/rest_types.rs
@@ -1,6 +1,7 @@
 use crate::types::public::LogLevel;
 use crate::types::public::StopMode;
 use arroyo_datastream::Program;
+use arroyo_rpc::grpc;
 use arroyo_rpc::grpc::api;
 use petgraph::visit::EdgeRef;
 use serde::{Deserialize, Serialize};
@@ -127,14 +128,14 @@ impl From<StopMode> for StopType {
     }
 }
 
-impl Into<arroyo_rpc::grpc::api::StopType> for StopType {
-    fn into(self) -> arroyo_rpc::grpc::api::StopType {
+impl Into<api::StopType> for StopType {
+    fn into(self) -> api::StopType {
         match self {
-            StopType::None => arroyo_rpc::grpc::api::StopType::None,
-            StopType::Checkpoint => arroyo_rpc::grpc::api::StopType::Checkpoint,
-            StopType::Graceful => arroyo_rpc::grpc::api::StopType::Graceful,
-            StopType::Immediate => arroyo_rpc::grpc::api::StopType::Immediate,
-            StopType::Force => arroyo_rpc::grpc::api::StopType::Force,
+            StopType::None => api::StopType::None,
+            StopType::Checkpoint => api::StopType::Checkpoint,
+            StopType::Graceful => api::StopType::Graceful,
+            StopType::Immediate => api::StopType::Immediate,
+            StopType::Force => api::StopType::Force,
         }
     }
 }
@@ -244,4 +245,24 @@ pub struct Checkpoint {
 pub struct Collection<T> {
     pub data: Vec<T>,
     pub has_more: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputData {
+    pub operator_id: String,
+    pub timestamp: u64,
+    pub key: String,
+    pub value: String,
+}
+
+impl From<grpc::OutputData> for OutputData {
+    fn from(value: grpc::OutputData) -> Self {
+        OutputData {
+            operator_id: value.operator_id,
+            timestamp: value.timestamp,
+            key: value.key,
+            value: value.value,
+        }
+    }
 }

--- a/arroyo-console/src/gen/api-types.ts
+++ b/arroyo-console/src/gen/api-types.ts
@@ -74,6 +74,13 @@ export interface paths {
      */
     get: operations["get_job_errors"];
   };
+  "/v1/pipelines/{pipeline_id}/jobs/{job_id}/output": {
+    /**
+     * Subscribe to a job's output 
+     * @description Subscribe to a job's output
+     */
+    get: operations["get_job_output"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -128,6 +135,13 @@ export interface components {
     JobLogMessageCollection: {
       data: (components["schemas"]["JobLogMessage"])[];
       hasMore: boolean;
+    };
+    OutputData: {
+      key: string;
+      operatorId: string;
+      /** Format: int64 */
+      timestamp: number;
+      value: string;
     };
     Pipeline: {
       action?: components["schemas"]["StopType"] | null;
@@ -402,6 +416,24 @@ export interface operations {
           "application/json": components["schemas"]["JobLogMessageCollection"];
         };
       };
+    };
+  };
+  /**
+   * Subscribe to a job's output 
+   * @description Subscribe to a job's output
+   */
+  get_job_output: {
+    parameters: {
+      path: {
+        /** @description Pipeline id */
+        pipeline_id: string;
+        /** @description Job id */
+        job_id: string;
+      };
+    };
+    responses: {
+      /** @description Job output as 'text/event-stream' */
+      200: never;
     };
   };
 }

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -17,6 +17,7 @@ export type StopType = schemas['StopType'];
 export type PipelineGraph = schemas['PipelineGraph'];
 export type JobLogMessage = schemas['JobLogMessage'];
 export type PipelineNode = schemas['PipelineNode'];
+export type OutputData = schemas['OutputData'];
 
 const BASE_URL = 'http://localhost:8000/api';
 export const { get, post, patch, del } = createClient<paths>({ baseUrl: BASE_URL });
@@ -363,4 +364,14 @@ export const useOperatorErrors = (pipelineId?: string, jobId?: string) => {
   return {
     operatorErrors: data?.data,
   };
+};
+
+export const useJobOutput = (
+  handler: (event: MessageEvent) => void,
+  pipelineId?: string,
+  jobId?: string
+) => {
+  const url = `${BASE_URL}/v1/pipelines/${pipelineId}/jobs/${jobId}/output`;
+  const eventSource = new EventSource(url);
+  eventSource.addEventListener('message', handler);
 };

--- a/arroyo-console/src/routes/pipelines/PipelineOutputs.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineOutputs.tsx
@@ -1,6 +1,6 @@
 import { Th, Td, Tr, Table, Thead, Tbody } from '@chakra-ui/react';
 import { ReactElement } from 'react';
-import { OutputData } from '../../gen/api_pb';
+import { OutputData } from '../../lib/data_fetching';
 
 export function PipelineOutputs({ outputs }: { outputs: Array<{ id: number; data: OutputData }> }) {
   let headers: Array<ReactElement> = [];
@@ -13,7 +13,7 @@ export function PipelineOutputs({ outputs }: { outputs: Array<{ id: number; data
 
       if (headers.length == 0) {
         Object.keys(parsed).forEach(k => {
-          headers.push(<Th>{k}</Th>);
+          headers.push(<Th key={k}>{k}</Th>);
         });
       }
 
@@ -23,8 +23,8 @@ export function PipelineOutputs({ outputs }: { outputs: Array<{ id: number; data
 
       return (
         <Tr key={row.id}>
-          <Th>{row.id}</Th>
-          <Th>
+          <Th key={'row'}>{row.id + 1}</Th>
+          <Th key={'date'}>
             {new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'long' }).format(
               new Date(Number(output.timestamp) / 1000)
             )}


### PR DESCRIPTION
Add an endpoint to the REST API to stream the job output using Server-Sent Events. Consume the output in the console.