### PR TITLE
Paginate job log messages and generalize paginated content

### DIFF
--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -263,7 +263,7 @@ DELETE FROM pipelines WHERE pipelines.id = (
 --: DbLogMessage (operator_id?, task_index?)
 
 --! get_operator_errors : DbLogMessage
-SELECT jlm.job_id, jlm.operator_id, jlm.task_index, jlm.created_at, jlm.log_level, jlm.message, jlm.details
+SELECT jlm.pub_id, jlm.job_id, jlm.operator_id, jlm.task_index, jlm.created_at, jlm.log_level, jlm.message, jlm.details
 FROM job_log_messages jlm
 JOIN public.job_configs ON job_configs.id = jlm.job_id
 INNER JOIN (
@@ -272,4 +272,10 @@ INNER JOIN (
     GROUP BY operator_id, task_index, job_id
 ) jlm_max ON jlm.operator_id = jlm_max.operator_id AND jlm.task_index = jlm_max.task_index AND jlm.created_at = jlm_max.max_created_at
 WHERE job_configs.organization_id = :organization_id AND job_configs.id = :job_id
-  AND jlm.log_level = 'error';
+  AND jlm.log_level = 'error'
+  AND (jlm.created_at < (
+    SELECT created_at FROM job_log_messages
+    WHERE pub_id = :starting_after
+) OR :starting_after = '')
+ORDER BY jlm.created_at DESC
+LIMIT :limit::integer;

--- a/arroyo-api/src/connection_profiles.rs
+++ b/arroyo-api/src/connection_profiles.rs
@@ -119,8 +119,5 @@ pub async fn get_connection_profiles(
         })
         .collect();
 
-    Ok(Json(ConnectionProfileCollection {
-        data,
-        has_more: false,
-    }))
+    Ok(Json(ConnectionProfileCollection { data }))
 }

--- a/arroyo-api/src/connectors.rs
+++ b/arroyo-api/src/connectors.rs
@@ -20,8 +20,5 @@ pub async fn get_connectors() -> Result<Json<ConnectorCollection>, ErrorResp> {
         .collect();
 
     connectors.sort_by_cached_key(|c| c.name.clone());
-    Ok(Json(ConnectorCollection {
-        data: connectors,
-        has_more: false,
-    }))
+    Ok(Json(ConnectorCollection { data: connectors }))
 }

--- a/arroyo-api/src/metrics.rs
+++ b/arroyo-api/src/metrics.rs
@@ -144,10 +144,7 @@ pub async fn get_operator_metric_groups(
             .get(),
     );
 
-    let mut collection = OperatorMetricGroupCollection {
-        data: vec![],
-        has_more: false,
-    };
+    let mut collection = OperatorMetricGroupCollection { data: vec![] };
 
     match result {
         Ok((r1, r2, r3, r4, r5)) => {

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -690,7 +690,6 @@ pub async fn get_pipeline_jobs(
         .map_err(log_and_map)?;
 
     Ok(Json(JobCollection {
-        has_more: false,
         data: jobs.into_iter().map(|p| p.into()).collect(),
     }))
 }

--- a/arroyo-console/src/components/PaginatedContent.tsx
+++ b/arroyo-console/src/components/PaginatedContent.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { Flex, IconButton, Stack } from '@chakra-ui/react';
+import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
+import Loading from './Loading';
+
+interface Page {
+  data: any[];
+  hasMore: boolean;
+}
+
+export interface PaginatedContentProps {
+  pages: Page[] | undefined;
+  loading?: boolean;
+  totalPages: number;
+  setMaxPages: (maxPages: number) => void;
+  content: JSX.Element;
+  setCurrentData: (data: any[]) => void;
+}
+
+const PaginatedContent: React.FC<PaginatedContentProps> = ({
+  pages,
+  loading,
+  totalPages,
+  setMaxPages,
+  content,
+  setCurrentData,
+}) => {
+  const [pageNum, setPageNum] = useState<number>(1);
+  setMaxPages(Math.max(pageNum, totalPages));
+
+  if (!pages || !pages.length || pages.length != totalPages || loading) {
+    return <Loading />;
+  }
+
+  const currentPage = pages[pageNum - 1];
+  setCurrentData(currentPage.data);
+
+  let pageButtons = <></>;
+  if (currentPage.hasMore || pages.length > 1) {
+    pageButtons = (
+      <Flex justifyContent={'center'} gap={'5px'}>
+        <IconButton
+          aria-label="Previous page"
+          icon={<ArrowBackIcon />}
+          isDisabled={pageNum === 1}
+          onClick={() => setPageNum(pageNum - 1)}
+        />
+        <IconButton
+          aria-label="Next Page"
+          icon={<ArrowForwardIcon />}
+          isDisabled={!currentPage.hasMore}
+          onClick={() => setPageNum(pageNum + 1)}
+        />
+      </Flex>
+    );
+  }
+
+  return (
+    <Stack spacing={'5'}>
+      {content}
+      {pageButtons}
+    </Stack>
+  );
+};
+
+export default PaginatedContent;

--- a/arroyo-console/src/components/PipelinesTable.tsx
+++ b/arroyo-console/src/components/PipelinesTable.tsx
@@ -8,11 +8,8 @@ import {
   AlertDialogHeader,
   AlertDialogOverlay,
   AlertIcon,
-  Box,
   Button,
   CloseButton,
-  Flex,
-  IconButton,
   Stack,
   Table,
   Tbody,
@@ -20,15 +17,13 @@ import {
   Th,
   Thead,
   Tr,
-  useColorModeValue,
   useDisclosure,
 } from '@chakra-ui/react';
 import React, { useRef, useState } from 'react';
-import { usePipelines, usePipeline } from '../lib/data_fetching';
+import { usePipelines, usePipeline, Pipeline } from '../lib/data_fetching';
 import { formatError } from '../lib/util';
-import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import PipelineRow from './PipelineRow';
-import Loading from './Loading';
+import PaginatedContent from './PaginatedContent';
 
 export interface JobsTableProps {}
 
@@ -41,16 +36,7 @@ const PipelinesTable: React.FC<JobsTableProps> = ({}) => {
   const [pipelineIdToBeDeleted, setPipelineIdToBeDeleted] = useState<string | undefined>(undefined);
   const { pipeline: pipelineToBeDeleted, deletePipeline } = usePipeline(pipelineIdToBeDeleted);
   const { pipelinePages, piplinesError, pipelineTotalPages, setPipelinesMaxPages } = usePipelines();
-  const [pageNum, setPageNum] = useState<number>(1);
-
-  setPipelinesMaxPages(Math.max(pageNum, pipelineTotalPages));
-
-  if (!pipelinePages || pipelinePages.length != pipelineTotalPages) {
-    return <Loading />;
-  }
-
-  const currentPage = pipelinePages[pageNum - 1];
-  const pipelines = currentPage.data;
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
 
   let messageBox = null;
   if (message != null) {
@@ -142,21 +128,11 @@ const PipelinesTable: React.FC<JobsTableProps> = ({}) => {
     </Tbody>
   );
 
-  const pageButtons = (
-    <Flex justifyContent={'center'} gap={'5px'}>
-      <IconButton
-        aria-label="Previous page"
-        icon={<ArrowBackIcon />}
-        isDisabled={pageNum === 1}
-        onClick={() => setPageNum(pageNum - 1)}
-      />
-      <IconButton
-        aria-label="Search database"
-        icon={<ArrowForwardIcon />}
-        isDisabled={!currentPage.hasMore}
-        onClick={() => setPageNum(pageNum + 1)}
-      />
-    </Flex>
+  const table = (
+    <Table>
+      {tableHeader}
+      {tableBody}
+    </Table>
   );
 
   return (
@@ -166,19 +142,15 @@ const PipelinesTable: React.FC<JobsTableProps> = ({}) => {
         lg: '6',
       }}
     >
-      <Box
-        bg="bg-surface"
-        boxShadow={{ base: 'none', md: useColorModeValue('sm', 'sm-dark') }}
-        borderRadius="lg"
-      >
-        {alert}
-        {messageBox}
-        <Table>
-          {tableHeader}
-          {tableBody}
-        </Table>
-      </Box>
-      {pageButtons}
+      {alert}
+      {messageBox}
+      <PaginatedContent
+        pages={pipelinePages}
+        totalPages={pipelineTotalPages}
+        setMaxPages={setPipelinesMaxPages}
+        content={table}
+        setCurrentData={setPipelines}
+      />
     </Stack>
   );
 };

--- a/arroyo-console/src/gen/api-types.ts
+++ b/arroyo-console/src/gen/api-types.ts
@@ -205,7 +205,6 @@ export interface components {
     };
     ConnectionProfileCollection: {
       data: (components["schemas"]["ConnectionProfile"])[];
-      hasMore: boolean;
     };
     ConnectionProfilePost: {
       config: unknown;
@@ -260,7 +259,6 @@ export interface components {
     };
     ConnectorCollection: {
       data: (components["schemas"]["Connector"])[];
-      hasMore: boolean;
     };
     FieldType: OneOf<[{
       primitive: components["schemas"]["PrimitiveType"];
@@ -294,7 +292,6 @@ export interface components {
     };
     JobCollection: {
       data: (components["schemas"]["Job"])[];
-      hasMore: boolean;
     };
     /** @enum {string} */
     JobLogLevel: "info" | "warn" | "error";
@@ -302,6 +299,7 @@ export interface components {
       /** Format: int64 */
       createdAt: number;
       details: string;
+      id: string;
       level: components["schemas"]["JobLogLevel"];
       message: string;
       operatorId?: string | null;
@@ -346,7 +344,6 @@ export interface components {
     };
     OperatorMetricGroupCollection: {
       data: (components["schemas"]["OperatorMetricGroup"])[];
-      hasMore: boolean;
     };
     OutputData: {
       key: string;
@@ -852,6 +849,12 @@ export interface operations {
    */
   get_job_errors: {
     parameters: {
+      query?: {
+        /** @description Starting after */
+        starting_after?: string | null;
+        /** @description Limit */
+        limit?: number | null;
+      };
       path: {
         /** @description Pipeline id */
         pipeline_id: string;

--- a/arroyo-console/src/routes/connections/Connections.tsx
+++ b/arroyo-console/src/routes/connections/Connections.tsx
@@ -26,16 +26,14 @@ import {
   ModalCloseButton,
   ModalBody,
   ModalFooter,
-  Flex,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { FiInfo, FiXCircle } from 'react-icons/fi';
 import { ConnectionTable, del, Format, useConnectionTables } from '../../lib/data_fetching';
-import Loading from '../../components/Loading';
 import { useNavigate } from 'react-router-dom';
 import { formatError } from '../../lib/util';
-import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import { formatDate } from '../../lib/util';
+import PaginatedContent from '../../components/PaginatedContent';
 
 interface ColumnDef {
   name: string;
@@ -95,20 +93,7 @@ export function Connections() {
     connectionTablesTotalPages,
     setConnectionTablesMaxPages,
   } = useConnectionTables(10);
-
-  const [pageNum, setPageNum] = useState<number>(1);
-
-  if (
-    !connectionTablePages ||
-    connectionTablesLoading ||
-    connectionTablePages.length != connectionTablesTotalPages
-  ) {
-    return <Loading />;
-  }
-
-  setConnectionTablesMaxPages(Math.max(pageNum, connectionTablesTotalPages));
-  const currentPage = connectionTablePages[pageNum - 1];
-  const connectionTables = currentPage.data;
+  const [connectionTables, setConnectionTables] = useState<ConnectionTable[]>([]);
 
   const deleteTable = async (connection: ConnectionTable) => {
     const { error } = await del('/v1/connection_tables/{id}', {
@@ -221,23 +206,6 @@ export function Connections() {
     </Box>
   );
 
-  const pageButtons = (
-    <Flex justifyContent={'center'} gap={'5px'}>
-      <IconButton
-        aria-label="Previous page"
-        icon={<ArrowBackIcon />}
-        isDisabled={pageNum === 1}
-        onClick={() => setPageNum(pageNum - 1)}
-      />
-      <IconButton
-        aria-label="Search database"
-        icon={<ArrowForwardIcon />}
-        isDisabled={!currentPage.hasMore}
-        onClick={() => setPageNum(pageNum + 1)}
-      />
-    </Flex>
-  );
-
   return (
     <Container py="8" flex="1">
       <Stack
@@ -269,8 +237,14 @@ export function Connections() {
             </Button>
           </HStack>
         </Stack>
-        {table}
-        {pageButtons}
+        <PaginatedContent
+          pages={connectionTablePages}
+          loading={connectionTablesLoading}
+          totalPages={connectionTablesTotalPages}
+          setMaxPages={setConnectionTablesMaxPages}
+          setCurrentData={setConnectionTables}
+          content={table}
+        />
       </Stack>
     </Container>
   );

--- a/arroyo-rpc/src/types.rs
+++ b/arroyo-rpc/src/types.rs
@@ -168,6 +168,7 @@ pub enum JobLogLevel {
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JobLogMessage {
+    pub id: String,
     pub created_at: u64,
     pub operator_id: Option<String>,
     pub task_index: Option<u64>,
@@ -222,13 +223,8 @@ pub struct OperatorCheckpointGroup {
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 #[aliases(
-    JobCollection = PaginatedCollection<Job>,
     PipelineCollection = PaginatedCollection<Pipeline>,
     JobLogMessageCollection = PaginatedCollection<JobLogMessage>,
-    CheckpointCollection = PaginatedCollection<Checkpoint>,
-    OperatorMetricGroupCollection = PaginatedCollection<OperatorMetricGroup>,
-    ConnectorCollection = PaginatedCollection<Connector>,
-    ConnectionProfileCollection = PaginatedCollection<ConnectionProfile>,
     ConnectionTableCollection = PaginatedCollection<ConnectionTable>,
 )]
 pub struct PaginatedCollection<T> {
@@ -239,7 +235,12 @@ pub struct PaginatedCollection<T> {
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 #[aliases(
+    JobCollection = NonPaginatedCollection<Job>,
     OperatorCheckpointGroupCollection = NonPaginatedCollection<OperatorCheckpointGroup>,
+    CheckpointCollection = NonPaginatedCollection<Checkpoint>,
+    OperatorMetricGroupCollection = NonPaginatedCollection<OperatorMetricGroup>,
+    ConnectorCollection = NonPaginatedCollection<Connector>,
+    ConnectionProfileCollection = NonPaginatedCollection<ConnectionProfile>,
 )]
 pub struct NonPaginatedCollection<T> {
     pub data: Vec<T>,


### PR DESCRIPTION
Paginate the job log messages and update the UI to use the paginated data. This also introduces a PaginatedContent component in the frontend to reuse some logic.

Change the types of the remaining collections to be non-paginated.

---

The only noticeable UI change other than the pagination buttons is the error badge is now an icon rather than a number, since with cursor-based pagination we don't know the full size of of the collection:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/6513b0fd-f3d2-44ac-bb4f-2a7536b751aa)
