### PR TITLE
Show API unavailable page on 5xx responses

### DIFF
--- a/arroyo-console/src/App.tsx
+++ b/arroyo-console/src/App.tsx
@@ -94,7 +94,7 @@ function Sidebar() {
 }
 
 function App() {
-  const { pingError } = usePing();
+  const { ping, pingError } = usePing();
 
   let content = (
     <GridItem className="main" area={'main'}>
@@ -102,7 +102,7 @@ function App() {
     </GridItem>
   );
 
-  if (pingError) {
+  if (!ping || pingError) {
     content = <ApiUnavailable />;
   }
 


### PR DESCRIPTION
With the change to proxy requests through the server the proxy now returns 500 responses when the API is unavailable. This changes the API unavailable page to be triggered by 500 responses.