### PR TITLE
Fix job output rendering

### DIFF
--- a/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
+++ b/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
@@ -116,7 +116,7 @@ export function CreatePipeline({ client }: { client: ApiClient }) {
     if (outputs.length > 20) {
       outputs.shift();
     }
-    setOutputs(outputs);
+    setOutputs(outputs.slice());
   };
 
   useEffect(() => {

--- a/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
@@ -87,7 +87,7 @@ export function PipelineDetails({ client }: { client: ApiClient }) {
     if (outputs.length > 20) {
       outputs.shift();
     }
-    setOutputs(outputs);
+    setOutputs(outputs.slice());
   };
 
   const subscribe = async () => {


### PR DESCRIPTION
Modifying the existing array of output doesn't trigger a re-render since the reference to the array in state doesn't change. This creates a new array on each message to force a re-render.