### PR TITLE
Fix pipeline cleanup

### DIFF
--- a/arroyo-macro/src/lib.rs
+++ b/arroyo-macro/src/lib.rs
@@ -539,18 +539,22 @@ fn impl_stream_node_type(
                             }
                         }
                     }
-                    Some(((idx, item), s)) = sel.next() => {
-                        match idx / (in_partitions / #handler_count) {
-                            #(#handle_matchers
-                            )*
-                            _ => unreachable!()
+                    p = sel.next() => {
+                        match p {
+                            Some(((idx, item), s)) => {
+                                match idx / (in_partitions / #handler_count) {
+                                    #(#handle_matchers
+                                    )*
+                                    _ => unreachable!()
+                                }
+                            }
+                            None => {
+                                tracing::info!("[{}] Stream completed", ctx.task_info.operator_name);
+                                break;
+                            }
                         }
                     }
                     #tick_case
-                    else => {
-                        tracing::info!("[{}] Stream completed", ctx.task_info.operator_name);
-                        break;
-                    }
                 }
             }
 

--- a/arroyo-worker/src/inq_reader.rs
+++ b/arroyo-worker/src/inq_reader.rs
@@ -62,7 +62,6 @@ impl<St: Stream + Unpin> Stream for InQReader<St> {
                     // because it yielded a Some.
                     // We do not return, but poll `FuturesUnordered`
                     // in the next loop iteration.
-                    tracing::info!("hit this case");
                 }
                 None => return Poll::Ready(None),
             }


### PR DESCRIPTION
This PR fixes a regression in #197 that caused operators to hang instead of properly shutting down when their input queues closed.