### PR TITLE
Move rest types to arroyo-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "utoipa",
 ]
 
 [[package]]

--- a/arroyo-api/src/lib.rs
+++ b/arroyo-api/src/lib.rs
@@ -9,12 +9,6 @@ use crate::pipelines::{
     __path_validate_pipeline,
 };
 use crate::rest::__path_ping;
-use crate::rest_types::{
-    Checkpoint, CheckpointCollection, Job, JobCollection, JobLogLevel, JobLogMessage,
-    JobLogMessageCollection, Metric, MetricGroup, MetricNames, OperatorMetricGroup, OutputData,
-    Pipeline, PipelineCollection, PipelineEdge, PipelineGraph, PipelineNode, PipelinePatch,
-    PipelinePost, StopType as StopTypeRest, SubtaskMetrics, Udf, UdfLanguage, ValidatePipelinePost,
-};
 use crate::rest_utils::ErrorResp;
 use arroyo_connectors::connectors;
 use arroyo_rpc::grpc::api::{
@@ -31,6 +25,12 @@ use arroyo_rpc::grpc::api::{
     DeleteConnectionTableReq, DeleteConnectionTableResp, DeleteJobReq, DeleteJobResp,
     GetConnectionTablesReq, GetConnectionTablesResp, GetConnectorsReq, GetConnectorsResp,
     PipelineProgram, TestSchemaReq, TestSchemaResp,
+};
+use arroyo_rpc::types::{
+    Checkpoint, CheckpointCollection, Job, JobCollection, JobLogLevel, JobLogMessage,
+    JobLogMessageCollection, Metric, MetricGroup, MetricNames, OperatorMetricGroup, OutputData,
+    Pipeline, PipelineCollection, PipelineEdge, PipelineGraph, PipelineNode, PipelinePatch,
+    PipelinePost, StopType as StopTypeRest, SubtaskMetrics, Udf, UdfLanguage, ValidatePipelinePost,
 };
 use arroyo_server_common::log_event;
 use cornucopia_async::GenericClient;
@@ -55,7 +55,6 @@ mod metrics;
 mod optimizations;
 mod pipelines;
 pub mod rest;
-mod rest_types;
 mod rest_utils;
 
 include!(concat!(env!("OUT_DIR"), "/api-sql.rs"));

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1", features = ["full"] }
 bincode = "2.0.0-rc.3"
 serde = {version = "1.0", features = ["derive"]}
 nanoid = "0.4"
+utoipa = "3"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod public_ids;
+pub mod types;
 
 use std::{fs, time::SystemTime};
 


### PR DESCRIPTION
In order to remove some protobuf types we need their replacements to be usable by the same dependencies. Keeping these types in in arroyo-rpc allows that.