### PR TITLE
Fix sink metrics stuck loading

### DIFF
--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -254,7 +254,7 @@ const jobMetricsFetcher = () => {
 };
 
 export const useJobMetrics = (pipelineId?: string, jobId?: string) => {
-  const { data, error } = useSWR<schemas['OperatorMetricGroupCollection']>(
+  const { data, isLoading, error } = useSWR<schemas['OperatorMetricGroupCollection']>(
     jobMetricsKey(pipelineId, jobId),
     jobMetricsFetcher(),
     {
@@ -264,6 +264,7 @@ export const useJobMetrics = (pipelineId?: string, jobId?: string) => {
 
   return {
     operatorMetricGroups: data?.data,
+    operatorMetricGroupsLoading: isLoading,
     operatorMetricGroupsError: error,
   };
 };


### PR DESCRIPTION
Since sinks don't have a messages_recv metric, the OperatorDetails component was stuck in a loading state. This handles the metrics individually and applies a default of 0.

---


![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/c294b4a6-cee1-403e-a433-c7787ea05f64)
