### PR TITLE
Show that preview pipeline has completed

### DIFF
--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -491,9 +491,13 @@ export const useJobOutput = (
   pipelineId?: string,
   jobId?: string
 ) => {
+  if (!pipelineId || !jobId) {
+    return;
+  }
   const url = `${BASE_URL}/v1/pipelines/${pipelineId}/jobs/${jobId}/output`;
   const eventSource = new EventSource(url);
   eventSource.addEventListener('message', handler);
+  return eventSource;
 };
 
 export const useConnectionTableTest = async (


### PR DESCRIPTION
Show a success alert when a preview job has completed. Also close the EventSource when stopping a preview so that there are not multiple pending requests.

---
![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/2b414b35-18b9-4663-89be-0cfa1df5f6fb)
