### PR TITLE
Use REST API for connectors

### DIFF
--- a/arroyo-api/src/connectors.rs
+++ b/arroyo-api/src/connectors.rs
@@ -1,0 +1,27 @@
+use crate::rest_utils::ErrorResp;
+use arroyo_connectors::connectors;
+use arroyo_rpc::types::ConnectorCollection;
+use axum::Json;
+
+/// List all connectors
+#[utoipa::path(
+    get,
+    path = "/v1/connectors",
+    tag = "connectors",
+    responses(
+        (status = 200, description = "Got connectors collection", body = ConnectorCollection),
+    ),
+)]
+pub async fn get_connectors() -> Result<Json<ConnectorCollection>, ErrorResp> {
+    let mut connectors: Vec<_> = connectors()
+        .values()
+        .map(|c| c.metadata())
+        .filter(|metadata| !metadata.hidden)
+        .collect();
+
+    connectors.sort_by_cached_key(|c| c.name.clone());
+    Ok(Json(ConnectorCollection {
+        data: connectors,
+        has_more: false,
+    }))
+}

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -17,6 +17,7 @@ use tower_http::services::ServeDir;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use crate::connectors::get_connectors;
 use crate::jobs::{get_job_checkpoints, get_job_errors, get_job_output, get_jobs};
 use crate::metrics::get_operator_metric_groups;
 use crate::pipelines::{
@@ -96,6 +97,7 @@ pub fn create_rest_app(server: ApiServer, pool: Pool) -> Router {
 
     let api_routes = Router::new()
         .route("/ping", get(ping))
+        .route("/connectors", get(get_connectors))
         .route("/pipelines", post(post_pipeline))
         .route("/pipelines", get(get_pipelines))
         .route("/jobs", get(get_jobs))

--- a/arroyo-connectors/src/blackhole.rs
+++ b/arroyo-connectors/src/blackhole.rs
@@ -17,8 +17,8 @@ impl Connector for BlackholeConnector {
         "null"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "blackhole".to_string(),
             name: "Blackhole".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/filesystem.rs
+++ b/arroyo-connectors/src/filesystem.rs
@@ -28,8 +28,8 @@ impl Connector for FileSystemConnector {
         "filesystem"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "filesystem".to_string(),
             name: "FileSystem Sink".to_string(),
             icon: "".to_string(),

--- a/arroyo-connectors/src/fluvio.rs
+++ b/arroyo-connectors/src/fluvio.rs
@@ -26,8 +26,8 @@ impl Connector for FluvioConnector {
         "fluvio"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "fluvio".to_string(),
             name: "Fluvio".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/impulse.rs
+++ b/arroyo-connectors/src/impulse.rs
@@ -41,8 +41,8 @@ impl Connector for ImpulseConnector {
         "impulse"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "impulse".to_string(),
             name: "Impulse".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -38,8 +38,8 @@ impl Connector for KafkaConnector {
         "kafka"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "kafka".to_string(),
             name: "Kafka".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -89,7 +89,7 @@ pub trait Connector: Send {
         serde_json::from_str(s)
     }
 
-    fn metadata(&self) -> grpc::api::Connector;
+    fn metadata(&self) -> arroyo_rpc::types::Connector;
 
     fn table_type(&self, config: Self::ConfigT, table: Self::TableT) -> TableType;
 
@@ -132,7 +132,7 @@ pub trait Connector: Send {
 pub trait ErasedConnector: Send {
     fn name(&self) -> &'static str;
 
-    fn metadata(&self) -> grpc::api::Connector;
+    fn metadata(&self) -> arroyo_rpc::types::Connector;
 
     fn validate_config(&self, s: &str) -> Result<(), serde_json::Error>;
 
@@ -180,7 +180,7 @@ impl<C: Connector> ErasedConnector for C {
         self.name()
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
         self.metadata()
     }
 

--- a/arroyo-connectors/src/nexmark.rs
+++ b/arroyo-connectors/src/nexmark.rs
@@ -88,8 +88,8 @@ impl Connector for NexmarkConnector {
         "nexmark"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "nexmark".to_string(),
             name: "Nexmark".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/sse.rs
+++ b/arroyo-connectors/src/sse.rs
@@ -36,8 +36,8 @@ impl Connector for SSEConnector {
         "sse"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "sse".to_string(),
             name: "Server-Sent Events".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-connectors/src/websocket.rs
+++ b/arroyo-connectors/src/websocket.rs
@@ -35,8 +35,8 @@ impl Connector for WebsocketConnector {
         "websocket"
     }
 
-    fn metadata(&self) -> grpc::api::Connector {
-        grpc::api::Connector {
+    fn metadata(&self) -> arroyo_rpc::types::Connector {
+        arroyo_rpc::types::Connector {
             id: "websocket".to_string(),
             name: "Websocket".to_string(),
             icon: ICON.to_string(),

--- a/arroyo-console/src/components/Checkpoints.tsx
+++ b/arroyo-console/src/components/Checkpoints.tsx
@@ -1,4 +1,3 @@
-import { CheckpointOverview } from '../gen/api_pb';
 import React, { useState } from 'react';
 import {
   Badge,
@@ -15,7 +14,7 @@ import {
   UnorderedList,
 } from '@chakra-ui/react';
 import * as util from '../lib/util';
-import { Job, Pipeline, useCheckpointDetails } from '../lib/data_fetching';
+import { Checkpoint, Job, Pipeline, useCheckpointDetails } from '../lib/data_fetching';
 import { ApiClient } from '../main';
 import CheckpointDetails from './CheckpointDetails';
 
@@ -23,7 +22,7 @@ export interface CheckpointsProps {
   client: ApiClient;
   pipeline: Pipeline;
   job: Job;
-  checkpoints: Array<CheckpointOverview>;
+  checkpoints: Array<Checkpoint>;
 }
 
 function formatDurationHMS(micros: number): string {

--- a/arroyo-console/src/components/OperatorDetail.tsx
+++ b/arroyo-console/src/components/OperatorDetail.tsx
@@ -3,7 +3,7 @@ import { getCurrentMaxMetric, transformMetricGroup } from '../lib/util';
 import React from 'react';
 import { TimeSeriesGraph } from './TimeSeriesGraph';
 import Loading from './Loading';
-import { PipelineNode, useJobMetrics, usePipeline } from '../lib/data_fetching';
+import { useJobMetrics, usePipeline } from '../lib/data_fetching';
 
 export interface OperatorDetailProps {
   pipelineId: string;
@@ -15,11 +15,11 @@ const OperatorDetail: React.FC<OperatorDetailProps> = ({ pipelineId, jobId, oper
   const { pipeline } = usePipeline(pipelineId);
   const { operatorMetricGroups } = useJobMetrics(pipelineId, jobId);
 
-  if (!operatorMetricGroups) {
+  if (!pipeline || !operatorMetricGroups) {
     return <Loading size={'lg'} />;
   }
 
-  const node = (pipeline.graph.nodes as PipelineNode[]).find(n => n.nodeId == operatorId);
+  const node = pipeline.graph.nodes.find(n => n.nodeId == operatorId);
   const operatorMetricGroup = operatorMetricGroups.find(o => o.operatorId == operatorId);
 
   if (!operatorMetricGroup) {

--- a/arroyo-console/src/components/PipelineRow.tsx
+++ b/arroyo-console/src/components/PipelineRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Job, Pipeline, usePipelineJobs } from '../lib/data_fetching';
+import { Pipeline, usePipelineJobs } from '../lib/data_fetching';
 import { IconButton, Link, Td, Tr } from '@chakra-ui/react';
 import { JobStatus } from '../gen/api_pb';
 import JobCard from './JobCard';
@@ -74,7 +74,7 @@ const PipelineRow: React.FC<PipelineRowProps> = ({
         />
       </Td>
       <Td key={'job'}>
-        {(jobs as Job[]).map(job => (
+        {jobs.map(job => (
           <JobCard key={job.id} job={job} />
         ))}
       </Td>

--- a/arroyo-console/src/components/PipelinesTable.tsx
+++ b/arroyo-console/src/components/PipelinesTable.tsx
@@ -21,7 +21,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import React, { useRef, useState } from 'react';
-import { usePipelines, usePipeline, Pipeline } from '../lib/data_fetching';
+import { usePipelines, usePipeline } from '../lib/data_fetching';
 import PipelineRow from './PipelineRow';
 import { formatError } from '../lib/util';
 
@@ -119,7 +119,7 @@ const PipelinesTable: React.FC<JobsTableProps> = ({}) => {
 
   const tableBody = (
     <Tbody>
-      {(pipelines as Pipeline[])?.flatMap(pipeline => (
+      {pipelines?.flatMap(pipeline => (
         <PipelineRow
           key={pipeline.id}
           pipeline={pipeline}

--- a/arroyo-console/src/gen/api-types.ts
+++ b/arroyo-console/src/gen/api-types.ts
@@ -5,6 +5,13 @@
 
 
 export interface paths {
+  "/v1/connectors": {
+    /**
+     * List all connectors 
+     * @description List all connectors
+     */
+    get: operations["get_connectors"];
+  };
   "/v1/jobs": {
     /**
      * Get all jobs 
@@ -105,6 +112,24 @@ export interface components {
     };
     CheckpointCollection: {
       data: (components["schemas"]["Checkpoint"])[];
+      hasMore: boolean;
+    };
+    Connector: {
+      connectionConfig?: string | null;
+      customSchemas: boolean;
+      description: string;
+      enabled: boolean;
+      hidden: boolean;
+      icon: string;
+      id: string;
+      name: string;
+      sink: boolean;
+      source: boolean;
+      tableConfig: string;
+      testing: boolean;
+    };
+    ConnectorCollection: {
+      data: (components["schemas"]["Connector"])[];
       hasMore: boolean;
     };
     Job: {
@@ -251,6 +276,20 @@ export type external = Record<string, never>;
 
 export interface operations {
 
+  /**
+   * List all connectors 
+   * @description List all connectors
+   */
+  get_connectors: {
+    responses: {
+      /** @description Got connectors collection */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ConnectorCollection"];
+        };
+      };
+    };
+  };
   /**
    * Get all jobs 
    * @description Get all jobs

--- a/arroyo-console/src/main.tsx
+++ b/arroyo-console/src/main.tsx
@@ -43,7 +43,7 @@ export function Router(): JSX.Element {
     },
     {
       path: 'connections/new',
-      element: <ChooseConnector client={client} />,
+      element: <ChooseConnector />,
     },
     {
       path: 'connections/new/:connectorId',

--- a/arroyo-console/src/routes/connections/ChooseConnector.tsx
+++ b/arroyo-console/src/routes/connections/ChooseConnector.tsx
@@ -16,15 +16,14 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react';
-import { ApiClient } from '../../main';
 import { useNavigate } from 'react-router-dom';
 import { useConnectors } from '../../lib/data_fetching';
 
-export function ChooseConnector({ client }: { client: ApiClient }) {
+export function ChooseConnector() {
   const navigate = useNavigate();
-  const { connectors } = useConnectors(client);
+  const { connectors } = useConnectors();
 
-  const connectorCards = connectors?.connectors.map(c => {
+  const connectorCards = connectors?.map(c => {
     return (
       <Card key={c.name} size={'md'} maxW={400}>
         <Text fontSize={'12px'} p={2} w={'100%'} bgColor={'gray.600'} color={'blue.100'}>

--- a/arroyo-console/src/routes/connections/ConfigureConnection.tsx
+++ b/arroyo-console/src/routes/connections/ConfigureConnection.tsx
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from 'json-schema';
-import { Connection, Connector, CreateConnectionReq } from '../../gen/api_pb';
+import { Connection, CreateConnectionReq } from '../../gen/api_pb';
 import { ApiClient } from '../../main';
 import {
   Button,
@@ -23,7 +23,7 @@ import { useState } from 'react';
 import { JsonForm } from './JsonForm';
 import { ConnectError } from '@bufbuild/connect-web';
 import { AddIcon } from '@chakra-ui/icons';
-import { useConnections } from '../../lib/data_fetching';
+import { Connector, useConnections } from '../../lib/data_fetching';
 import { CreateConnectionState } from './CreateConnection';
 
 const ClusterEditor = ({

--- a/arroyo-console/src/routes/connections/ConnectionTester.tsx
+++ b/arroyo-console/src/routes/connections/ConnectionTester.tsx
@@ -24,9 +24,10 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Connector, CreateConnectionTableReq, TestSourceMessage } from '../../gen/api_pb';
+import { CreateConnectionTableReq, TestSourceMessage } from '../../gen/api_pb';
 import { ConnectError } from '@bufbuild/connect-web';
 import { useNavigate } from 'react-router-dom';
+import { Connector } from '../../lib/data_fetching';
 
 export function ConnectionTester({
   connector,

--- a/arroyo-console/src/routes/connections/CreateConnection.tsx
+++ b/arroyo-console/src/routes/connections/CreateConnection.tsx
@@ -18,13 +18,13 @@ import {
   Stepper,
   useSteps,
 } from '@chakra-ui/react';
-import { useConnectors } from '../../lib/data_fetching';
+import { Connector, useConnectors } from '../../lib/data_fetching';
 import { useEffect, useState } from 'react';
-import { ConnectionSchema, Connector } from '../../gen/api_pb';
 
 import { ConfigureConnection } from './ConfigureConnection';
 import { DefineSchema } from './DefineSchema';
 import { ConnectionTester } from './ConnectionTester';
+import { ConnectionSchema } from '../../gen/api_pb';
 
 export type CreateConnectionState = {
   name: string | undefined;
@@ -129,11 +129,11 @@ export const ConnectionCreator = ({
 
 export const CreateConnection = ({ client }: { client: ApiClient }) => {
   let { connectorId } = useParams();
-  let { connectors, connectorsLoading } = useConnectors(client);
+  let { connectors, connectorsLoading } = useConnectors();
 
   let navigate = useNavigate();
 
-  let connector = connectors?.connectors.find(c => c.id === connectorId);
+  let connector = connectors?.find(c => c.id === connectorId);
 
   useEffect(() => {
     if (connectors != null && connector == null) {

--- a/arroyo-console/src/routes/connections/DefineSchema.tsx
+++ b/arroyo-console/src/routes/connections/DefineSchema.tsx
@@ -2,9 +2,10 @@ import { Button, Code, FormControl, FormLabel, Link, Select, Stack, Text } from 
 import React, { Dispatch } from 'react';
 import { CreateConnectionState } from './CreateConnection';
 import { ApiClient } from '../../main';
-import { ConnectionSchema, Connector, Format, FormatOptions } from '../../gen/api_pb';
+import { ConnectionSchema, Format, FormatOptions } from '../../gen/api_pb';
 import { ConfluentSchemaEditor } from './ConfluentSchemaEditor';
 import { JsonSchemaEditor } from './JsonSchemaEditor';
+import { Connector } from '../../lib/data_fetching';
 
 const JsonEditor = ({
   connector,

--- a/arroyo-console/src/routes/home/Home.tsx
+++ b/arroyo-console/src/routes/home/Home.tsx
@@ -11,7 +11,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
-import { Job, useJobs } from '../../lib/data_fetching';
+import { useJobs } from '../../lib/data_fetching';
 import Loading from '../../components/Loading';
 
 interface Props {
@@ -56,11 +56,11 @@ export function Home() {
   }
 
   if (jobs) {
-    runningJobs = (jobs as Job[]).filter(
+    runningJobs = jobs.filter(
       j => j.state == 'Running' || j.state == 'Checkpointing' || j.state == 'Compacting'
     ).length;
     allJobs = jobs.length;
-    failedJobs = (jobs as Job[]).filter(j => j.state == 'Failed').length;
+    failedJobs = jobs.filter(j => j.state == 'Failed').length;
   }
 
   return (

--- a/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
@@ -31,7 +31,6 @@ import { CodeEditor } from './SqlEditor';
 import PipelineConfigModal from './PipelineConfigModal';
 import {
   OutputData,
-  PipelineNode,
   StopType,
   useJobCheckpoints,
   useJobOutput,
@@ -161,8 +160,7 @@ export function PipelineDetails({ client }: { client: ApiClient }) {
   const outputsTab = (
     <TabPanel w={'100%'}>
       {outputs.length == 0 ? (
-        (pipeline.graph.nodes as PipelineNode[]).find(n => n.operator.includes('WebSink')) !=
-        null ? (
+        pipeline.graph.nodes.find(n => n.operator.includes('WebSink')) != null ? (
           <Button isLoading={subscribed} onClick={subscribe} width={150} size="sm">
             Read output
           </Button>
@@ -242,9 +240,7 @@ export function PipelineDetails({ client }: { client: ApiClient }) {
 
   let configModal = <></>;
   if (pipeline.graph.nodes) {
-    const parallelism = Math.max(
-      ...(pipeline.graph.nodes as PipelineNode[]).map(({ parallelism }) => parallelism)
-    );
+    const parallelism = Math.max(...pipeline.graph.nodes.map(({ parallelism }) => parallelism));
 
     configModal = (
       <PipelineConfigModal

--- a/arroyo-rpc/src/types.rs
+++ b/arroyo-rpc/src/types.rs
@@ -214,7 +214,8 @@ pub struct Checkpoint {
     PipelineCollection = Collection<Pipeline>,
     JobLogMessageCollection = Collection<JobLogMessage>,
     CheckpointCollection = Collection<Checkpoint>,
-    OperatorMetricGroupCollection = Collection<OperatorMetricGroup>
+    OperatorMetricGroupCollection = Collection<OperatorMetricGroup>,
+    ConnectorCollection = Collection<Connector>,
 )]
 pub struct Collection<T> {
     pub data: Vec<T>,
@@ -277,4 +278,21 @@ pub struct MetricGroup {
 pub struct OperatorMetricGroup {
     pub operator_id: String,
     pub metric_groups: Vec<MetricGroup>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Connector {
+    pub id: String,
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+    pub table_config: String,
+    pub enabled: bool,
+    pub source: bool,
+    pub sink: bool,
+    pub custom_schemas: bool,
+    pub testing: bool,
+    pub hidden: bool,
+    pub connection_config: Option<String>,
 }


### PR DESCRIPTION
Add an endpoint to the REST API to retrieve connectors. Use the new endpoint in the console.

Also change the useSWR calls for the REST API to explicitly set the data type. This removes implicit 'any' types and improves type safety.