### PR TITLE
Support deletes in the parquet backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "bytes",
  "ctor",
  "futures",
+ "lazy_static",
  "once_cell",
  "parquet",
  "prometheus",
@@ -746,6 +747,7 @@ dependencies = [
  "rand",
  "test-case",
  "tokio",
+ "tonic",
  "tracing",
 ]
 

--- a/arroyo-controller/src/job_controller/checkpointer.rs
+++ b/arroyo-controller/src/job_controller/checkpointer.rs
@@ -368,7 +368,7 @@ impl CheckpointState {
             .values()
             .fold(0, |size, s| size + s.metadata.as_ref().unwrap().bytes);
 
-        StateBackend::complete_operator_checkpoint(OperatorCheckpointMetadata {
+        StateBackend::write_operator_checkpoint_metadata(OperatorCheckpointMetadata {
             job_id: self.job_id.to_string(),
             operator_id: operator_id.clone(),
             epoch: self.epoch,

--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -56,6 +56,16 @@ lazy_static! {
         "number of active pipelines in arroyo-controller"
     )
     .unwrap();
+    pub static ref COMPACTION_TUPLES_IN: Gauge = register_gauge!(
+        "arroyo_controller_compaction_tuples_in",
+        "Number of tuples being considered for compaction"
+    )
+    .unwrap();
+    static ref COMPACTION_TUPLES_OUT: Gauge = register_gauge!(
+        "arroyo_controller_compaction_tuples_in",
+        "Number of tuples being considered for compaction"
+    )
+    .unwrap();
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/arroyo-macro/src/lib.rs
+++ b/arroyo-macro/src/lib.rs
@@ -537,6 +537,9 @@ fn impl_stream_node_type(
                             arroyo_rpc::ControlMessage::Stop { mode: _ } => tracing::warn!("shouldn't receive stop"),
                             arroyo_rpc::ControlMessage::Commit { epoch } => {
                                 self.handle_commit(epoch, &mut ctx).await;
+                            },
+                            arroyo_rpc::ControlMessage::LoadCompacted { compacted } => {
+                                ctx.load_compacted(compacted).await;
                             }
                         }
                     }
@@ -715,16 +718,16 @@ fn impl_stream_node_type(
             checkpoint_barrier: arroyo_types::CheckpointBarrier,
             ctx: &mut crate::engine::Context<#out_k, #out_t>) -> bool {
 
-            crate::process_fn::ProcessFnUtils::send_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::StartedCheckpointing).await;
+            crate::process_fn::ProcessFnUtils::send_checkpoint_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::StartedCheckpointing).await;
 
             self.handle_checkpoint(&checkpoint_barrier, ctx).await;
 
-            crate::process_fn::ProcessFnUtils::send_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::FinishedOperatorSetup).await;
+            crate::process_fn::ProcessFnUtils::send_checkpoint_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::FinishedOperatorSetup).await;
 
             let watermark = ctx.watermarks.last_present_watermark();
             ctx.state.checkpoint(checkpoint_barrier, watermark).await;
 
-            crate::process_fn::ProcessFnUtils::send_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::FinishedSync).await;
+            crate::process_fn::ProcessFnUtils::send_checkpoint_event(checkpoint_barrier, ctx, arroyo_rpc::grpc::TaskCheckpointEventType::FinishedSync).await;
 
             ctx.broadcast(arroyo_types::Message::Barrier(checkpoint_barrier)).await;
 

--- a/arroyo-rpc/proto/rpc.proto
+++ b/arroyo-rpc/proto/rpc.proto
@@ -195,6 +195,7 @@ message ParquetStoreData {
   uint64 max_routing_key = 5;
   uint64 max_timestamp_micros = 6;
   optional uint64 min_required_timestamp_micros = 7;
+  uint32 generation = 8;
 }
 
 // Checkpoint metadata
@@ -309,6 +310,15 @@ message CheckpointReq {
 message CheckpointResp {
 }
 
+message LoadCompactedDataReq {
+  string operator_id = 1;
+  repeated BackendData backend_data_to_drop = 2; // this data got compressed...
+  repeated BackendData backend_data_to_load = 3; // ...into this data
+}
+
+message LoadCompactedDataRes {
+}
+
 enum StopMode {
   // The stop message flows through the dataflow like a checkpoint, causing every node to stop at a consistent point
   GRACEFUL = 0;
@@ -332,6 +342,7 @@ message JobFinishedResp {
 service WorkerGrpc {
   rpc StartExecution(StartExecutionReq) returns (StartExecutionResp);
   rpc Checkpoint(CheckpointReq) returns (CheckpointResp);
+  rpc LoadCompactedData(LoadCompactedDataReq) returns (LoadCompactedDataRes);
   rpc StopExecution(StopExecutionReq) returns (StopExecutionResp);
   rpc JobFinished(JobFinishedReq) returns (JobFinishedResp);
 }

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -3,7 +3,7 @@ pub mod types;
 
 use std::{fs, time::SystemTime};
 
-use crate::grpc::SubtaskCheckpointMetadata;
+use crate::grpc::{LoadCompactedDataReq, SubtaskCheckpointMetadata};
 use crate::types::{Format, PrimitiveType};
 use arroyo_types::CheckpointBarrier;
 use grpc::{StopMode, TaskCheckpointEventType};
@@ -32,6 +32,24 @@ pub enum ControlMessage {
     Checkpoint(CheckpointBarrier),
     Stop { mode: StopMode },
     Commit { epoch: u32 },
+    LoadCompacted { compacted: CompactionResult },
+}
+
+#[derive(Debug, Clone)]
+pub struct CompactionResult {
+    pub operator_id: String,
+    pub backend_data_to_drop: Vec<grpc::BackendData>,
+    pub backend_data_to_load: Vec<grpc::BackendData>,
+}
+
+impl From<LoadCompactedDataReq> for CompactionResult {
+    fn from(req: LoadCompactedDataReq) -> Self {
+        Self {
+            operator_id: req.operator_id,
+            backend_data_to_drop: req.backend_data_to_drop,
+            backend_data_to_load: req.backend_data_to_load,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/arroyo-state/Cargo.toml
+++ b/arroyo-state/Cargo.toml
@@ -29,6 +29,8 @@ futures = "0.3"
 bytes = "1.4"
 prost = "0.11"
 prometheus = '0.13'
+tonic = {workspace = true}
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 test-case = "3"

--- a/arroyo-state/src/metrics.rs
+++ b/arroyo-state/src/metrics.rs
@@ -1,0 +1,20 @@
+use lazy_static::lazy_static;
+use prometheus::{register_gauge_vec, GaugeVec};
+
+lazy_static! {
+    pub static ref WORKER_LABELS_NAMES: Vec<&'static str> = vec!["operator_id", "task_id"];
+    pub static ref CURRENT_FILES_GAUGE: GaugeVec = register_gauge_vec!(
+        "arroyo_worker_current_files",
+        "Number of parquet files in the checkpoint",
+        &WORKER_LABELS_NAMES
+    )
+    .unwrap();
+    pub static ref TABLE_LABELS_NAMES: Vec<&'static str> =
+        vec!["operator_id", "task_id", "table_char"];
+    pub static ref TABLE_SIZE_GAUGE: GaugeVec = register_gauge_vec!(
+        "arroyo_worker_table_size_keys",
+        "Number of keys in the table",
+        &TABLE_LABELS_NAMES
+    )
+    .unwrap();
+}

--- a/arroyo-state/src/parquet.rs
+++ b/arroyo-state/src/parquet.rs
@@ -1,4 +1,6 @@
-use crate::{hash_key, BackingStore, BINCODE_CONFIG};
+use crate::metrics::CURRENT_FILES_GAUGE;
+use crate::tables::{BlindDataTuple, Compactor, DataTuple};
+use crate::{hash_key, BackingStore, DataOperation, StateStore, BINCODE_CONFIG};
 use anyhow::{Context, Result};
 use arrow_array::RecordBatch;
 use arroyo_rpc::grpc::backend_data::BackendData;
@@ -6,11 +8,11 @@ use arroyo_rpc::grpc::{
     backend_data, CheckpointMetadata, OperatorCheckpointMetadata, ParquetStoreData,
     SubtaskCheckpointMetadata, TableDeleteBehavior, TableDescriptor, TableType,
 };
-use arroyo_rpc::{CheckpointCompleted, ControlResp};
+use arroyo_rpc::{grpc, CheckpointCompleted, CompactionResult, ControlResp};
 use arroyo_storage::StorageProvider;
 use arroyo_types::{
-    from_micros, to_micros, CheckpointBarrier, Data, Key, TaskInfo, CHECKPOINT_URL_ENV,
-    S3_ENDPOINT_ENV, S3_REGION_ENV,
+    from_micros, range_for_server, to_micros, CheckpointBarrier, Data, Key, TaskInfo,
+    CHECKPOINT_URL_ENV, S3_ENDPOINT_ENV, S3_REGION_ENV,
 };
 use bincode::config;
 use bytes::Bytes;
@@ -25,10 +27,13 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
-use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::sync::{oneshot, Mutex};
-use tracing::warn;
-use tracing::{debug, info};
+use tokio::sync::mpsc::{self, channel, Receiver, Sender};
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+pub const FULL_KEY_RANGE: RangeInclusive<u64> = 0..=u64::MAX;
+pub const GENERATIONS_TO_COMPACT: u32 = 1; // only compact generation 0 files
 
 async fn get_storage_provider() -> anyhow::Result<StorageProvider> {
     // TODO: this should be encoded in the config so that the controller doesn't need
@@ -67,12 +72,13 @@ fn operator_path(job_id: &str, epoch: u32, operator: &str) -> String {
     format!("{}/operator-{}", base_path(job_id, epoch), operator)
 }
 
-fn table_checkpoint_path(task_info: &TaskInfo, table: char, epoch: u32) -> String {
+fn table_checkpoint_path(task_info: &TaskInfo, table: char, epoch: u32, compacted: bool) -> String {
     format!(
-        "{}/table-{}-{:0>3}",
+        "{}/table-{}-{:0>3}{}",
         operator_path(&task_info.job_id, epoch, &task_info.operator_id),
         table,
         task_info.task_index,
+        if compacted { "-compacted" } else { "" }
     )
 }
 
@@ -80,6 +86,10 @@ fn table_checkpoint_path(task_info: &TaskInfo, table: char, epoch: u32) -> Strin
 impl BackingStore for ParquetBackend {
     fn name() -> &'static str {
         "parquet"
+    }
+
+    fn task_info(&self) -> &TaskInfo {
+        &self.task_info
     }
 
     async fn load_latest_checkpoint_metadata(_job_id: &str) -> Option<CheckpointMetadata> {
@@ -110,7 +120,7 @@ impl BackingStore for ParquetBackend {
         Some(OperatorCheckpointMetadata::decode(&data[..]).unwrap())
     }
 
-    async fn complete_operator_checkpoint(metadata: OperatorCheckpointMetadata) {
+    async fn write_operator_checkpoint_metadata(metadata: OperatorCheckpointMetadata) {
         let storage_client = get_storage_provider().await.unwrap();
         let path = metadata_path(&operator_path(
             &metadata.job_id,
@@ -232,20 +242,24 @@ impl BackingStore for ParquetBackend {
         Ok(())
     }
 
-    async fn compact_checkpoint(
+    async fn cleanup_checkpoint(
         mut metadata: CheckpointMetadata,
         old_min_epoch: u32,
         min_epoch: u32,
     ) -> Result<()> {
-        info!(message = "Compacting", min_epoch, job_id = metadata.job_id);
+        info!(
+            message = "Cleaning checkpoint",
+            min_epoch,
+            job_id = metadata.job_id
+        );
 
         let mut futures: FuturesUnordered<_> = metadata
             .operator_ids
             .iter()
-            .map(|operator| {
-                Self::compact_operator(
+            .map(|operator_id| {
+                Self::cleanup_operator(
                     metadata.job_id.clone(),
-                    operator.clone(),
+                    operator_id.clone(),
                     old_min_epoch,
                     min_epoch,
                 )
@@ -264,11 +278,10 @@ impl BackingStore for ParquetBackend {
                     epoch_to_remove,
                     &operator_id,
                 ));
-                debug!("deleting {}", path);
                 storage_client.lock().await.delete_if_present(path).await?;
             }
             debug!(
-                message = "Finished compacting operator",
+                message = "Finished cleaning operator",
                 job_id = metadata.job_id,
                 operator_id,
                 min_epoch
@@ -301,11 +314,13 @@ impl BackingStore for ParquetBackend {
         self.epoch - 1
     }
 
-    async fn get_data_triples<K: Key, V: Data>(&self, table: char) -> Vec<(SystemTime, K, V)> {
+    async fn get_data_tuples<K: Key, V: Data>(&self, table: char) -> Vec<DataTuple<K, V>> {
         let mut result = vec![];
         match self.tables.get(&table).unwrap().table_type() {
             TableType::Global => todo!(),
             TableType::TimeKeyMap | TableType::KeyTimeMultiMap => {
+                // current_files is  table -> epoch -> file
+                // so we look at all epoch's files for this table
                 let Some(files) = self.current_files.get(&table) else {
                     return vec![];
                 };
@@ -315,7 +330,7 @@ impl BackingStore for ParquetBackend {
                     });
                     result.append(
                         &mut self
-                            .triples_from_parquet_bytes(bytes.into(), &self.task_info.key_range),
+                            .tuples_from_parquet_bytes(bytes.into(), &self.task_info.key_range),
                     );
                 }
             }
@@ -323,7 +338,7 @@ impl BackingStore for ParquetBackend {
         result
     }
 
-    async fn write_data_triple<K: Key, V: Data>(
+    async fn write_data_tuple<K: Key, V: Data>(
         &mut self,
         table: char,
         _table_type: TableType,
@@ -339,65 +354,286 @@ impl BackingStore for ParquetBackend {
             )
         };
         self.writer
-            .write(table, key_hash, timestamp, key_bytes, value_bytes)
+            .write(
+                table,
+                key_hash,
+                timestamp,
+                key_bytes,
+                value_bytes,
+                DataOperation::Insert,
+            )
+            .await;
+    }
+
+    async fn delete_data_tuple<K: Key>(
+        &mut self,
+        table: char,
+        _table_type: TableType,
+        timestamp: SystemTime,
+        key: &mut K,
+    ) {
+        let (key_hash, key_bytes) = {
+            (
+                hash_key(key),
+                bincode::encode_to_vec(&*key, config::standard()).unwrap(),
+            )
+        };
+        self.writer
+            .write(
+                table,
+                key_hash,
+                timestamp,
+                key_bytes,
+                vec![],
+                DataOperation::DeleteKey,
+            )
             .await;
     }
 
     async fn write_key_value<K: Key, V: Data>(&mut self, table: char, key: &mut K, value: &mut V) {
-        self.write_data_triple(table, TableType::Global, SystemTime::UNIX_EPOCH, key, value)
+        self.write_data_tuple(table, TableType::Global, SystemTime::UNIX_EPOCH, key, value)
+            .await
+    }
+
+    async fn delete_key_value<K: Key>(&mut self, table: char, key: &mut K) {
+        self.delete_data_tuple(table, TableType::Global, SystemTime::UNIX_EPOCH, key)
             .await
     }
 
     async fn get_global_key_values<K: Key, V: Data>(&self, table: char) -> Vec<(K, V)> {
-        let Some(files) = self.current_files.get(&table) else {
-            return vec![];
-        };
-        let mut state_map = HashMap::new();
-        for file in files.values().flatten() {
-            let bytes = self
-                .storage
-                .get(&file.file)
-                .await
-                .unwrap_or_else(|_| panic!("unable to find file {} in checkpoint", file.file));
-            for (_timestamp, key, value) in
-                self.triples_from_parquet_bytes(bytes.into(), &(0..=u64::MAX))
-            {
-                state_map.insert(key, value);
-            }
-        }
-        state_map.into_iter().collect()
+        self.get_key_values_for_key_range(table, &FULL_KEY_RANGE)
+            .await
     }
 
     async fn get_key_values<K: Key, V: Data>(&self, table: char) -> Vec<(K, V)> {
-        let Some(files) = self.current_files.get(&table) else {
-            return vec![];
-        };
-        let mut state_map = HashMap::new();
-        for file in files.values().flatten() {
-            let bytes = self
-                .storage
-                .get(&file.file)
-                .await
-                .unwrap_or_else(|_| panic!("unable to find file {} in checkpoint", file.file));
-            for (_timestamp, key, value) in
-                self.triples_from_parquet_bytes(bytes.into(), &self.task_info.key_range)
-            {
-                state_map.insert(key, value);
-            }
-        }
-        state_map.into_iter().collect()
+        self.get_key_values_for_key_range(table, &self.task_info.key_range)
+            .await
+    }
+
+    async fn load_compacted(&mut self, compaction: CompactionResult) {
+        self.writer.load_compacted_data(compaction).await;
     }
 }
 
 impl ParquetBackend {
-    async fn compact_operator(
+    /// Get all key-value pairs in the given table.
+    /// Looks at the operation to determine if the key-value pair should be included.
+    async fn get_key_values_for_key_range<K: Key, V: Data>(
+        &self,
+        table: char,
+        key_range: &RangeInclusive<u64>,
+    ) -> Vec<(K, V)> {
+        let Some(files) = self.current_files.get(&table) else {
+            return vec![];
+        };
+        let mut state_map = HashMap::new();
+        for file in files.values().flatten() {
+            let bytes = self
+                .storage
+                .get(&file.file)
+                .await
+                .unwrap_or_else(|_| panic!("unable to find file {} in checkpoint", file.file))
+                .into();
+            for tuple in self.tuples_from_parquet_bytes(bytes, key_range) {
+                match tuple.operation {
+                    DataOperation::Insert => {
+                        state_map.insert(tuple.key, tuple.value.unwrap());
+                    }
+                    DataOperation::DeleteKey => {
+                        state_map.remove(&tuple.key);
+                    }
+                }
+            }
+        }
+        state_map.into_iter().collect()
+    }
+
+    async fn compact_table_partition(
+        table_char: char,
+        task: TaskInfo,
+        generation: u32,
+        generation_files: Vec<ParquetStoreData>,
+        storage_client: StorageProvider,
+        new_min_epoch: u32,
+        table_descriptor: &TableDescriptor,
+    ) -> Option<ParquetStoreData> {
+        // accumulate this partition's tuples from all the table's files
+        // (spread across multiple epochs and files)
+        let mut tuples_in = vec![];
+        for file in generation_files {
+            let bytes = storage_client
+                .get(&file.file)
+                .await
+                .unwrap_or_else(|_| panic!("unable to find file {} in checkpoint", file.file));
+            let tuples =
+                ParquetBackend::blind_tuples_from_parquet_bytes(bytes.into(), &task.key_range);
+            tuples_in.extend(tuples);
+        }
+
+        // do the compaction
+        let compactor: Compactor = Compactor::for_table_type(table_descriptor.table_type());
+        let tuples_length = tuples_in.len();
+        let tuples_out = compactor.compact_tuples(tuples_in);
+
+        info!(
+            "Compaction summary for operator {}, table {}, task {}: {} tuples in, {} tuples out, {} tuples compacted",
+            task.operator_id,
+            table_char,
+            task.task_index,
+            tuples_length,
+            tuples_out.len(),
+            tuples_length - tuples_out.len()
+        );
+
+        let mut parquet_writer =
+            ParquetCompactFileWriter::new(table_char, new_min_epoch, task.clone(), generation + 1);
+
+        for tuple in tuples_out {
+            parquet_writer.write(
+                tuple.key_hash,
+                tuple.timestamp,
+                tuple.key,
+                tuple.value,
+                tuple.operation,
+            );
+        }
+
+        let p = parquet_writer
+            .flush(&storage_client)
+            .await
+            .expect("Failed to flush parquet writer");
+        p
+    }
+
+    /// Called after a checkpoint is committed
+    pub async fn compact_operator(
+        parallelism: usize,
         job_id: String,
-        operator: String,
+        operator_id: String,
+        epoch: u32,
+    ) -> Result<Option<CompactionResult>> {
+        let min_files_to_compact = env::var("MIN_FILES_TO_COMPACT")
+            .unwrap_or_else(|_| "4".to_string())
+            .parse()
+            .unwrap();
+
+        let checkpoint_metadata = Self::load_checkpoint_metadata(&job_id, epoch)
+            .await
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing checkpoint metadata for job {}, epoch {}",
+                    job_id, epoch
+                )
+            });
+
+        let operator_checkpoint_metadata =
+            Self::load_operator_metadata(&job_id, &operator_id, epoch)
+                .await
+                .expect("expect operator metadata to still be present");
+
+        let mut backend_data_to_drop = HashMap::new();
+        let mut backend_data_to_load = vec![]; // one file per partition per table
+
+        // we reduce the range of epochs to a set of compacted files
+        for index in 0..parallelism {
+            let key_range = range_for_server(index, parallelism);
+
+            // construct a theoretical TaskInfo for the purpose of partitioning the data
+            let task = TaskInfo {
+                job_id: job_id.clone(),
+                operator_name: "".to_string(), // TODO: this is not used
+                operator_id: operator_id.clone(),
+                task_index: index,
+                parallelism,
+                key_range: key_range.clone(),
+            };
+            let (tx, _) = channel(10);
+
+            // we must access the data through the state store because
+            // it keeps track of the table -> file relation
+            let mut state_store = StateStore::<ParquetBackend>::from_checkpoint(
+                &task,
+                checkpoint_metadata.clone(),
+                operator_checkpoint_metadata.tables.clone(),
+                tx.clone(),
+            )
+            .await;
+
+            // for each table this operator has, generate this partition's compacted file
+            for (table_char, epoch_files) in state_store.backend.current_files.drain() {
+                for generation in 0..GENERATIONS_TO_COMPACT {
+                    // get just the files for this table
+                    let generation_files: Vec<ParquetStoreData> = epoch_files
+                        .values()
+                        .flatten()
+                        .filter(|file| file.generation == generation)
+                        .cloned()
+                        .collect();
+
+                    if generation_files.len() < min_files_to_compact {
+                        continue;
+                    }
+
+                    info!(
+                        message = "Compacting table partition",
+                        job_id,
+                        operator_id,
+                        table = table_char.to_string(),
+                        epoch,
+                        index,
+                        files = generation_files.len(),
+                    );
+
+                    for file in &generation_files {
+                        backend_data_to_drop.insert(
+                            file.file.clone(),
+                            grpc::BackendData {
+                                backend_data: Some(BackendData::ParquetStore(file.clone())),
+                            },
+                        );
+                    }
+
+                    let compact_parquet_store_data = ParquetBackend::compact_table_partition(
+                        table_char,
+                        task.clone(),
+                        generation,
+                        generation_files,
+                        get_storage_provider().await?,
+                        epoch,
+                        state_store.table_descriptors.get(&table_char).unwrap(),
+                    )
+                    .await;
+
+                    if let Some(p) = compact_parquet_store_data {
+                        backend_data_to_load.push(grpc::BackendData {
+                            backend_data: Some(BackendData::ParquetStore(p)),
+                        });
+                    }
+                }
+            }
+        }
+
+        if !backend_data_to_drop.is_empty() {
+            // CompactionResult is only sent if there is data to drop
+            Ok(Some(CompactionResult {
+                operator_id,
+                backend_data_to_drop: backend_data_to_drop.values().cloned().collect(),
+                backend_data_to_load,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Delete files no longer referenced by the new min epoch
+    pub async fn cleanup_operator(
+        job_id: String,
+        operator_id: String,
         old_min_epoch: u32,
         new_min_epoch: u32,
-    ) -> anyhow::Result<String> {
+    ) -> Result<String> {
         let paths_to_keep: HashSet<String> =
-            Self::load_operator_metadata(&job_id, &operator, new_min_epoch)
+            Self::load_operator_metadata(&job_id, &operator_id, new_min_epoch)
                 .await
                 .expect("expect new_min_epoch metadata to still be present")
                 .backend_data
@@ -416,10 +652,12 @@ impl ParquetBackend {
 
         for epoch_to_remove in old_min_epoch..new_min_epoch {
             let Some(metadata) =
-                Self::load_operator_metadata(&job_id, &operator, epoch_to_remove).await
+                Self::load_operator_metadata(&job_id, &operator_id, epoch_to_remove).await
             else {
                 continue;
             };
+
+            // delete any files that are not in the new min epoch
             for backend_data in metadata.backend_data {
                 let Some(BackendData::ParquetStore(parquet_store)) = &backend_data.backend_data
                 else {
@@ -432,13 +670,16 @@ impl ParquetBackend {
                 }
             }
         }
-        Ok(operator)
+
+        Ok(operator_id)
     }
-    fn triples_from_parquet_bytes<K: Key, V: Data>(
+
+    /// Return rows from the given bytes that are in the given key range
+    fn tuples_from_parquet_bytes<K: Key, V: Data>(
         &self,
         bytes: Vec<u8>,
         range: &RangeInclusive<u64>,
-    ) -> Vec<(SystemTime, K, V)> {
+    ) -> Vec<DataTuple<K, V>> {
         let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::copy_from_slice(&bytes))
             .unwrap()
             .build()
@@ -469,6 +710,11 @@ impl ParquetBackend {
                 .as_any()
                 .downcast_ref::<arrow_array::BinaryArray>()
                 .unwrap();
+            let operation_array = batch
+                .column(4)
+                .as_any()
+                .downcast_ref::<arrow_array::UInt8Array>()
+                .unwrap();
             for index in 0..num_rows {
                 if !range.contains(&key_hash_array.value(index)) {
                     continue;
@@ -479,19 +725,173 @@ impl ParquetBackend {
                 let key: K = bincode::decode_from_slice(key_array.value(index), BINCODE_CONFIG)
                     .unwrap()
                     .0;
-                let value: V = bincode::decode_from_slice(value_array.value(index), BINCODE_CONFIG)
-                    .unwrap()
-                    .0;
-                result.push((timestamp, key, value));
+
+                let value_option =
+                    bincode::decode_from_slice(value_array.value(index), BINCODE_CONFIG);
+
+                let value: Option<V> = match value_option {
+                    Ok(v) => Some(v.0),
+                    Err(_) => None,
+                };
+
+                let operation = operation_array.value(index).into();
+
+                result.push(DataTuple {
+                    timestamp,
+                    key,
+                    value,
+                    operation,
+                });
+            }
+        }
+        result
+    }
+
+    /// Return rows from the given bytes that are in the given key range,
+    /// but without deserializing the key and value.
+    fn blind_tuples_from_parquet_bytes(
+        bytes: Vec<u8>,
+        range: &RangeInclusive<u64>,
+    ) -> Vec<BlindDataTuple> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::copy_from_slice(&bytes))
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let mut result = vec![];
+
+        let batches: Vec<RecordBatch> = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        for batch in batches {
+            let num_rows = batch.num_rows();
+            let key_hash_array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow_array::UInt64Array>()
+                .unwrap();
+            let time_array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<arrow_array::TimestampMicrosecondArray>()
+                .expect("Column 1 is not a TimestampMicrosecondArray");
+            let key_array = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<arrow_array::BinaryArray>()
+                .unwrap();
+            let value_array = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<arrow_array::BinaryArray>()
+                .unwrap();
+            let operation_array = batch
+                .column(4)
+                .as_any()
+                .downcast_ref::<arrow_array::UInt8Array>()
+                .unwrap();
+            for index in 0..num_rows {
+                let key_hash = key_hash_array.value(index);
+                if !range.contains(&key_hash) {
+                    continue;
+                }
+
+                let timestamp = from_micros(time_array.value(index) as u64);
+
+                let key = key_array.value(index).to_owned();
+                let value = value_array.value(index).to_owned();
+                let operation = operation_array.value(index).into();
+
+                result.push(BlindDataTuple {
+                    key_hash,
+                    timestamp,
+                    key,
+                    value,
+                    operation,
+                });
             }
         }
         result
     }
 }
 
-struct ParquetWriter {
+pub struct ParquetCompactFileWriter {
+    table_char: char,
+    epoch: u32,
+    task_info: TaskInfo,
+    builder: RecordBatchBuilder,
+    new_generation: u32,
+}
+
+impl ParquetCompactFileWriter {
+    pub fn new(table_char: char, epoch: u32, task_info: TaskInfo, new_generation: u32) -> Self {
+        ParquetCompactFileWriter {
+            table_char,
+            epoch,
+            task_info,
+            builder: RecordBatchBuilder::default(),
+            new_generation,
+        }
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        key_hash: u64,
+        timestamp: SystemTime,
+        key: Vec<u8>,
+        data: Vec<u8>,
+        operation: DataOperation,
+    ) {
+        self.builder
+            .insert(key_hash, timestamp, key, data, operation);
+    }
+
+    async fn upload_record_batch(
+        key: &str,
+        record_batch: arrow_array::RecordBatch,
+        storage: &StorageProvider,
+    ) -> Result<usize> {
+        let props = WriterProperties::builder()
+            .set_compression(parquet::basic::Compression::ZSTD(ZstdLevel::default()))
+            .set_statistics_enabled(EnabledStatistics::None)
+            .build();
+        let cursor = Vec::new();
+        let mut writer = ArrowWriter::try_new(cursor, record_batch.schema(), Some(props)).unwrap();
+        writer.write(&record_batch)?;
+        writer.flush().unwrap();
+        let parquet_bytes = writer.into_inner().unwrap();
+        let bytes = parquet_bytes.len();
+        storage.put(key, parquet_bytes).await?;
+        Ok(bytes)
+    }
+
+    pub async fn flush(self, storage: &StorageProvider) -> Result<Option<ParquetStoreData>> {
+        let s3_key = table_checkpoint_path(&self.task_info, self.table_char, self.epoch, true);
+
+        // write the file even if the builder is empty
+        // so that we can delete the old files
+        match self.builder.flush() {
+            Some((record_batch, stats)) => {
+                ParquetCompactFileWriter::upload_record_batch(&s3_key, record_batch, storage)
+                    .await?;
+                return Ok(Some(ParquetStoreData {
+                    epoch: self.epoch,
+                    file: s3_key,
+                    table: self.table_char.to_string(),
+                    min_routing_key: stats.min_routing_key,
+                    max_routing_key: stats.max_routing_key,
+                    max_timestamp_micros: to_micros(stats.max_timestamp),
+                    min_required_timestamp_micros: None,
+                    generation: self.new_generation,
+                }));
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+pub struct ParquetWriter {
     sender: Sender<ParquetQueueItem>,
     finish_rx: Option<oneshot::Receiver<()>>,
+    load_compacted_rx: Sender<CompactionResult>,
 }
 
 impl ParquetWriter {
@@ -504,6 +904,7 @@ impl ParquetWriter {
     ) -> Self {
         let (tx, rx) = mpsc::channel(1024 * 1024);
         let (finish_tx, finish_rx) = oneshot::channel();
+        let (load_compacted_rx, load_compacted_tx) = mpsc::channel(1024 * 1024);
 
         (ParquetFlusher {
             queue: rx,
@@ -517,12 +918,15 @@ impl ParquetWriter {
                 .collect(),
             builders: HashMap::new(),
             current_files,
+            load_compacted_tx,
+            new_compacted: vec![],
         })
         .start();
 
         ParquetWriter {
             sender: tx,
             finish_rx: Some(finish_rx),
+            load_compacted_rx,
         }
     }
 
@@ -533,6 +937,7 @@ impl ParquetWriter {
         timestamp: SystemTime,
         key: Vec<u8>,
         data: Vec<u8>,
+        operation: DataOperation,
     ) {
         self.sender
             .send(ParquetQueueItem::Write(ParquetWrite {
@@ -541,9 +946,14 @@ impl ParquetWriter {
                 timestamp,
                 key,
                 data,
+                operation,
             }))
             .await
             .unwrap();
+    }
+
+    async fn load_compacted_data(&mut self, compaction: CompactionResult) {
+        self.load_compacted_rx.send(compaction).await.unwrap();
     }
 
     async fn checkpoint(
@@ -584,6 +994,7 @@ struct ParquetWrite {
     timestamp: SystemTime,
     key: Vec<u8>,
     data: Vec<u8>,
+    operation: DataOperation,
 }
 
 #[derive(Debug)]
@@ -593,6 +1004,7 @@ struct ParquetCheckpoint {
     watermark: Option<SystemTime>,
     then_stop: bool,
 }
+
 struct RecordBatchBuilder {
     key_hash_builder: arrow_array::builder::PrimitiveBuilder<arrow_array::types::UInt64Type>,
     start_time_array:
@@ -600,6 +1012,7 @@ struct RecordBatchBuilder {
     key_bytes: arrow_array::builder::BinaryBuilder,
     data_bytes: arrow_array::builder::BinaryBuilder,
     parquet_stats: ParquetStats,
+    operation_array: arrow_array::builder::PrimitiveBuilder<arrow_array::types::UInt8Type>,
 }
 
 struct ParquetStats {
@@ -619,7 +1032,14 @@ impl Default for ParquetStats {
 }
 
 impl RecordBatchBuilder {
-    fn insert(&mut self, key_hash: u64, timestamp: SystemTime, key: Vec<u8>, data: Vec<u8>) {
+    fn insert(
+        &mut self,
+        key_hash: u64,
+        timestamp: SystemTime,
+        key: Vec<u8>,
+        data: Vec<u8>,
+        operation: DataOperation,
+    ) {
         self.parquet_stats.min_routing_key = self.parquet_stats.min_routing_key.min(key_hash);
         self.parquet_stats.max_routing_key = self.parquet_stats.max_routing_key.max(key_hash);
 
@@ -628,6 +1048,8 @@ impl RecordBatchBuilder {
             .append_value(to_micros(timestamp) as i64);
         self.key_bytes.append_value(key);
         self.data_bytes.append_value(data);
+
+        self.operation_array.append_value(operation as u8);
         self.parquet_stats.max_timestamp = self.parquet_stats.max_timestamp.max(timestamp);
     }
 
@@ -642,6 +1064,7 @@ impl RecordBatchBuilder {
         > = self.start_time_array.finish();
         let key_array: arrow_array::BinaryArray = self.key_bytes.finish();
         let data_array: arrow_array::BinaryArray = self.data_bytes.finish();
+        let operations_array = self.operation_array.finish();
         Some((
             arrow_array::RecordBatch::try_new(
                 self.schema(),
@@ -650,6 +1073,7 @@ impl RecordBatchBuilder {
                     std::sync::Arc::new(start_time_array),
                     std::sync::Arc::new(key_array),
                     std::sync::Arc::new(data_array),
+                    std::sync::Arc::new(operations_array),
                 ],
             )
             .unwrap(),
@@ -671,6 +1095,7 @@ impl RecordBatchBuilder {
                 arrow::datatypes::DataType::Binary,
                 false,
             ),
+            arrow::datatypes::Field::new("operation", arrow::datatypes::DataType::UInt8, false),
         ]))
     }
 }
@@ -685,6 +1110,9 @@ impl Default for RecordBatchBuilder {
             >::with_capacity(1024),
             key_bytes: arrow_array::builder::BinaryBuilder::default(),
             data_bytes: arrow_array::builder::BinaryBuilder::default(),
+            operation_array: arrow_array::builder::PrimitiveBuilder::<
+                arrow_array::types::UInt8Type,
+            >::with_capacity(1024),
             parquet_stats: ParquetStats::default(),
         }
     }
@@ -698,7 +1126,9 @@ struct ParquetFlusher {
     task_info: TaskInfo,
     table_descriptors: HashMap<char, TableDescriptor>,
     builders: HashMap<char, RecordBatchBuilder>,
-    current_files: HashMap<char, BTreeMap<u32, Vec<ParquetStoreData>>>,
+    current_files: HashMap<char, BTreeMap<u32, Vec<ParquetStoreData>>>, // table -> epoch -> file
+    load_compacted_tx: Receiver<CompactionResult>,
+    new_compacted: Vec<ParquetStoreData>,
 }
 
 impl ParquetFlusher {
@@ -722,7 +1152,7 @@ impl ParquetFlusher {
             .build();
         let cursor = Vec::new();
         let mut writer = ArrowWriter::try_new(cursor, record_batch.schema(), Some(props)).unwrap();
-        writer.write(&record_batch).expect("Writing batch");
+        writer.write(&record_batch)?;
         writer.flush().unwrap();
         let parquet_bytes = writer.into_inner().unwrap();
         let bytes = parquet_bytes.len();
@@ -730,15 +1160,72 @@ impl ParquetFlusher {
         Ok(bytes)
     }
 
+    fn get_parquet_store_parts(backend_data: grpc::BackendData) -> (ParquetStoreData, char, u32) {
+        let Some(BackendData::ParquetStore(parquet_store)) = backend_data.backend_data else {
+            unreachable!("expect parquet backends")
+        };
+        let table_char = parquet_store.table.chars().next().unwrap();
+        let epoch = parquet_store.epoch;
+        (parquet_store, table_char, epoch)
+    }
+
+    async fn load_compacted(&mut self, compaction: &CompactionResult) {
+        info!(
+            "Loading compacted data for operator {}. Dropping {} files, loading {} files.",
+            compaction.operator_id,
+            compaction.backend_data_to_drop.len(),
+            compaction.backend_data_to_load.len(),
+        );
+
+        // add all the new files
+        for backend_data in compaction.backend_data_to_load.clone() {
+            let (parquet_store, table_char, epoch) = Self::get_parquet_store_parts(backend_data);
+
+            self.current_files
+                .entry(table_char)
+                .or_default()
+                .entry(epoch)
+                .or_default()
+                .push(parquet_store.clone());
+
+            // separately keep track of the new files so we can
+            // force them to be included in the next checkpoint
+            self.new_compacted.push(parquet_store);
+        }
+
+        // remove all the old files
+        for backend_data in compaction.backend_data_to_drop.clone() {
+            let (parquet_store, table_char, epoch) = Self::get_parquet_store_parts(backend_data);
+
+            if let Some(x) = self.current_files.get_mut(&table_char) {
+                if let Some(y) = x.get_mut(&epoch) {
+                    if let Some(index) = y.iter().position(|f| f.file == parquet_store.file) {
+                        y.remove(index);
+                    }
+                }
+            }
+        }
+    }
+
     async fn flush_iteration(&mut self) -> Result<bool> {
         let mut checkpoint_epoch = None;
 
+        // accumulate writes in the RecordBatchBuilders until we get a checkpoint
         while checkpoint_epoch.is_none() {
             tokio::select! {
+                compaction = self.load_compacted_tx.recv() => {
+                    match compaction {
+                        Some(compaction) => {
+                            self.load_compacted(&compaction).await;
+                            return Ok(true)
+                        }
+                        None => { return Ok(false)}
+                    }
+                }
                 op = self.queue.recv() => {
                     match op {
-                        Some(ParquetQueueItem::Write( ParquetWrite{table, key_hash, timestamp, key, data})) => {
-                            self.builders.entry(table).or_default().insert(key_hash, timestamp, key, data);
+                        Some(ParquetQueueItem::Write( ParquetWrite{table, key_hash, timestamp, key, data, operation})) => {
+                            self.builders.entry(table).or_default().insert(key_hash, timestamp, key, data, operation);
                         }
                         Some(ParquetQueueItem::Checkpoint(epoch)) => {
                             checkpoint_epoch = Some(epoch);
@@ -752,8 +1239,6 @@ impl ParquetFlusher {
             }
         }
 
-        let mut backend_data = vec![];
-
         if let Some(cp) = checkpoint_epoch {
             let mut bytes = 0;
             let mut to_write = vec![];
@@ -761,10 +1246,11 @@ impl ParquetFlusher {
                 let Some((record_batch, stats)) = builder.flush() else {
                     continue;
                 };
-                let s3_key = table_checkpoint_path(&self.task_info, table, cp.epoch);
+                let s3_key = table_checkpoint_path(&self.task_info, table, cp.epoch, false);
                 to_write.push((record_batch, s3_key, table, stats));
             }
 
+            // write the files and update current_files
             for (record_batch, s3_key, table, stats) in to_write {
                 bytes += self.upload_record_batch(&s3_key, record_batch).await?;
                 self.current_files
@@ -780,10 +1266,16 @@ impl ParquetFlusher {
                         max_routing_key: stats.max_routing_key,
                         max_timestamp_micros: to_micros(stats.max_timestamp),
                         min_required_timestamp_micros: None,
+                        generation: 0,
                     });
             }
-            let mut new_file_map: HashMap<char, BTreeMap<u32, Vec<ParquetStoreData>>> =
+
+            // build backend_data (to send to controller in SubtaskCheckpointMetadata)
+            // and new current_files
+            let mut checkpoint_backend_data = vec![];
+            let mut new_current_files: HashMap<char, BTreeMap<u32, Vec<ParquetStoreData>>> =
                 HashMap::new();
+
             for (table, epoch_files) in self.current_files.drain() {
                 let table_descriptor = self.table_descriptors.get(&table).unwrap();
                 for (epoch, files) in epoch_files {
@@ -795,39 +1287,59 @@ impl ParquetFlusher {
                             == TableDeleteBehavior::NoReadsBeforeWatermark
                         {
                             if let Some(checkpoint_watermark) = cp.watermark {
-                                // this file is not needed by the new checkpoint.
                                 if file.max_timestamp_micros
                                     < to_micros(checkpoint_watermark)
                                         - table_descriptor.retention_micros
+                                    && !self.new_compacted.iter().any(|f| f.file == file.file)
                                 {
+                                    // this file is not needed by the new checkpoint
+                                    // because its data is older than the watermark
                                     continue;
                                 }
                             }
                         }
-                        backend_data.push(arroyo_rpc::grpc::BackendData {
+                        checkpoint_backend_data.push(grpc::BackendData {
                             backend_data: Some(BackendData::ParquetStore(file.clone())),
                         });
-                        new_file_map
+                        new_current_files
                             .entry(table)
                             .or_default()
-                            .entry(cp.epoch)
+                            .entry(epoch)
                             .or_default()
                             .push(file);
                     }
                 }
             }
+            self.current_files = new_current_files;
+            self.new_compacted = vec![];
 
-            self.current_files = new_file_map;
+            // compute total number of files in this checkpoint
+            let mut total_files = 0;
+            let mut max_timestamp: u64 = 0;
+            for (_table, epoch_files) in self.current_files.iter() {
+                for (_epoch, files) in epoch_files.iter() {
+                    total_files += files.len();
+                    for file in files {
+                        max_timestamp = max_timestamp.max(file.max_timestamp_micros);
+                    }
+                }
+            }
 
-            // write checkpoint metadata
+            let task_index = self.task_info.task_index.to_string();
+            let label_values = [self.task_info.operator_id.as_str(), task_index.as_str()];
+            CURRENT_FILES_GAUGE
+                .with_label_values(&label_values)
+                .set(total_files as f64);
+
+            // send controller the subtask metadata
             let subtask_metadata = SubtaskCheckpointMetadata {
                 subtask_index: self.task_info.task_index as u32,
                 start_time: to_micros(cp.time),
                 finish_time: to_micros(SystemTime::now()),
-                has_state: !backend_data.is_empty(),
+                has_state: !checkpoint_backend_data.is_empty(),
                 tables: self.table_descriptors.values().cloned().collect(),
                 watermark: cp.watermark.map(to_micros),
-                backend_data,
+                backend_data: checkpoint_backend_data,
                 bytes: bytes as u64,
             };
             self.control_tx

--- a/arroyo-worker/src/connectors/fluvio/source.rs
+++ b/arroyo-worker/src/connectors/fluvio/source.rs
@@ -241,6 +241,9 @@ where
                         Some(ControlMessage::Commit{..}) => {
                             return Err(UserError::new("Fluvio source does not support committing", ""));
                         }
+                        Some(ControlMessage::LoadCompacted {compacted}) => {
+                            ctx.load_compacted(compacted).await;
+                        }
                         None => {
 
                         }

--- a/arroyo-worker/src/connectors/impulse.rs
+++ b/arroyo-worker/src/connectors/impulse.rs
@@ -170,6 +170,9 @@ impl<K: Data, T: Data> ImpulseSourceFunc<K, T> {
                 Ok(ControlMessage::Commit { epoch: _ }) => {
                     unreachable!("sources shouldn't receive commit messages");
                 }
+                Ok(ControlMessage::LoadCompacted { compacted }) => {
+                    ctx.load_compacted(compacted).await;
+                }
                 Err(_) => {
                     // no messages
                 }

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -280,6 +280,9 @@ where
                         Some(ControlMessage::Commit { epoch: _ }) => {
                             unreachable!("sources shouldn't receive commit messages");
                         }
+                        Some(ControlMessage::LoadCompacted {compacted}) => {
+                            ctx.load_compacted(compacted).await;
+                        }
                         None => {
 
                         }

--- a/arroyo-worker/src/connectors/kafka/source/test.rs
+++ b/arroyo-worker/src/connectors/kafka/source/test.rs
@@ -220,7 +220,7 @@ async fn test_kafka() {
 
     reader.assert_next_message_checkpoint(1).await;
 
-    StateBackend::complete_operator_checkpoint(OperatorCheckpointMetadata {
+    StateBackend::write_operator_checkpoint_metadata(OperatorCheckpointMetadata {
         job_id: task_info.job_id.clone(),
         operator_id: task_info.operator_id.clone(),
         epoch: 1,

--- a/arroyo-worker/src/connectors/kinesis/source/mod.rs
+++ b/arroyo-worker/src/connectors/kinesis/source/mod.rs
@@ -449,6 +449,9 @@ impl<K: Data, T: Data + DeserializeOwned> KinesisSourceFunc<K, T> {
                         Some(ControlMessage::Commit { epoch: _ }) => {
                             unreachable!("sources shouldn't receive commit messages");
                         }
+                        Some(ControlMessage::LoadCompacted { compacted }) => {
+                            ctx.load_compacted(compacted).await;
+                        },
                         None => {
 
                         }

--- a/arroyo-worker/src/connectors/polling_http.rs
+++ b/arroyo-worker/src/connectors/polling_http.rs
@@ -155,6 +155,9 @@ where
             ControlMessage::Commit { epoch: _ } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
+            ControlMessage::LoadCompacted { compacted } => {
+                ctx.load_compacted(compacted).await;
+            }
         }
         None
     }

--- a/arroyo-worker/src/connectors/sse.rs
+++ b/arroyo-worker/src/connectors/sse.rs
@@ -129,6 +129,9 @@ where
             ControlMessage::Commit { epoch: _ } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
+            ControlMessage::LoadCompacted { compacted } => {
+                ctx.load_compacted(compacted).await;
+            }
         }
         None
     }

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -112,6 +112,9 @@ where
             ControlMessage::Commit { epoch: _ } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
+            ControlMessage::LoadCompacted { compacted } => {
+                ctx.load_compacted(compacted).await;
+            }
         }
         None
     }

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -1,10 +1,8 @@
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 
-use std::collections::{BTreeMap, HashMap};
-use std::ops::RangeInclusive;
-
 use std::any::Any;
+use std::collections::{BTreeMap, HashMap};
 use std::{mem, thread};
 
 use std::time::SystemTime;
@@ -19,10 +17,10 @@ use arroyo_rpc::grpc::{
     CheckpointMetadata, TableDeleteBehavior, TableDescriptor, TableType, TableWriteBehavior,
     TaskAssignment,
 };
-use arroyo_rpc::{ControlMessage, ControlResp};
+use arroyo_rpc::{CompactionResult, ControlMessage, ControlResp};
 use arroyo_types::{
-    from_micros, CheckpointBarrier, Data, Key, Message, Record, TaskInfo, UserError, Watermark,
-    WorkerId, BYTES_SENT, MESSAGES_SENT,
+    from_micros, range_for_server, server_for_hash, CheckpointBarrier, Data, Key, Message, Record,
+    TaskInfo, UserError, Watermark, WorkerId, BYTES_SENT, MESSAGES_SENT,
 };
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
@@ -57,21 +55,6 @@ impl<K: Key, T: Data> From<QueueItem> for Message<K, T> {
             }
         }
     }
-}
-fn range_for_server(i: usize, n: usize) -> RangeInclusive<u64> {
-    let range_size = u64::MAX / (n as u64);
-    let start = range_size * (i as u64);
-    let end = if i + 1 == n {
-        u64::MAX
-    } else {
-        start + range_size - 1
-    };
-    start..=end
-}
-
-fn server_for_hash(x: u64, n: usize) -> usize {
-    let range_size = u64::MAX / (n as u64);
-    (n - 1).min((x / range_size) as usize)
 }
 
 pub trait StreamNode: Send {
@@ -437,6 +420,10 @@ impl<K: Key, T: Data> Context<K, T> {
             .await
             .unwrap();
     }
+
+    pub async fn load_compacted(&mut self, compaction: CompactionResult) {
+        self.state.load_compacted(compaction).await;
+    }
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
@@ -784,6 +771,43 @@ impl RunningEngine {
             })
             .collect()
     }
+
+    pub fn operator_controls(&self) -> HashMap<String, Vec<Sender<ControlMessage>>> {
+        let mut controls = HashMap::new();
+
+        self.program
+            .graph
+            .node_indices()
+            .filter(|idx| {
+                let w = self.program.graph.node_weight(*idx).unwrap();
+                self.assignments
+                    .get(&(w.id().to_string(), w.subtask_idx()))
+                    .unwrap()
+                    .worker_id
+                    == self.worker_id.0
+            })
+            .for_each(|idx| {
+                let w = self.program.graph.node_weight(idx).unwrap();
+                let assignment = self
+                    .assignments
+                    .get(&(w.id().to_string(), w.subtask_idx()))
+                    .unwrap();
+                let tx = self
+                    .program
+                    .graph
+                    .node_weight(idx)
+                    .unwrap()
+                    .as_queue()
+                    .tx
+                    .clone();
+                controls
+                    .entry(assignment.operator_id.clone())
+                    .or_insert(vec![])
+                    .push(tx);
+            });
+
+        controls
+    }
 }
 
 impl Engine {
@@ -1118,39 +1142,6 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-
-    #[test]
-    fn test_range_for_server() {
-        let n = 6;
-
-        for i in 0..(n - 1) {
-            let range1 = range_for_server(i, n);
-            let range2 = range_for_server(i + 1, n);
-
-            assert_eq!(*range1.end() + 1, *range2.start(), "Ranges not adjacent");
-        }
-
-        let last_range = range_for_server(n - 1, n);
-        assert_eq!(
-            *last_range.end(),
-            u64::MAX,
-            "Last range does not contain u64::MAX"
-        );
-    }
-
-    #[test]
-    fn test_server_for_hash() {
-        let n = 2;
-        let x = u64::MAX;
-
-        let server_index = server_for_hash(x, n);
-        let server_range = range_for_server(server_index, n);
-
-        assert!(
-            server_range.contains(&x),
-            "u64::MAX is not in the correct range"
-        );
-    }
 
     #[test]
     fn test_watermark_holder() {

--- a/arroyo-worker/src/process_fn.rs
+++ b/arroyo-worker/src/process_fn.rs
@@ -23,11 +23,13 @@ impl ProcessFnUtils {
         state.evict_all_before_watermark(watermark)
     }
 
-    pub async fn send_event<OutK: Key, OutT: Data>(
+    pub async fn send_checkpoint_event<OutK: Key, OutT: Data>(
         barrier: arroyo_types::CheckpointBarrier,
         ctx: &mut Context<OutK, OutT>,
         event_type: TaskCheckpointEventType,
     ) {
+        // These messages are received by the engine control thread,
+        // which then sends a TaskCheckpointEventReq to the controller.
         ctx.control_tx
             .send(arroyo_rpc::ControlResp::CheckpointEvent(
                 arroyo_rpc::CheckpointEvent {


### PR DESCRIPTION
Modify the parquet schema to support writing deletions. Currently only
the KeyedState table performs any deletions. Reading the parquet file
when restoring from a checkpoint accounts for deletes.

This also adds a new mechanism for generational compaction. After
completing a checkpoint, the controller will look at the backend and for
each operator and table, if there are at least MIN_FILES_TO_COMPACT
(currently set to 4) of the same generation, it will read those files,
account for deletes, and write a set of newly partitioned, compacted
files. The controller then calls an rpc on the workers to trigger them
to load that new data.

Compaction defaults to disabled, and can be enable with the environment
variable COMPACTION_ENABLED.


---

Here's a sequence diagram for how compaction works:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/95329bbe-b38a-408c-92a0-43b0c3d0725e)





