### PR TITLE
Fix some data fetching race conditions

### DIFF
--- a/arroyo-console/src/components/PaginatedContent.tsx
+++ b/arroyo-console/src/components/PaginatedContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Flex, IconButton, Stack } from '@chakra-ui/react';
 import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 import Loading from './Loading';
@@ -26,14 +26,18 @@ const PaginatedContent: React.FC<PaginatedContentProps> = ({
   setCurrentData,
 }) => {
   const [pageNum, setPageNum] = useState<number>(1);
+  const currentPage = pages?.length ? pages[pageNum - 1] : undefined;
   setMaxPages(Math.max(pageNum, totalPages));
 
-  if (!pages || !pages.length || pages.length != totalPages || loading) {
+  useEffect(() => {
+    if (currentPage) {
+      setCurrentData(currentPage.data);
+    }
+  }, [currentPage]);
+
+  if (!pages || !pages.length || pages.length != totalPages || loading || !currentPage) {
     return <Loading />;
   }
-
-  const currentPage = pages[pageNum - 1];
-  setCurrentData(currentPage.data);
 
   let pageButtons = <></>;
   if (currentPage.hasMore || pages.length > 1) {

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -99,6 +99,7 @@ const checkpointDetailsKey = (pipelineId?: string, jobId?: string, epoch?: numbe
 
 const operatorErrorsKey = (pipelineId?: string, jobId?: string) => {
   return (pageIndex: number, previousPageData: schemas['JobLogMessageCollection']) => {
+    if (!pipelineId || !jobId) return null;
     if (previousPageData && !previousPageData.hasMore) return null;
 
     if (pageIndex === 0) {

--- a/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
@@ -71,7 +71,8 @@ export function PipelineDetails() {
     useOperatorErrors(id, job?.id);
   const [operatorErrors, setOperatorErrors] = useState<JobLogMessage[]>([]);
   const { operatorMetricGroups } = useJobMetrics(id, job?.id);
-  const hasErrors = operatorErrorsPages?.length && operatorErrorsPages[0].data.length > 0;
+
+  const hasErrors = operatorErrorsPages?.length && operatorErrorsPages[0]?.data.length > 0;
 
   if (pipelineError || jobsError) {
     return (


### PR DESCRIPTION
When the API becomes unavailable there was a race condition where useSWRInfinite returns an undefined page.

This also fixes the SWR key for fetching operator errors, and resolves a React warning about updating state during rendering.