### PR TITLE
sql: correctly constrain sql calculations.

### DIFF
--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -111,11 +111,6 @@ GROUP BY 2
 )
 WHERE auction % 2 = 0"}
 
-full_pipeline_codegen! {"sum_of_sums_updating",
-"SELECT bids, count(*) as occurrences FROM (
-  SELECT count(*) as bids, bid.auction as auction FROM nexmark where bid is not null group by 2)
-GROUP BY 1"}
-
 full_pipeline_codegen! {"create_parquet_s3_source",
 "CREATE TABLE bids (
   auction bigint,


### PR DESCRIPTION
We had a number of leaks where you could write queries that would not actually run correctly, such as nested non-window aggregates. This change patches them while we improve the overall SQL semantics.