### PR TITLE
Improve scheduler cleanup robustness

### DIFF
--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -203,7 +203,11 @@ impl ControllerGrpc for ControllerServer {
         &self,
         request: Request<RegisterWorkerReq>,
     ) -> Result<Response<RegisterWorkerResp>, Status> {
-        info!("Worker registered: {:?}", request.get_ref());
+        info!(
+            "Worker registered: {:?} -- {:?}",
+            request.get_ref(),
+            request.remote_addr()
+        );
 
         let req = request.into_inner();
 

--- a/arroyo-controller/src/schedulers/kubernetes.rs
+++ b/arroyo-controller/src/schedulers/kubernetes.rs
@@ -57,7 +57,7 @@ impl KubernetesScheduler {
             name: format!("{}-worker", string_config(K8S_WORKER_NAME_ENV, "arroyo")),
             image: string_config(
                 K8S_WORKER_IMAGE_ENV,
-                "ghcr.io/arroyosystems/arroyo-worker:amd64",
+                "ghcr.io/arroyosystems/arroyo-worker:latest",
             ),
             labels: yaml_config(K8S_WORKER_LABELS_ENV, BTreeMap::new()),
             annotations: yaml_config(K8S_WORKER_ANNOTATIONS_ENV, BTreeMap::new()),

--- a/arroyo-controller/src/states/mod.rs
+++ b/arroyo-controller/src/states/mod.rs
@@ -424,6 +424,12 @@ async fn execute_state<'a>(
         | Err(StateError::RetryableError {
             message,
             source,
+            retries: 1,
+            ..
+        })
+        | Err(StateError::RetryableError {
+            message,
+            source,
             retries: 0,
             ..
         }) => {
@@ -435,7 +441,7 @@ async fn execute_state<'a>(
                 error = format!("{:?}", source)
             );
             log_event(
-                "state_error",
+                "fatal_state_error",
                 json!({
                     "service": "controller",
                     "job_id": ctx.config.id,

--- a/arroyo-controller/src/states/scheduling.rs
+++ b/arroyo-controller/src/states/scheduling.rs
@@ -110,7 +110,7 @@ async fn handle_worker_connect<'a>(
                     rpc_address
                 );
 
-                for i in 0..10 {
+                for i in 0..3 {
                     match Channel::from_shared(rpc_address.clone())
                         .unwrap()
                         .timeout(Duration::from_secs(10))
@@ -258,6 +258,7 @@ impl State for Scheduling {
         let start = Instant::now();
         loop {
             let timeout = STARTUP_TIME
+                .min(ctx.config.ttl.unwrap_or(STARTUP_TIME))
                 .checked_sub(start.elapsed())
                 .unwrap_or(Duration::ZERO);
 


### PR DESCRIPTION
This PR makes a few changes to improve robustness of cleanup during the stopping phase:
* If we fail to talk to the workers during clean up we will immediately turn to tearing down the resources instead of retrying 10 times and then moving to FAILED
* Previously we had no timeout on waiting for the workers to finish, so this could get stuck indefinitely if the workers were up but not doing anything. Now we have a 60 second timeout, after which we force stop
* For preview jobs (which have a ttl) we now will only wait up to the TTL for them to schedule, rather than waiting 20 minutes under the assumption that fast failing is preferable for preview jobs