### PR TITLE
Session windows

### DIFF
--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -1328,7 +1328,7 @@ impl Program {
                             };
 
                             quote! {
-                                WindowOperation::#operation(|key: #in_k, window: Window, mut arg: Vec<_>| {
+                                WindowOperation::#operation(|key: &#in_k, window: arroyo_types::Window, mut arg: Vec<_>| {
                                     #expr
                                 })
                             }

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -1328,7 +1328,7 @@ impl Program {
                             };
 
                             quote! {
-                                WindowOperation::#operation(|mut arg: Vec<_>| {
+                                WindowOperation::#operation(|key: #in_k, window: Window, mut arg: Vec<_>| {
                                     #expr
                                 })
                             }

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -109,6 +109,7 @@ pub enum WindowType {
     Tumbling { width: Duration },
     Sliding { width: Duration, slide: Duration },
     Instant,
+    Session { gap: Duration, }
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -145,6 +146,9 @@ impl Debug for WindowType {
             }
             Self::Instant => {
                 write!(f, "InstantWindow")
+            }
+            Self::Session { gap } => {
+                write!(f, "SessionWindow({})", format_duration(*gap))
             }
         }
     }
@@ -1355,6 +1359,14 @@ impl Program {
                                     instant_window(#agg))
                             }
                         }
+                        WindowType::Session { gap } => {
+                            let gap = duration_to_syn_expr(*gap);
+                            quote! {
+                                Box::new(SessionWindowFunc::<#in_k, #in_t, #out_t>::new(
+                                    #gap, #agg
+                                ))
+                            }
+                        }
                     }
                 }
                 Operator::Watermark(watermark) => {
@@ -1431,6 +1443,9 @@ impl Program {
                                 Box::new(WindowedHashJoin::<#in_k, #in_t1, #in_t2, InstantWindowAssigner, InstantWindowAssigner>::
                                     instant_window())
                             }
+                        }
+                        WindowType::Session { .. } => {
+                            unimplemented!("Session windows are not supported in joins")
                         }
                     }
                 }
@@ -2098,6 +2113,9 @@ impl From<WindowType> for GrpcApi::window::Window {
             WindowType::Instant => {
                 GrpcApi::window::Window::InstantWindow(GrpcApi::InstantWindow {})
             }
+            WindowType::Session { gap } => {
+                GrpcApi::window::Window::SessionWindow(GrpcApi::SessionWindow { gap_micros: gap.as_micros() as u64 })
+            }
         }
     }
 }
@@ -2386,6 +2404,9 @@ impl From<arroyo_rpc::grpc::api::Window> for WindowType {
                 }
             }
             Some(arroyo_rpc::grpc::api::window::Window::InstantWindow(_)) => WindowType::Instant,
+            Some(arroyo_rpc::grpc::api::window::Window::SessionWindow(session)) => {
+                WindowType::Session { gap: Duration::from_micros(session.gap_micros) }
+            }
             None => todo!(),
         }
     }

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -1363,7 +1363,7 @@ impl Program {
                             let gap = duration_to_syn_expr(*gap);
                             quote! {
                                 Box::new(SessionWindowFunc::<#in_k, #in_t, #out_t>::new(
-                                    #gap, #agg
+                                    #agg, #gap
                                 ))
                             }
                         }

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -109,7 +109,7 @@ pub enum WindowType {
     Tumbling { width: Duration },
     Sliding { width: Duration, slide: Duration },
     Instant,
-    Session { gap: Duration, }
+    Session { gap: Duration },
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -2114,7 +2114,9 @@ impl From<WindowType> for GrpcApi::window::Window {
                 GrpcApi::window::Window::InstantWindow(GrpcApi::InstantWindow {})
             }
             WindowType::Session { gap } => {
-                GrpcApi::window::Window::SessionWindow(GrpcApi::SessionWindow { gap_micros: gap.as_micros() as u64 })
+                GrpcApi::window::Window::SessionWindow(GrpcApi::SessionWindow {
+                    gap_micros: gap.as_micros() as u64,
+                })
             }
         }
     }
@@ -2405,7 +2407,9 @@ impl From<arroyo_rpc::grpc::api::Window> for WindowType {
             }
             Some(arroyo_rpc::grpc::api::window::Window::InstantWindow(_)) => WindowType::Instant,
             Some(arroyo_rpc::grpc::api::window::Window::SessionWindow(session)) => {
-                WindowType::Session { gap: Duration::from_micros(session.gap_micros) }
+                WindowType::Session {
+                    gap: Duration::from_micros(session.gap_micros),
+                }
             }
             None => todo!(),
         }

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -194,6 +194,7 @@ message Window {
     SlidingWindow sliding_window = 2;
     TumblingWindow tumbling_window = 3;
     InstantWindow instant_window = 4;
+    SessionWindow session_window = 5;
   }
 }
 
@@ -206,6 +207,10 @@ message TumblingWindow {
   uint64 size_micros = 1;
 }
 message InstantWindow {}
+
+message SessionWindow {
+  uint64 gap_micros = 1;
+}
 
 enum Aggregator {
   NONE = 0;

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -130,7 +130,8 @@ full_pipeline_codegen! {"cast_bug",
 "SELECT CAST(1 as FLOAT)
 from nexmark; "}
 
-full_pipeline_codegen! {"session_window",
+/* full_pipeline_codegen! {"session_window",
 "SELECT count(*), session(INTERVAL '2' SECOND, INTERVAL '10' SECOND) AS window
 from nexmark
 group by window, auction.id; "}
+ */

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -129,3 +129,8 @@ INSERT INTO Bids select bid.auction, bid.bidder, bid.price , bid.datetime FROM n
 full_pipeline_codegen! {"cast_bug",
 "SELECT CAST(1 as FLOAT)
 from nexmark; "}
+
+full_pipeline_codegen! {"session_window",
+"SELECT count(*), session(INTERVAL '2' SECOND, INTERVAL '10' SECOND) AS window
+from nexmark
+group by window, auction.id; "}

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -130,8 +130,7 @@ full_pipeline_codegen! {"cast_bug",
 "SELECT CAST(1 as FLOAT)
 from nexmark; "}
 
-/* full_pipeline_codegen! {"session_window",
-"SELECT count(*), session(INTERVAL '2' SECOND, INTERVAL '10' SECOND) AS window
+full_pipeline_codegen! {"session_window",
+"SELECT count(*), session(INTERVAL '10' SECOND) AS window
 from nexmark
 group by window, auction.id; "}
- */

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -90,6 +90,16 @@ impl ArroyoSchemaProvider {
             Arc::new(create_udf(
                 "tumble",
                 vec![DataType::Interval(datatypes::IntervalUnit::MonthDayNano)],
+                window_return_type.clone(),
+                Volatility::Volatile,
+                make_scalar_function(fn_impl),
+            )),
+        );
+        functions.insert(
+            "session".to_string(),
+            Arc::new(create_udf(
+                "session",
+                vec![DataType::Interval(datatypes::IntervalUnit::MonthDayNano)],
                 window_return_type,
                 Volatility::Volatile,
                 make_scalar_function(fn_impl),

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -278,8 +278,8 @@ impl GroupByKind {
             let field_name = format_ident!("{}", return_struct.fields[*index].field_name());
             let width_literal: LitInt = parse_str(&width.as_millis().to_string()).unwrap();
             assignments.push(quote!(#field_name: arroyo_types::Window{
-                        start_time: arg.timestamp - std::time::Duration::from_millis(#width_literal) + std::time::Duration::from_nanos(1),
-                        end_time: arg.timestamp + std::time::Duration::from_nanos(1)}));
+                        start: arg.timestamp - std::time::Duration::from_millis(#width_literal) + std::time::Duration::from_nanos(1),
+                        end: arg.timestamp + std::time::Duration::from_nanos(1)}));
         }
         let return_type = return_struct.get_type();
         let struct_expression = parse_quote!(

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -270,22 +270,14 @@ impl GroupByKind {
 
         if let GroupByKind::WindowOutput {
             index,
-            column: _,
-            window_type,
+            ..
         } = self
         {
-            let width = match window_type {
-                WindowType::Tumbling { width } | WindowType::Sliding { width, .. } => width,
-                WindowType::Instant => &Duration::ZERO,
-                WindowType::Session { gap } => todo!(),
-            };
-
             let field_name = format_ident!("{}", return_struct.fields[*index].field_name());
-            let width_literal: LitInt = parse_str(&width.as_millis().to_string()).unwrap();
             assignments.push(quote! {
                 #field_name: arroyo_types::Window {
-                    start: arg.timestamp - std::time::Duration::from_millis(#width_literal) + std::time::Duration::from_nanos(1),
-                    end: arg.timestamp + std::time::Duration::from_nanos(1)
+                    start: arg.timestamp,
+                    end: arg.timestamp
                 }
             });
         }

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::comparison_chain)]
-use std::time::Duration;
-
 use crate::{
     expressions::{AggregationExpression, Aggregator, Column, Expression},
     schemas::window_type_def,
@@ -8,12 +5,11 @@ use crate::{
 };
 use anyhow::Result;
 use arrow_schema::DataType;
-use arroyo_datastream::WindowType;
 use arroyo_types::formats::Format;
 use datafusion_expr::type_coercion::aggregates::{avg_return_type, sum_return_type};
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::{parse_quote, parse_str, Ident, LitInt};
+use quote::quote;
+use syn::{parse_quote, parse_str};
 
 #[derive(Debug, Clone)]
 pub struct Projection {
@@ -197,121 +193,6 @@ impl AggregateProjection {
         self.aggregates
             .iter()
             .all(|(_, computation)| computation.allows_two_phase())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum GroupByKind {
-    Basic,
-    // The aggregation is responsible for building the final struct
-    InAggregation,
-    WindowOutput {
-        index: usize,
-        column: Column,
-        window_type: WindowType,
-    },
-    Updating,
-}
-
-impl GroupByKind {
-    pub fn output_struct(&self, key_struct: &StructDef, aggregate_struct: &StructDef) -> StructDef {
-        let key_fields = key_struct.fields.len();
-        let aggregate_fields = aggregate_struct.fields.len();
-        match self {
-            GroupByKind::WindowOutput {
-                index,
-                column,
-                window_type: _,
-            } => {
-                let fields = (0..(key_fields + aggregate_fields + 1))
-                    .map(|i| {
-                        if i < key_fields + 1 {
-                            if i == *index {
-                                StructField::new(
-                                    column.name.clone(),
-                                    column.relation.clone(),
-                                    window_type_def(),
-                                )
-                            } else if i < *index {
-                                key_struct.fields[i].clone()
-                            } else {
-                                key_struct.fields[i - 1].clone()
-                            }
-                        } else {
-                            aggregate_struct.fields[i - key_fields - 1].clone()
-                        }
-                    })
-                    .collect();
-                StructDef::for_fields(fields)
-            }
-            GroupByKind::Basic | GroupByKind::Updating => {
-                let fields = (0..(key_fields + aggregate_fields))
-                    .map(|i| {
-                        if i < key_fields {
-                            key_struct.fields[i].clone()
-                        } else {
-                            aggregate_struct.fields[i - key_fields].clone()
-                        }
-                    })
-                    .collect();
-                StructDef::for_fields(fields)
-            }
-            GroupByKind::InAggregation => aggregate_struct.clone(),
-        }
-    }
-
-    pub fn to_syn_expression(
-        &self,
-        key_struct: &StructDef,
-        aggregate_struct: &StructDef,
-    ) -> syn::Expr {
-        let mut assignments: Vec<_> = vec![];
-
-        key_struct.fields.iter().for_each(|field| {
-            let field_name: Ident = format_ident!("{}", field.field_name());
-            assignments.push(quote!(#field_name : arg.key.#field_name.clone()));
-        });
-        aggregate_struct.fields.iter().for_each(|field| {
-            let field_name: Ident = format_ident!("{}", field.field_name());
-            assignments.push(quote!(#field_name : arg.aggregate.#field_name.clone()));
-        });
-        let return_struct = self.output_struct(key_struct, aggregate_struct);
-        if let GroupByKind::WindowOutput {
-            index,
-            column: _,
-            window_type,
-        } = self
-        {
-            let width = match window_type {
-                WindowType::Tumbling { width } | WindowType::Sliding { width, .. } => width,
-                WindowType::Instant => &Duration::ZERO,
-                WindowType::Session { .. } => {
-                    panic!("session windows cannot be planned with GroupByKind::WindowOutput")
-                }
-            };
-            let field_name = format_ident!("{}", return_struct.fields[*index].field_name());
-            let width_literal: LitInt = parse_str(&width.as_millis().to_string()).unwrap();
-            assignments.push(quote!(#field_name: arroyo_types::Window{
-                        start_time: arg.timestamp - std::time::Duration::from_millis(#width_literal) + std::time::Duration::from_nanos(1),
-                        end_time: arg.timestamp + std::time::Duration::from_nanos(1)}));
-        }
-        let return_type = return_struct.get_type();
-        let struct_expression = parse_quote!(
-            #return_type {
-                    #(#assignments)
-                    ,*
-                }
-        );
-        if matches!(self, GroupByKind::Updating) {
-            parse_quote!(
-                arg.aggregate.map(|subfield| {
-                    let arg =
-                    #struct_expression
-                })
-            )
-        } else {
-            struct_expression
-        }
     }
 }
 

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -250,6 +250,7 @@ impl Optimizer for TwoPhaseOptimization {
             WindowType::Tumbling { width } => (width, width),
             WindowType::Sliding { width, slide } => (width, slide),
             WindowType::Instant => (Duration::ZERO, Duration::ZERO),
+            WindowType::Session { .. } => return false,
         };
         if !slide.is_zero() && width.as_micros() % slide.as_micros() != 0 {
             return false;

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -416,6 +416,7 @@ impl Optimizer for WindowTopNOptimization {
                             WindowType::Tumbling { width } => (width, width),
                             WindowType::Sliding { width, slide } => (width, slide),
                             WindowType::Instant => (Duration::ZERO, Duration::ZERO),
+                            WindowType::Session { .. } => { return false; },
                         };
                         if width.as_micros() % slide.as_micros() != 0 {
                             self.clear();

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -22,7 +22,7 @@ use crate::schemas::window_type_def;
 use crate::tables::{Insert, Table};
 use crate::{
     expressions::{AggregationExpression, Column, ColumnExpression, Expression, SortExpression},
-    operators::{AggregateProjection, GroupByKind, Projection},
+    operators::{AggregateProjection, Projection},
     types::{interval_month_day_nanos_to_duration, StructDef, StructField, TypeDef},
     ArroyoSchemaProvider,
 };
@@ -132,7 +132,6 @@ pub struct AggregateOperator {
     pub key: Projection,
     pub window: WindowType,
     pub aggregating: AggregateProjection,
-    pub merge: GroupByKind,
 }
 
 impl AggregateOperator {
@@ -616,7 +615,6 @@ impl<'a> SqlPipelineBuilder<'a> {
                 key,
                 window,
                 aggregating,
-                merge: GroupByKind::InAggregation,
             },
         ))
     }

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -14,10 +14,12 @@ use datafusion_expr::expr::ScalarUDF;
 use datafusion_expr::{BuiltInWindowFunction, Expr, JoinConstraint, LogicalPlan, Window, WriteOp};
 
 use quote::{format_ident, quote};
-use syn::{parse_quote, Type};
+use syn::punctuated::Punctuated;
+use syn::{parse_quote, Type, ExprPath, Path};
 
 use crate::expressions::ExpressionContext;
 use crate::external::{ProcessingMode, SqlSink, SqlSource};
+use crate::schemas::window_type_def;
 use crate::tables::{Insert, Table};
 use crate::{
     expressions::{AggregationExpression, Column, ColumnExpression, Expression, SortExpression},
@@ -136,8 +138,7 @@ pub struct AggregateOperator {
 
 impl AggregateOperator {
     pub fn output_struct(&self) -> StructDef {
-        self.merge
-            .output_struct(&self.key.output_struct(), &self.aggregating.output_struct())
+        self.aggregating.output_struct()
     }
 }
 
@@ -308,10 +309,7 @@ impl SqlOperator {
         match self {
             SqlOperator::Source(source_operator) => source_operator.return_type(),
             SqlOperator::Aggregator(_input, aggregate_operator) => {
-                aggregate_operator.merge.output_struct(
-                    &aggregate_operator.key.output_struct(),
-                    &aggregate_operator.aggregating.output_struct(),
-                )
+                aggregate_operator.aggregating.output_struct()
             }
             SqlOperator::JoinOperator(left, right, operator) => operator
                 .join_type
@@ -558,40 +556,71 @@ impl<'a> SqlPipelineBuilder<'a> {
 
         let window = self.window(&aggregate.group_expr)?;
 
-        let group_count = aggregate.group_expr.len();
-        let aggregate_fields: Vec<_> = aggregate
+        let source_return_type = source.return_type();
+        let mut ctx = self.ctx(&source_return_type);
+
+        let group_bys = aggregate.group_expr
+            .iter()
+            .zip(aggregate.schema.fields().iter())
+            .map(|(expr, field)| {
+                let column = Column::convert(&field.qualified_column());
+                Ok(if let Some(window) = Self::find_window(expr)? {
+                    if let WindowType::Instant = window {
+                        bail!("don't support instant window in return type yet");
+                    }
+
+                    let ident = format_ident!("window");
+
+                    (
+                        column,
+                        parse_quote!(#ident),
+                        window_type_def()
+                    )
+                } else {
+                    let typ = TypeDef::DataType(field.data_type().clone(), ctx.compile_expr(expr)?.nullable());
+                    let field_ident = StructField::new(column.name.clone(), column.relation.clone(), typ.clone()).field_ident();
+
+                    (
+                        column,
+                        parse_quote!(key.#field_ident),
+                        typ
+                    )
+                })
+            }).collect::<Result<Vec<_>>>()?;
+
+        let aggregates = aggregate
             .schema
             .fields()
             .iter()
-            .enumerate()
-            .filter_map(|(i, field)| {
-                if i >= group_count {
-                    Some(field.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
+            .skip(aggregate.group_expr.len()) // the group bys always come first
+            .zip(aggregate.aggr_expr.iter())
+            .map(|(field, expr)| {
+                Ok((
+                    Column::convert(&field.qualified_column()),
+                    AggregationExpression::try_from_expression(&mut ctx, expr)?
+                ))
+            }).collect::<Result<Vec<_>>>()?;
 
-        let aggregating = self.aggregate_calculation(
-            &aggregate.aggr_expr,
-            aggregate_fields,
-            &source.return_type(),
-        )?;
+
+        let aggregating = AggregateProjection {
+            aggregates,
+            group_bys,
+        };
+
         if !source.has_window()
             && matches!(window, WindowType::Instant)
             && !aggregating.supports_two_phase()
         {
             bail!("updating aggregates only support two phase aggregations. Currently count distinct is not supported");
         }
-        let merge = self.window_field(&aggregate.group_expr, aggregate.schema.fields())?;
+
         Ok(SqlOperator::Aggregator(
             Box::new(source),
             AggregateOperator {
                 key,
                 window,
                 aggregating,
-                merge,
+                merge: GroupByKind::InAggregation,
             },
         ))
     }
@@ -646,26 +675,6 @@ impl<'a> SqlPipelineBuilder<'a> {
             1 => Ok(windows[0].clone()),
             multiple => bail!("{} windows detected, must be one or zero.", multiple),
         }
-    }
-
-    fn window_field(
-        &mut self,
-        group_expressions: &[Expr],
-        fields: &[DFField],
-    ) -> Result<GroupByKind> {
-        for (i, expr) in group_expressions.iter().enumerate() {
-            if let Some(window) = Self::find_window(expr)? {
-                if let WindowType::Instant = window {
-                    bail!("don't support instant window in return type yet");
-                }
-                return Ok(GroupByKind::WindowOutput {
-                    index: i,
-                    column: Column::convert(&fields[i].qualified_column()),
-                    window_type: window,
-                });
-            }
-        }
-        Ok(GroupByKind::Basic)
     }
 
     fn is_window(expression: &Expr) -> bool {
@@ -938,29 +947,6 @@ impl<'a> SqlPipelineBuilder<'a> {
             Box::new(input),
             RecordTransform::ValueProjection(projection),
         ))
-    }
-
-    fn aggregate_calculation(
-        &mut self,
-        aggr_expr: &[Expr],
-        aggregate_fields: Vec<DFField>,
-        input_struct: &StructDef,
-    ) -> Result<AggregateProjection> {
-        let mut ctx = self.ctx(input_struct);
-
-        let field_names = aggregate_fields
-            .iter()
-            .map(|field| Column::convert(&field.qualified_column()))
-            .collect();
-
-        let field_computations = aggr_expr
-            .iter()
-            .map(|expr| AggregationExpression::try_from_expression(&mut ctx, expr))
-            .collect::<Result<Vec<_>>>()?;
-        Ok(AggregateProjection {
-            field_names,
-            field_computations,
-        })
     }
 
     pub(crate) fn add_insert(&mut self, insert: Insert) -> Result<()> {

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -674,7 +674,7 @@ impl<'a> SqlPipelineBuilder<'a> {
     fn is_window(expression: &Expr) -> bool {
         match expression {
             Expr::ScalarUDF(ScalarUDF { fun, args: _ }) => {
-                matches!(fun.name.as_str(), "hop" | "tumble")
+                matches!(fun.name.as_str(), "hop" | "tumble" | "session")
             }
             Expr::Alias(datafusion_expr::expr::Alias { expr, name: _ }) => Self::is_window(expr),
             _ => false,
@@ -698,6 +698,13 @@ impl<'a> SqlPipelineBuilder<'a> {
                     }
                     let width = Self::get_duration(&args[0])?;
                     Ok(Some(WindowType::Tumbling { width }))
+                }
+                "session" => {
+                    if args.len() != 1 {
+                        unreachable!("wrong number of arguments for session(), expected one");
+                    }
+                    let gap = Self::get_duration(&args[0])?;
+                    Ok(Some(WindowType::Session { gap }))
                 }
                 _ => Ok(None),
             },

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -498,7 +498,7 @@ impl PlanNode {
                 arroyo_datastream::Operator::SlidingWindowAggregator(SlidingWindowAggregator {
                     width: *width,
                     slide: *slide,
-                    aggregator: quote!(|arg| {#aggregate_expr}).to_string(),
+                    aggregator: quote!(|key, window, arg| {#aggregate_expr}).to_string(),
                     bin_merger: quote!(|arg, current_bin| {#bin_merger}).to_string(),
                     in_memory_add: quote!(|current, bin_value| {#in_memory_add}).to_string(),
                     in_memory_remove: quote!(|current, bin_value| {#in_memory_remove}).to_string(),
@@ -886,12 +886,13 @@ impl PlanNode {
                 output_types.extend(group_by_projection.output_struct().all_structs());
                 output_types.extend(partition_projection.output_struct().all_structs());
                 output_types.extend(converting_projection.output_struct().all_structs());
-                output_types.extend(
+/*                 output_types.extend(
                     converting_projection
                         .truncated_return_type(aggregating_projection.field_names.len())
                         .all_structs(),
                 );
-
+ */
+                todo!();
                 let aggregate_struct = aggregating_projection.output_struct();
                 let key_struct = group_by_projection.output_struct();
                 let merge_struct = SqlOperator::merge_struct_type(&key_struct, &aggregate_struct);

--- a/arroyo-sql/src/schemas.rs
+++ b/arroyo-sql/src/schemas.rs
@@ -6,12 +6,12 @@ pub(crate) fn window_arrow_struct() -> DataType {
     DataType::Struct(
         vec![
             Arc::new(arrow::datatypes::Field::new(
-                "start_time",
+                "start",
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 false,
             )),
             Arc::new(arrow::datatypes::Field::new(
-                "end_time",
+                "end",
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 false,
             )),
@@ -26,12 +26,12 @@ pub(crate) fn window_type_def() -> TypeDef {
             Some("arroyo_types::Window".to_string()),
             vec![
                 StructField::new(
-                    "start_time".to_string(),
+                    "start".to_string(),
                     None,
                     TypeDef::DataType(DataType::Timestamp(TimeUnit::Millisecond, None), false),
                 ),
                 StructField::new(
-                    "end_time".to_string(),
+                    "end".to_string(),
                     None,
                     TypeDef::DataType(DataType::Timestamp(TimeUnit::Millisecond, None), false),
                 ),

--- a/arroyo-sql/src/test.rs
+++ b/arroyo-sql/src/test.rs
@@ -186,6 +186,22 @@ async fn test_no_inserting_updates_into_non_updating() {
 }
 
 #[tokio::test]
+async fn test_no_aggregates_in_window() {
+    let schema_provider = get_test_schema_provider();
+    let sql = "WITH bids as (
+  SELECT bid.auction as auction, bid.price as price, bid.bidder as bidder, bid.extra as extra, bid.datetime as datetime
+  FROM nexmark where bid is not null)
+
+SELECT * FROM (
+SELECT bidder, COUNT( distinct auction) as distinct_auctions
+FROM bids B1
+GROUP BY bidder, HOP(INTERVAL '3 second', INTERVAL '10' minute)) WHERE distinct_auctions > 2";
+    let _ = parse_and_get_program(sql, schema_provider, SqlConfig::default())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn test_udf() {
     let mut schema_provider = get_test_schema_provider();
 

--- a/arroyo-state/src/tables.rs
+++ b/arroyo-state/src/tables.rs
@@ -502,10 +502,10 @@ impl<'a, K: Key, V: Data, S: BackingStore> KeyedState<'a, K, V, S> {
         self.cache.insert(key, wrapped.unwrap());
     }
 
-    pub async fn remove(&mut self, mut key: K) {
+    pub async fn remove(&mut self, key: &mut K) {
         self.cache.remove(&key);
         self.backing_state
-            .write_key_value::<K, Option<V>>(self.table, &mut key, &mut None)
+            .write_key_value::<K, Option<V>>(self.table, key, &mut None)
             .await;
     }
 

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::{RangeInclusive, Range};
+use std::ops::{Range, RangeInclusive};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -21,10 +21,7 @@ pub struct Window {
 
 impl Window {
     pub fn new(start: SystemTime, end: SystemTime) -> Self {
-        Self {
-            start,
-            end
-        }
+        Self { start, end }
     }
 
     pub fn session(start: SystemTime, gap: Duration) -> Self {

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -32,7 +32,7 @@ impl Window {
     }
 
     pub fn contains(&self, t: SystemTime) -> bool {
-        self.start >= t && t < self.end
+        self.start <= t && t < self.end
     }
 }
 

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -34,6 +34,22 @@ impl Window {
     pub fn contains(&self, t: SystemTime) -> bool {
         self.start <= t && t < self.end
     }
+
+    pub fn size(&self) -> Duration {
+        self.end.duration_since(self.start).unwrap_or_default()
+    }
+
+    pub fn extend(&self, new_end: SystemTime, max_size: Duration) -> Window {
+        let new_end = self.end.max(new_end);
+        Window {
+            start: self.start,
+            end: if new_end.duration_since(self.start).unwrap_or_default() > max_size {
+                self.start + max_size
+            } else {
+                new_end
+            },
+        }
+    }
 }
 
 impl From<Range<SystemTime>> for Window {

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -479,13 +479,12 @@ impl<K: Key, T: Data> Context<K, T> {
     pub async fn cancel_timer<D: Data + PartialEq + Eq>(
         &mut self,
         key: &mut K,
-        event_time: SystemTime
+        event_time: SystemTime,
     ) -> Option<D> {
         let mut timer_state: TimeKeyMap<K, TimerValue<K, D>, _> =
             self.state.get_time_key_map(TIMER_TABLE, None).await;
 
-        timer_state.remove(event_time, key)
-            .map(|v| v.data)
+        timer_state.remove(event_time, key).map(|v| v.data)
     }
 
     pub async fn collect(&mut self, record: Record<K, T>) {

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -476,6 +476,18 @@ impl<K: Key, T: Data> Context<K, T> {
         timer_state.insert(event_time, key.clone(), value);
     }
 
+    pub async fn cancel_timer<D: Data + PartialEq + Eq>(
+        &mut self,
+        key: &mut K,
+        event_time: SystemTime
+    ) -> Option<D> {
+        let mut timer_state: TimeKeyMap<K, TimerValue<K, D>, _> =
+            self.state.get_time_key_map(TIMER_TABLE, None).await;
+
+        timer_state.remove(event_time, key)
+            .map(|v| v.data)
+    }
+
     pub async fn collect(&mut self, record: Record<K, T>) {
         self.collector.collect(record).await;
     }

--- a/arroyo-worker/src/operators/aggregating_window.rs
+++ b/arroyo-worker/src/operators/aggregating_window.rs
@@ -198,7 +198,14 @@ impl<K: Key, T: Data, BinA: Data, MemA: Data, OutT: Data>
         let window_end = bin_end - Duration::from_nanos(1);
         let mut records = vec![];
         for (key, in_memory) in self.memory_view.iter() {
-            let value = (self.aggregator)(key, Window { start: bin_start, end: bin_end },  in_memory);
+            let value = (self.aggregator)(
+                key,
+                Window {
+                    start: bin_start,
+                    end: bin_end,
+                },
+                in_memory,
+            );
             records.push(Record {
                 timestamp: window_end,
                 key: Some(key.clone()),

--- a/arroyo-worker/src/operators/aggregating_window.rs
+++ b/arroyo-worker/src/operators/aggregating_window.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 pub struct AggregatingWindowFunc<K: Key, T: Data, BinA: Data, MemA: Data, OutT: Data> {
     width: Duration,
     slide: Duration,
-    aggregator: fn(&MemA) -> OutT,
+    aggregator: fn(&K, Window, &MemA) -> OutT,
     bin_merger: fn(&T, Option<&BinA>) -> BinA,
     in_memory_add: fn(Option<MemA>, BinA) -> MemA,
     in_memory_remove: fn(MemA, BinA) -> Option<MemA>,
@@ -44,7 +44,7 @@ impl<K: Key, T: Data, BinA: Data, MemA: Data, OutT: Data>
     pub fn new(
         width: Duration,
         slide: Duration,
-        aggregator: fn(&MemA) -> OutT,
+        aggregator: fn(&K, Window, &MemA) -> OutT,
         bin_merger: fn(&T, Option<&BinA>) -> BinA,
         in_memory_add: fn(Option<MemA>, BinA) -> MemA,
         in_memory_remove: fn(MemA, BinA) -> Option<MemA>,
@@ -198,7 +198,7 @@ impl<K: Key, T: Data, BinA: Data, MemA: Data, OutT: Data>
         let window_end = bin_end - Duration::from_nanos(1);
         let mut records = vec![];
         for (key, in_memory) in self.memory_view.iter() {
-            let value = (self.aggregator)(in_memory);
+            let value = (self.aggregator)(key, Window { start: bin_start, end: bin_end },  in_memory);
             records.push(Record {
                 timestamp: window_end,
                 key: Some(key.clone()),

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -237,9 +237,7 @@ pub trait TimeWindowAssigner<K: Key, T: Data>: Copy + Clone + Send + 'static {
     fn safe_retention_duration(&self) -> Option<Duration>;
 }
 
-pub trait WindowAssigner<K: Key, T: Data>: Clone + Send {
-
-}
+pub trait WindowAssigner<K: Key, T: Data>: Clone + Send {}
 
 #[derive(Clone, Copy)]
 pub struct TumblingWindowAssigner {

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -221,7 +221,10 @@ impl<K: Key, D: Data> PeriodicWatermarkGenerator<K, D> {
     async fn handle_tick(&mut self, _: u64, ctx: &mut Context<K, D>) {
         if let Some(idle_time) = self.idle_time {
             if self.last_event.elapsed().unwrap_or(Duration::ZERO) > idle_time && !self.idle {
-                info!("Setting partition {} to idle", ctx.task_info.task_index);
+                info!(
+                    "Setting partition {} to idle after {:?}",
+                    ctx.task_info.task_index, idle_time
+                );
                 ctx.broadcast(Message::Watermark(Watermark::Idle)).await;
                 self.idle = true;
             }

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -237,6 +237,10 @@ pub trait TimeWindowAssigner<K: Key, T: Data>: Copy + Clone + Send + 'static {
     fn safe_retention_duration(&self) -> Option<Duration>;
 }
 
+pub trait WindowAssigner<K: Key, T: Data>: Clone + Send {
+
+}
+
 #[derive(Clone, Copy)]
 pub struct TumblingWindowAssigner {
     size: Duration,
@@ -246,15 +250,15 @@ impl<K: Key, T: Data> TimeWindowAssigner<K, T> for TumblingWindowAssigner {
     fn windows(&self, ts: SystemTime) -> Vec<Window> {
         let key = to_millis(ts) / (self.size.as_millis() as u64);
         vec![Window {
-            start_time: from_millis(key * self.size.as_millis() as u64),
-            end_time: from_millis((key + 1) * (self.size.as_millis() as u64)),
+            start: from_millis(key * self.size.as_millis() as u64),
+            end: from_millis((key + 1) * (self.size.as_millis() as u64)),
         }]
     }
 
     fn next(&self, window: Window) -> Window {
         Window {
-            start_time: window.end_time,
-            end_time: window.end_time + self.size,
+            start: window.end,
+            end: window.end + self.size,
         }
     }
 
@@ -268,15 +272,15 @@ pub struct InstantWindowAssigner {}
 impl<K: Key, T: Data> TimeWindowAssigner<K, T> for InstantWindowAssigner {
     fn windows(&self, ts: SystemTime) -> Vec<Window> {
         vec![Window {
-            start_time: ts,
-            end_time: ts + Duration::from_nanos(1),
+            start: ts,
+            end: ts + Duration::from_nanos(1),
         }]
     }
 
     fn next(&self, window: Window) -> Window {
         Window {
-            start_time: window.start_time + Duration::from_micros(1),
-            end_time: window.end_time + Duration::from_micros(1),
+            start: window.start + Duration::from_micros(1),
+            end: window.end + Duration::from_micros(1),
         }
     }
 
@@ -317,8 +321,8 @@ impl<K: Key, T: Data> TimeWindowAssigner<K, T> for SlidingWindowAssigner {
 
         while start <= ts {
             windows.push(Window {
-                start_time: start,
-                end_time: start + self.size,
+                start,
+                end: start + self.size,
             });
             start += self.slide;
         }
@@ -327,10 +331,10 @@ impl<K: Key, T: Data> TimeWindowAssigner<K, T> for SlidingWindowAssigner {
     }
 
     fn next(&self, window: Window) -> Window {
-        let start_time = window.start_time + self.slide;
+        let start_time = window.start + self.slide;
         Window {
-            start_time,
-            end_time: start_time + self.size,
+            start: start_time,
+            end: start_time + self.size,
         }
     }
 

--- a/arroyo-worker/src/operators/updating_aggregate.rs
+++ b/arroyo-worker/src/operators/updating_aggregate.rs
@@ -130,7 +130,7 @@ impl<K: Key, T: Data, BinA: Data, OutT: Data> UpdatingAggregateOperator<K, T, Bi
                         .await;
                 }
                 StateOp::Delete => {
-                    aggregating_map.remove(mut_key).await;
+                    aggregating_map.remove(&mut mut_key).await;
                 }
                 StateOp::Update { new, old: _ } => {
                     aggregating_map.insert(record.timestamp, mut_key, new).await;

--- a/arroyo-worker/src/operators/updating_aggregate.rs
+++ b/arroyo-worker/src/operators/updating_aggregate.rs
@@ -28,7 +28,7 @@ enum StateOp<T: Data> {
 #[process_fn(in_k = K, in_t = T, out_k = K, out_t = UpdatingData<OutT>)]
 impl<K: Key, T: Data, BinA: Data, OutT: Data> UpdatingAggregateOperator<K, T, BinA, OutT> {
     fn name(&self) -> String {
-        "KeyWindow".to_string()
+        "UpdatingAggregate".to_string()
     }
 
     pub fn new(

--- a/arroyo-worker/src/operators/windows.rs
+++ b/arroyo-worker/src/operators/windows.rs
@@ -11,6 +11,10 @@ use super::{
     InstantWindowAssigner, SlidingWindowAssigner, TimeWindowAssigner, TumblingWindowAssigner,
 };
 
+// Enforce a maximum session size to prevent unbounded state growth until we are able to
+// delete from parquet state.
+const MAX_SESSION_SIZE: Duration = Duration::from_secs(24 * 60 * 60); // 1 day
+
 pub mod aggregators {
     use std::ops::Add;
 
@@ -199,6 +203,103 @@ pub struct SessionWindowFunc<K: Key, T: Data, OutT: Data> {
     _t: PhantomData<K>,
 }
 
+struct WindowGroup {
+    windows: Vec<Window>,
+    gap_size: Duration,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct HandleResult {
+    remove: Option<SystemTime>,
+    add: Option<SystemTime>,
+}
+
+impl WindowGroup {
+    fn handle_new_window(&mut self, mut new: Window) -> Option<SystemTime> {
+        // look for an existing window to extend forward, unless it would be too long
+        if let Some(w) = self.windows.iter_mut().find(|w| w.contains(new.end)) {
+            if Window::new(new.start, w.end).size() < MAX_SESSION_SIZE {
+                w.start = new.start;
+                None
+            } else {
+                // if the merged window would be too long, we will extend the new window to MAX_SESSION_SIZE
+                // and shorten the overlapping one
+                new.end = new.start + MAX_SESSION_SIZE;
+                w.start = new.end;
+                self.windows.push(new);
+                Some(new.end)
+            }
+        } else {
+            // otherwise we're going to insert and schedule a new window
+            self.windows.push(new);
+            Some(new.end)
+        }
+    }
+
+    fn handle_event(&mut self, timestamp: SystemTime) -> HandleResult {
+        let (remove, add) = if !self.windows.is_empty() {
+            if let Some((i, window)) = self
+                .windows
+                .iter()
+                .enumerate()
+                .find(|(_, w)| w.contains(timestamp))
+                .map(|(i, w)| (i, *w))
+            {
+                // there's an existing window this record falls into
+                let new_window = window.extend(timestamp + self.gap_size, MAX_SESSION_SIZE);
+                if window != new_window {
+                    // we're extending an existing window
+                    self.windows.remove(i);
+                    (Some(window.end), self.handle_new_window(new_window))
+                } else {
+                    (None, None)
+                }
+                // otherwise the window is unchanged, we don't need to do anything
+            } else {
+                // there's no existing window, we need to add one
+                (
+                    None,
+                    self.handle_new_window(Window::session(timestamp, self.gap_size)),
+                )
+            }
+        } else {
+            // no existing window, create one
+            let window = Window::session(timestamp, self.gap_size);
+            let t = self.handle_new_window(window);
+            (None, t)
+        };
+
+        // sort the windows by start time
+        self.windows.sort_by_key(|w| w.start);
+
+        assert!(
+            self.is_valid(),
+            "invalid session window state: {:?}",
+            self.windows
+        );
+
+        HandleResult { remove, add }
+    }
+
+    fn max_end(&self) -> SystemTime {
+        // windows are sorted by start time and do not overlap
+        self.windows
+            .iter()
+            .last()
+            .expect("this must be non-empty when called")
+            .end
+    }
+
+    // ensures we've followed the two rules of session windows:
+    //  1. Windows must not overlap
+    //  2. Windows must not be longer than MAX_SESSION_SIZE
+    fn is_valid(&self) -> bool {
+        self.windows
+            .windows(2)
+            .all(|w| w[0].end <= w[1].start && w[0].size() <= MAX_SESSION_SIZE)
+    }
+}
+
 #[process_fn(in_k = K, in_t = T, out_k = K, out_t = OutT, time_t = Window)]
 impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
     fn name(&self) -> String {
@@ -221,7 +322,8 @@ impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
                 table_type: TableType::KeyTimeMultiMap as i32,
                 delete_behavior: TableDeleteBehavior::NoReadsBeforeWatermark as i32,
                 write_behavior: TableWriteBehavior::NoWritesBeforeWatermark as i32,
-                retention_micros: self.gap_size.as_micros() as u64,
+                // we always write the largest end in the list of windows
+                retention_micros: 0 as u64,
             },
             TableDescriptor {
                 name: "s".to_string(),
@@ -229,21 +331,9 @@ impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
                 table_type: TableType::TimeKeyMap as i32,
                 delete_behavior: TableDeleteBehavior::NoReadsBeforeWatermark as i32,
                 write_behavior: TableWriteBehavior::NoWritesBeforeWatermark as i32,
-                retention_micros: self.gap_size.as_micros() as u64,
+                retention_micros: MAX_SESSION_SIZE.as_micros() as u64,
             },
         ]
-    }
-
-    fn handle_new_window(windows: &mut Vec<Window>, new: Window) -> Option<SystemTime> {
-        // look for an existing window to extend forward
-        if let Some(w) = windows.iter_mut().find(|w| w.contains(new.end)) {
-            w.start = new.start;
-            None
-        } else {
-            // otherwise we're going to insert and schedule a new window
-            windows.push(new.clone());
-            Some(new.end)
-        }
     }
 
     async fn process_element(&mut self, record: &Record<K, T>, ctx: &mut Context<K, OutT>) {
@@ -260,61 +350,33 @@ impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
         let value = record.value.clone();
         let timestamp = record.timestamp;
 
-        let mut windows: Option<Vec<Window>> = {
-            let t: KeyedState<'_, K, Vec<Window>, _> = ctx.state.get_key_state('s').await;
-            t.get(&key).map(|t| t.iter().map(|w| *w).collect())
-        };
-
-        let (remove, add) = if let Some(windows) = windows.as_mut() {
-            if let Some((i, window)) = windows
-                .iter()
-                .enumerate()
-                .find(|(_, w)| w.contains(timestamp))
-                .map(|(i, w)| (i, *w))
-            {
-                // there's an existing window this record falls into
-                let our_end = timestamp + self.gap_size;
-                if our_end > window.end {
-                    // we're extending an existing window
-                    windows.remove(i);
-                    let new = (window.start..our_end).into();
-                    (Some(window.end), Self::handle_new_window(windows, new))
-                } else {
-                    (None, None)
-                }
-                // otherwise the window is unchanged, we don't need to do anything
-            } else {
-                // there's no existing window, we need to add one
-                (
-                    None,
-                    Self::handle_new_window(windows, Window::session(timestamp, self.gap_size)),
-                )
+        let mut windows = WindowGroup {
+            windows: {
+                let t: KeyedState<'_, K, Vec<Window>, _> = ctx.state.get_key_state('s').await;
+                t.get(&key).map(|t| t.iter().map(|w| *w).collect())
             }
-        } else {
-            // no existing window, create one
-            let window = Window::session(timestamp, self.gap_size);
-            windows = Some(vec![]);
-            let t = Self::handle_new_window(windows.as_mut().unwrap(), window);
-            (None, t)
+            .unwrap_or_default(),
+            gap_size: self.gap_size,
         };
 
-        if let Some(remove) = remove {
+        let result = windows.handle_event(timestamp);
+
+        if let Some(remove) = result.remove {
             let _: Option<Window> = ctx.cancel_timer(&mut key, remove).await;
         }
-        if let Some(add) = add {
+        if let Some(add) = result.add {
             // we use UNIX_EPOCH as the start of our windows to avoid having to update them when we extend
             // the beginning; this works because windows are always handled in order
             ctx.schedule_timer(&mut key, add, Window::new(SystemTime::UNIX_EPOCH, add))
                 .await;
         }
 
-        if add.is_some() || remove.is_some() {
+        if result.add.is_some() || result.remove.is_some() {
             let key = key.clone();
             ctx.state
                 .get_key_state('s')
                 .await
-                // I have no idea if this timestamp is correct -- this datastructure does not make sense to me
-                .insert(timestamp, key, windows.unwrap())
+                .insert(windows.max_end(), key, windows.windows)
                 .await;
         }
 
@@ -326,7 +388,6 @@ impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
     }
 
     async fn handle_timer(&mut self, mut key: K, window: Window, ctx: &mut Context<K, OutT>) {
-        println!("Handling timer for {:?}, {:?}", key, window);
         let window = {
             // get the actual window (as the timer one doesn't have the actual start time)
             let mut t: KeyedState<'_, K, Vec<Window>, _> = ctx.state.get_key_state('s').await;
@@ -362,5 +423,213 @@ impl<K: Key, T: Data, OutT: Data> SessionWindowFunc<K, T, OutT> {
         state
             .clear_time_range(&mut key, window.start, window.end)
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use arroyo_types::{from_millis, Window};
+
+    use crate::operators::windows::{HandleResult, MAX_SESSION_SIZE};
+
+    use super::WindowGroup;
+
+    #[test]
+    fn test_no_windows() {
+        let mut wg = WindowGroup {
+            windows: vec![],
+            gap_size: Duration::from_millis(100),
+        };
+
+        // no existing windows, so we should create one
+        assert_eq!(
+            wg.handle_event(from_millis(0)),
+            HandleResult {
+                remove: None,
+                add: Some(from_millis(100))
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![Window {
+                start: from_millis(0),
+                end: from_millis(100)
+            }]
+        );
+
+        assert_eq!(from_millis(100), wg.max_end());
+    }
+
+    #[test]
+    fn test_extend_window() {
+        let mut wg = WindowGroup {
+            windows: vec![Window::session(from_millis(0), Duration::from_millis(100))],
+            gap_size: Duration::from_millis(100),
+        };
+
+        // we should extend the existing window which involves removing the timer and re-adding it
+        // at the new stop time
+        assert_eq!(
+            wg.handle_event(from_millis(50)),
+            HandleResult {
+                remove: Some(from_millis(100)),
+                add: Some(from_millis(150))
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![Window {
+                start: from_millis(0),
+                end: from_millis(150)
+            }]
+        );
+
+        assert_eq!(from_millis(150), wg.max_end());
+    }
+
+    #[test]
+    fn test_add_window() {
+        let mut wg = WindowGroup {
+            windows: vec![Window::session(from_millis(0), Duration::from_millis(100))],
+            gap_size: Duration::from_millis(100),
+        };
+
+        // this doesn't overlap with the existing window, so we should add a new one
+        assert_eq!(
+            wg.handle_event(from_millis(150)),
+            HandleResult {
+                remove: None,
+                add: Some(from_millis(250))
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![
+                Window {
+                    start: from_millis(0),
+                    end: from_millis(100)
+                },
+                Window {
+                    start: from_millis(150),
+                    end: from_millis(250)
+                }
+            ]
+        );
+
+        assert_eq!(from_millis(250), wg.max_end());
+    }
+
+    #[test]
+    fn test_merge_windows() {
+        let mut wg: WindowGroup = WindowGroup {
+            windows: vec![
+                Window {
+                    start: from_millis(0),
+                    end: from_millis(100),
+                },
+                Window {
+                    start: from_millis(150),
+                    end: from_millis(250),
+                },
+            ],
+            gap_size: Duration::from_millis(100),
+        };
+
+        // this extends one window far enough that it merges with the next one
+        assert_eq!(
+            wg.handle_event(from_millis(80)),
+            HandleResult {
+                remove: Some(from_millis(100)),
+                add: None
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![Window {
+                start: from_millis(0),
+                end: from_millis(250)
+            }]
+        );
+
+        assert_eq!(from_millis(250), wg.max_end());
+    }
+
+    #[test]
+    fn test_dont_extend_past_max_size() {
+        let mut wg = WindowGroup {
+            windows: vec![Window::session(
+                from_millis(0),
+                MAX_SESSION_SIZE - Duration::from_secs(3),
+            )],
+            gap_size: Duration::from_secs(10),
+        };
+
+        // this would extend the window past the max size, so it should only be extended up to the max size
+        let start = from_millis(MAX_SESSION_SIZE.as_millis() as u64 - 5000);
+        assert_eq!(
+            wg.handle_event(start),
+            HandleResult {
+                remove: Some(from_millis(0) + (MAX_SESSION_SIZE - Duration::from_secs(3))),
+                add: Some(SystemTime::UNIX_EPOCH + MAX_SESSION_SIZE)
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![Window {
+                start: from_millis(0),
+                end: SystemTime::UNIX_EPOCH + MAX_SESSION_SIZE
+            },]
+        );
+    }
+
+    #[test]
+    fn dont_merge_past_max_size() {
+        // we have two windows, each slightly less than half of the max session size, and separated by 2 seconds
+        // adding an event at the end of the first window would normally cause them to be merged into one
+        // however, because that would violate the max session window, the first window should be extended
+        // to the max session size and the second one should follow immediately after it
+        let half_millis = MAX_SESSION_SIZE.as_millis() as u64 / 2;
+        let mut wg: WindowGroup = WindowGroup {
+            windows: vec![
+                Window::session(from_millis(0), Duration::from_millis(half_millis - 1000)),
+                Window::session(
+                    from_millis(half_millis + 1000),
+                    Duration::from_millis(half_millis + 5000),
+                ),
+            ],
+            gap_size: Duration::from_secs(10),
+        };
+
+        let start = from_millis(half_millis - 2000);
+
+        assert_eq!(
+            wg.handle_event(start),
+            HandleResult {
+                remove: Some(from_millis(half_millis - 1000)),
+                add: Some(from_millis(MAX_SESSION_SIZE.as_millis() as u64))
+            }
+        );
+
+        assert_eq!(
+            wg.windows,
+            vec![
+                Window {
+                    start: from_millis(0),
+                    end: from_millis(MAX_SESSION_SIZE.as_millis() as u64)
+                },
+                Window {
+                    start: from_millis(MAX_SESSION_SIZE.as_millis() as u64),
+                    end: from_millis(half_millis + 1000)
+                        + Duration::from_millis(half_millis + 5000)
+                }
+            ]
+        );
     }
 }

--- a/arroyo-worker/src/operators/windows.rs
+++ b/arroyo-worker/src/operators/windows.rs
@@ -1,11 +1,10 @@
-use std::{marker::PhantomData, time::SystemTime, collections::HashMap};
+use std::{marker::PhantomData, time::SystemTime};
 
 use crate::engine::{Context, StreamNode};
 use arroyo_macro::process_fn;
 use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableType, TableWriteBehavior};
 use arroyo_state::tables::{KeyTimeMultiMap, KeyedState};
 use arroyo_types::*;
-use md5::digest::generic_array::functional::FunctionalSequence;
 use std::time::Duration;
 
 use super::{


### PR DESCRIPTION
This PR adds support for session windows, addressing #239.

Session windows divide time up by a _minimum gap size_ and are useful for sessionization. For example, a session window could be defined on clickstream data to determine metrics for a particular usage period.

Session windows can be used like our existing time window functions (hop and tumble). For example:

```sql
select bid.auction, count(*), avg(bid.price), session(interval '30 seconds')
from nexmark
where bid is not null
group by bid.auction, session(interval '30 seconds')
```

This PR introduces only an unoptimized implementation of session windows without support for partial aggregates. 

---

This PR also includes a large rework of how windows are handled in SQL. This was necessary because the existing implementation relied on windows being fixed width in order to determine the window output.

Previously, we would compile a window-groupby into two nodes: a window aggregation, and a merge node. The window aggregation was responsible for outputting all of the aggregate fields (in the above query, that would be the `count(*)`), while the subsequent _merge_ was responsible for combining the aggregates with the group by fields. Key fields (like `bid.auction`) would be pulled from the key, while window fields (`session(interval '30 seconds')`) would be computed statically from the timestamp and the window size. However, this doesn't work with dynamically-sized windows.

Now instead each aggregation closure takes both a key and the window, and is responsible for outputting the full struct. In addition to allowing us to support non-fixed sized windows like session windows, it also saves a (non-fused) node graph and simplifies the code significantly.