### PR TITLE
apply cargo fmt with new 1.72 rules

### DIFF
--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -279,8 +279,11 @@ impl TryInto<ConnectionTable> for DbConnectionTable {
     type Error = String;
     fn try_into(self) -> Result<ConnectionTable, Self::Error> {
         let Some(connector) = connector_for_type(&self.connector) else {
-                return Err(format!("invalid connector {} in saved ConnectionTable {}", self.connector, self.id));
-            };
+            return Err(format!(
+                "invalid connector {} in saved ConnectionTable {}",
+                self.connector, self.id
+            ));
+        };
 
         let connection = get_connection_profile(&self, &*connector);
 
@@ -441,10 +444,9 @@ pub(crate) fn expand_schema(
 pub(crate) async fn test_schema(
     WithRejection(Json(req), _): WithRejection<Json<ConnectionSchema>, ApiError>,
 ) -> Result<(), ErrorResp> {
-    let Some(schema_def) = req
-        .definition else {
-            return Ok(());
-        };
+    let Some(schema_def) = req.definition else {
+        return Ok(());
+    };
 
     match schema_def {
         SchemaDefinition::JsonSchema(schema) => {

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -67,7 +67,10 @@ where
 
     for table in connection_tables::get_all_connection_tables(auth_data, tx).await? {
         let Some(connector) = connector_for_type(&table.connector) else {
-            warn!("Saved table found with unknown connector {}", table.connector);
+            warn!(
+                "Saved table found with unknown connector {}",
+                table.connector
+            );
             continue;
         };
 

--- a/arroyo-controller/src/job_controller/checkpointer.rs
+++ b/arroyo-controller/src/job_controller/checkpointer.rs
@@ -392,7 +392,7 @@ impl CheckpointState {
 
     fn backend_data_to_key(backend_data: BackendData) -> Option<((u32, String), BackendData)> {
         let Some(internal_data) = &backend_data.backend_data else {
-            return None
+            return None;
         };
         match &internal_data {
             backend_data::BackendData::ParquetStore(data) => {

--- a/arroyo-controller/src/job_controller/mod.rs
+++ b/arroyo-controller/src/job_controller/mod.rs
@@ -141,7 +141,9 @@ impl RunningJobModel {
                             self.job_id,
                         );
                     } else {
-                        let CheckpointingOrCommittingState::Checkpointing(checkpoint_state)  = checkpoint_state else {
+                        let CheckpointingOrCommittingState::Checkpointing(checkpoint_state) =
+                            checkpoint_state
+                        else {
                             bail!("Received checkpoint finished but not checkpointing");
                         };
                         checkpoint_state.checkpoint_finished(c).await;
@@ -571,7 +573,9 @@ impl JobController {
     }
 
     pub async fn send_commit_messages(&mut self) -> anyhow::Result<()> {
-        let Some(CheckpointingOrCommittingState::Committing(_committing)) = &self.model.checkpoint_state else {
+        let Some(CheckpointingOrCommittingState::Committing(_committing)) =
+            &self.model.checkpoint_state
+        else {
             bail!("should be committing")
         };
         for worker in self.model.workers.values_mut() {

--- a/arroyo-controller/src/schedulers/mod.rs
+++ b/arroyo-controller/src/schedulers/mod.rs
@@ -370,7 +370,10 @@ impl NodeScheduler {
         };
 
         let Some(node) = state.nodes.get(&worker.node_id) else {
-            warn!(message = "node not found for stop worker", node_id = worker.node_id.0);
+            warn!(
+                message = "node not found for stop worker",
+                node_id = worker.node_id.0
+            );
             return Ok(Some(worker_id));
         };
 
@@ -397,10 +400,11 @@ impl NodeScheduler {
                 worker_id: worker_id.0,
                 force,
             }))
-            .await else {
-                warn!("Failed to connect to worker to stop; this likely means it is dead");
-                return Ok(Some(worker_id));
-            };
+            .await
+        else {
+            warn!("Failed to connect to worker to stop; this likely means it is dead");
+            return Ok(Some(worker_id));
+        };
 
         match (resp.get_ref().status(), force) {
             (StopWorkerStatus::NotFound, false) => {

--- a/arroyo-controller/src/states/scheduling.rs
+++ b/arroyo-controller/src/states/scheduling.rs
@@ -363,7 +363,10 @@ impl State for Scheduling {
                         StateBackend::load_operator_metadata(&ctx.config.id, operator_id, epoch)
                             .await;
                     let Some(operator_metadata) = operator_metadata else {
-                        panic!("operator metadata for {} not found for job {}", operator_id, ctx.config.id);
+                        panic!(
+                            "operator metadata for {} not found for job {}",
+                            operator_id, ctx.config.id
+                        );
                     };
                     if operator_metadata.has_state
                         && operator_metadata

--- a/arroyo-node/src/main.rs
+++ b/arroyo-node/src/main.rs
@@ -96,8 +96,13 @@ async fn signal_process(signal: &str, pid: u32) -> bool {
 
 impl NodeServer {
     async fn start_worker_int(&self, mut s: Streaming<StartWorkerReq>) -> anyhow::Result<WorkerId> {
-        let start_worker_req::Msg::Header(header) = s.next().await
-                .ok_or_else(|| anyhow!("Didn't receive header"))??.msg.unwrap() else {
+        let start_worker_req::Msg::Header(header) = s
+            .next()
+            .await
+            .ok_or_else(|| anyhow!("Didn't receive header"))??
+            .msg
+            .unwrap()
+        else {
             bail!("First message was not a header");
         };
 
@@ -254,7 +259,9 @@ impl NodeGrpc for NodeServer {
             let workers = self.workers.lock().unwrap();
 
             let Some(worker) = workers.get(&WorkerId(req.worker_id)) else {
-                return Ok(Response::new(StopWorkerResp { status: StopWorkerStatus::NotFound.into()}));
+                return Ok(Response::new(StopWorkerResp {
+                    status: StopWorkerStatus::NotFound.into(),
+                }));
             };
 
             (worker.running, worker.pid, worker.job_id.clone())

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -1747,7 +1747,10 @@ impl TryFrom<(BuiltinScalarFunction, Vec<Expression>)> for StringFunction {
             (2, BuiltinScalarFunction::RegexpMatch) => {
                 let first_argument = Box::new(args.remove(0));
                 let regex_arg = args.remove(0);
-                let Expression::Literal(LiteralExpression{literal: ScalarValue::Utf8(Some(regex))}) = regex_arg else {
+                let Expression::Literal(LiteralExpression {
+                    literal: ScalarValue::Utf8(Some(regex)),
+                }) = regex_arg
+                else {
                     bail!("regex argument must be a string literal")
                 };
                 let _ = Regex::new(&regex)?;
@@ -1820,7 +1823,10 @@ impl TryFrom<(BuiltinScalarFunction, Vec<Expression>)> for StringFunction {
             (3, BuiltinScalarFunction::RegexpReplace) => {
                 let first_argument = Box::new(args.remove(0));
                 let regex_arg = args.remove(0);
-                let Expression::Literal(LiteralExpression{literal: ScalarValue::Utf8(Some(regex))}) = regex_arg else {
+                let Expression::Literal(LiteralExpression {
+                    literal: ScalarValue::Utf8(Some(regex)),
+                }) = regex_arg
+                else {
                     bail!("regex argument must be a string literal")
                 };
                 let _ = Regex::new(&regex)?;
@@ -2371,7 +2377,7 @@ impl DataStructureFunction {
             }
             DataStructureFunction::NullIf { left, right: _ } => left.return_type().as_nullable(),
             DataStructureFunction::MakeArray(terms) => {
-                let TypeDef::DataType(primitive_type, _ ) = terms[0].return_type() else {
+                let TypeDef::DataType(primitive_type, _) = terms[0].return_type() else {
                     unreachable!("make_array should only be called on a primitive type")
                 };
                 let nullable = terms.iter().any(|term| term.nullable());
@@ -2688,7 +2694,10 @@ pub enum DateTimeFunction {
 }
 
 fn extract_literal_string(expr: Expression) -> Result<String, anyhow::Error> {
-    let Expression::Literal(LiteralExpression{literal: ScalarValue::Utf8(Some(literal_string))}) = expr else {
+    let Expression::Literal(LiteralExpression {
+        literal: ScalarValue::Utf8(Some(literal_string)),
+    }) = expr
+    else {
         bail!("Can only convert a literal into a string")
     };
     Ok(literal_string)

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -570,7 +570,12 @@ pub fn get_test_expression(
         };
     }
 
-    let Insert::Anonymous{logical_plan: LogicalPlan::Projection(projection)} = inserts.remove(0) else {panic!("expect projection")};
+    let Insert::Anonymous {
+        logical_plan: LogicalPlan::Projection(projection),
+    } = inserts.remove(0)
+    else {
+        panic!("expect projection")
+    };
     let ctx = ExpressionContext {
         schema_provider: &schema_provider,
         input_struct: &struct_def,

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -245,7 +245,9 @@ impl Optimizer for TwoPhaseOptimization {
         node: PlanNode,
         graph: &mut DiGraph<PlanNode, PlanEdge>,
     ) -> bool {
-        let PlanOperator::WindowAggregate { window, projection } = node.operator else { return false };
+        let PlanOperator::WindowAggregate { window, projection } = node.operator else {
+            return false;
+        };
         let (width, slide) = match window {
             WindowType::Tumbling { width } => (width, width),
             WindowType::Sliding { width, slide } => (width, slide),
@@ -378,7 +380,7 @@ impl Optimizer for WindowTopNOptimization {
                 if let PlanOperator::RecordTransform(RecordTransform::Filter(filter)) =
                     node.operator
                 {
-                    let  PlanType::Unkeyed(input_type) = node.output_type.clone() else {
+                    let PlanType::Unkeyed(input_type) = node.output_type.clone() else {
                         unreachable!("Filter must have unkeyed output type")
                     };
                     let field_name = &self.window_function_operator.as_ref().unwrap().field_name;
@@ -413,7 +415,9 @@ impl Optimizer for WindowTopNOptimization {
                             self.clear();
                             return false;
                         }
-                        let Ok(two_phase_projection) : Result<TwoPhaseAggregateProjection> = projection.try_into() else {
+                        let Ok(two_phase_projection): Result<TwoPhaseAggregateProjection> =
+                            projection.try_into()
+                        else {
                             self.clear();
                             return false;
                         };

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -782,7 +782,7 @@ impl<'a> SqlPipelineBuilder<'a> {
             },
         );
         let Some(join_filter) = &join.filter else {
-            return Ok(join_operator)
+            return Ok(join_operator);
         };
         let join_filter = self
             .ctx(&join_operator.return_type())

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -117,7 +117,7 @@ impl FusedRecordTransform {
         let mut predicates = Vec::new();
         let mut names = Vec::new();
         for expression in &self.expressions {
-            let RecordTransform::Filter(predicate)= expression else {
+            let RecordTransform::Filter(predicate) = expression else {
                 panic!("FusedRecordTransform.to_predicate_operator() called on non-predicate expression");
             };
             names.push("filter");

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -515,7 +515,7 @@ impl Table {
                 .fields
                 .iter()
                 .map(|f| {
-                    let TypeDef::DataType(data_type, nullable ) = f.data_type.clone() else {
+                    let TypeDef::DataType(data_type, nullable) = f.data_type.clone() else {
                         bail!("expect data type for generated column")
                     };
                     Ok(DFField::new_unqualified(&f.name, data_type, nullable))

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -460,11 +460,11 @@ impl TryFrom<&Type> for TypeDef {
                 let last = pat.path.segments.last().unwrap();
                 if last.ident == "Option" {
                     let AngleBracketed(args) = &last.arguments else {
-                        return Err(())
+                        return Err(());
                     };
 
                     let GenericArgument::Type(inner) = args.args.first().ok_or(())? else {
-                        return Err(())
+                        return Err(());
                     };
 
                     Ok(TypeDef::DataType(rust_to_arrow(inner)?, true))

--- a/arroyo-state/src/parquet.rs
+++ b/arroyo-state/src/parquet.rs
@@ -188,7 +188,9 @@ impl BackingStore for ParquetBackend {
             .map(|table| (table.name.clone().chars().next().unwrap(), table))
             .collect();
         for backend_data in operator_metadata.backend_data {
-            let Some(backend_data::BackendData::ParquetStore(parquet_data)) = backend_data.backend_data else {
+            let Some(backend_data::BackendData::ParquetStore(parquet_data)) =
+                backend_data.backend_data
+            else {
                 panic!("expect parquet data")
             };
             let table_descriptor = tables
@@ -405,8 +407,8 @@ impl ParquetBackend {
                 .backend_data
                 .iter()
                 .map(|backend_data| {
-                    let Some(BackendData::ParquetStore(parquet_store)) =
-                  &backend_data.backend_data else {
+                    let Some(BackendData::ParquetStore(parquet_store)) = &backend_data.backend_data
+                    else {
                         unreachable!("expect parquet backends")
                     };
                     parquet_store.file.clone()
@@ -417,12 +419,14 @@ impl ParquetBackend {
         let storage_client = StorageClient::new();
 
         for epoch_to_remove in old_min_epoch..new_min_epoch {
-            let Some(metadata) = Self::load_operator_metadata(&job_id, &operator, epoch_to_remove)
-            .await else {
+            let Some(metadata) =
+                Self::load_operator_metadata(&job_id, &operator, epoch_to_remove).await
+            else {
                 continue;
             };
             for backend_data in metadata.backend_data {
-                let Some(BackendData::ParquetStore(parquet_store)) = &backend_data.backend_data else {
+                let Some(BackendData::ParquetStore(parquet_store)) = &backend_data.backend_data
+                else {
                     unreachable!("expect parquet backends")
                 };
                 let file = parquet_store.file.clone();

--- a/arroyo-state/src/tables.rs
+++ b/arroyo-state/src/tables.rs
@@ -172,8 +172,7 @@ impl<'a, K: Key, V: Data + PartialEq, S: BackingStore> TimeKeyMap<'a, K, V, S> {
     }
 
     pub async fn flush(&mut self) {
-        let Some(timestamp) = self.cache.buffered_values
-        .keys().max() else {
+        let Some(timestamp) = self.cache.buffered_values.keys().max() else {
             return;
         };
         self.flush_at_watermark(*timestamp).await;

--- a/arroyo-worker/src/connectors/filesystem/local.rs
+++ b/arroyo-worker/src/connectors/filesystem/local.rs
@@ -152,9 +152,15 @@ impl<K: Key, D: Data + Sync, V: LocalWriter<D> + Send + 'static> TwoPhaseCommitt
             if task_info.task_index > 0 {
                 continue;
             }
-            let Some(CurrentFileRecovery { tmp_file, bytes_written, suffix, destination }) = current_file else {
+            let Some(CurrentFileRecovery {
+                tmp_file,
+                bytes_written,
+                suffix,
+                destination,
+            }) = current_file
+            else {
                 continue;
-             };
+            };
             let mut file = OpenOptions::new()
                 .write(true)
                 .open(tmp_file.clone())

--- a/arroyo-worker/src/connectors/filesystem/mod.rs
+++ b/arroyo-worker/src/connectors/filesystem/mod.rs
@@ -852,20 +852,20 @@ impl MultipartManager {
         if !self.closed {
             unreachable!("get_closed_file_checkpoint_data called on open file");
         }
-        let Some(ref multipart_id) =  self.multipart_id else  {
+        let Some(ref multipart_id) = self.multipart_id else {
             if self.pushed_size == 0 {
-            return FileCheckpointData::Empty;
+                return FileCheckpointData::Empty;
             } else {
-            return FileCheckpointData::MultiPartNotCreated {
-                parts_to_add: self
-                    .parts_to_add
-                    .iter()
-                    .map(|val| val.byte_data.clone())
-                    .collect(),
-                trailing_bytes: None,
-            };
-        }
-    };
+                return FileCheckpointData::MultiPartNotCreated {
+                    parts_to_add: self
+                        .parts_to_add
+                        .iter()
+                        .map(|val| val.byte_data.clone())
+                        .collect(),
+                    trailing_bytes: None,
+                };
+            }
+        };
         if self.all_uploads_finished() {
             return FileCheckpointData::MultiPartWriterUploadCompleted {
                 multi_part_upload_id: multipart_id.clone(),

--- a/arroyo-worker/src/connectors/fluvio/sink.rs
+++ b/arroyo-worker/src/connectors/fluvio/sink.rs
@@ -26,7 +26,7 @@ impl<K: Key + Serialize, T: Data + Serialize> FluvioSinkFunc<K, T> {
             serde_json::from_str(config).expect("Invalid config for FluvioSink");
         let table: FluvioTable =
             serde_json::from_value(config.table).expect("Invalid table config for FluvioSource");
-        let TableType::Sink{ .. } = &table.type_ else {
+        let TableType::Sink { .. } = &table.type_ else {
             panic!("found non-sink fluvio config in sink operator");
         };
 

--- a/arroyo-worker/src/connectors/fluvio/source.rs
+++ b/arroyo-worker/src/connectors/fluvio/source.rs
@@ -71,7 +71,7 @@ where
             serde_json::from_str(config).expect("Invalid config for FluvioSource");
         let table: FluvioTable =
             serde_json::from_value(config.table).expect("Invalid table config for FluvioSource");
-        let TableType::Source{ offset, .. } = &table.type_ else {
+        let TableType::Source { offset, .. } = &table.type_ else {
             panic!("found non-source Fluvio config in source operator");
         };
 

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -89,7 +89,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
             .expect("Invalid connection config for KafkaSink");
         let table: KafkaTable =
             serde_json::from_value(config.table).expect("Invalid table config for KafkaSource");
-        let TableType::Sink{ commit_mode } = table.type_ else {
+        let TableType::Sink { commit_mode } = table.type_ else {
             panic!("found non-sink kafka config in sink operator");
         };
 
@@ -250,12 +250,16 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
     }
 
     async fn handle_commit(&mut self, epoch: u32, ctx: &mut crate::engine::Context<(), ()>) {
-        let ConsistencyMode::ExactlyOnce { next_transaction_index: _, producer_to_complete } = &mut self.consistency_mode else {
+        let ConsistencyMode::ExactlyOnce {
+            next_transaction_index: _,
+            producer_to_complete,
+        } = &mut self.consistency_mode
+        else {
             warn!("received commit but consistency mode is not exactly once");
-            return
+            return;
         };
 
-        let Some(committing_producer)= producer_to_complete.take() else {
+        let Some(committing_producer) = producer_to_complete.take() else {
             unimplemented!("received a commit message without a producer ready to commit. Restoring from commit phase not yet implemented");
         };
         let mut commits_attempted = 0;

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -85,7 +85,7 @@ where
             .expect("Invalid connection config for KafkaSource");
         let table: KafkaTable =
             serde_json::from_value(config.table).expect("Invalid table config for KafkaSource");
-        let TableType::Source{ offset, read_mode } = &table.type_ else {
+        let TableType::Source { offset, read_mode } = &table.type_ else {
             panic!("found non-source kafka config in source operator");
         };
         let mut client_configs = client_configs(&connection);

--- a/arroyo-worker/src/connectors/kinesis/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kinesis/sink/mod.rs
@@ -101,7 +101,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KinesisSinkFunc<K, T> {
 
     async fn handle_tick(&mut self, _: u64, _ctx: &mut Context<(), ()>) {
         let Some(batch_preparer) = &self.in_progress_batch else {
-            return
+            return;
         };
 
         if !self.flush_config.should_flush(batch_preparer) {
@@ -167,7 +167,12 @@ struct FlushConfig {
 
 impl FlushConfig {
     fn new_from_table(table: &KinesisTable) -> Self {
-        let TableType::Sink { batch_flush_interval_millis, batch_max_buffer_size, records_per_batch } = &table.type_ else {
+        let TableType::Sink {
+            batch_flush_interval_millis,
+            batch_max_buffer_size,
+            records_per_batch,
+        } = &table.type_
+        else {
             panic!("found non-sink kinesis config in sink operator");
         };
         Self {

--- a/arroyo-worker/src/connectors/kinesis/source/mod.rs
+++ b/arroyo-worker/src/connectors/kinesis/source/mod.rs
@@ -61,7 +61,7 @@ struct KinesisSourceConfig {
 
 impl KinesisSourceConfig {
     fn new_from_table(table: &KinesisTable) -> Self {
-        let TableType::Source{offset: read_mode} = table.type_ else {
+        let TableType::Source { offset: read_mode } = table.type_ else {
             panic!("found non-source kinesis table in KinesisSource");
         };
         Self { read_mode }

--- a/arroyo-worker/src/operators/aggregating_window.rs
+++ b/arroyo-worker/src/operators/aggregating_window.rs
@@ -109,13 +109,15 @@ impl<K: Key, T: Data, BinA: Data, MemA: Data, OutT: Data>
         let watermark = ctx.last_present_watermark();
         let map = ctx.state.get_time_key_map::<K, BinA>('a', watermark).await;
 
-        let Some(map_min_time) = map.get_min_time()  else {
+        let Some(map_min_time) = map.get_min_time() else {
             self.state = SlidingWindowState::NoData;
             return;
         };
         let map_min_bin = self.bin_start(map_min_time);
         let Some(watermark) = watermark else {
-            self.state = SlidingWindowState::OnlyBufferedData { earliest_bin_time: map_min_bin };
+            self.state = SlidingWindowState::OnlyBufferedData {
+                earliest_bin_time: map_min_bin,
+            };
             return;
         };
         let watermark_bin = self.bin_start(watermark);

--- a/arroyo-worker/src/operators/sliding_top_n_aggregating_window.rs
+++ b/arroyo-worker/src/operators/sliding_top_n_aggregating_window.rs
@@ -152,13 +152,15 @@ impl<
         let watermark = ctx.last_present_watermark();
         let map: TimeKeyMap<K, BinA, _> = ctx.state.get_time_key_map('a', watermark).await;
 
-        let Some(map_min_time) = map.get_min_time()  else {
+        let Some(map_min_time) = map.get_min_time() else {
             self.state = SlidingWindowState::NoData;
             return;
         };
         let map_min_bin = self.bin_start(map_min_time);
         let Some(watermark) = watermark else {
-            self.state = SlidingWindowState::OnlyBufferedData { earliest_bin_time: map_min_bin };
+            self.state = SlidingWindowState::OnlyBufferedData {
+                earliest_bin_time: map_min_bin,
+            };
             return;
         };
         let watermark_bin = self.bin_start(watermark);


### PR DESCRIPTION
My PR #258 started failing with `cargo fmt` issues on untouched files. It seems newest Rust version is more restrictive/aggressive with formatting. Updated locally and ran to get this change set.