### PR TITLE
Add support for serializing raw_string formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
 name = "arroyo-rpc"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "arroyo-types",
  "bincode 2.0.0-rc.3",
  "nanoid",

--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -90,8 +90,8 @@ async fn get_and_validate_connector<E: GenericClient>(
 
     let schema: Option<ConnectionSchema> = req
         .schema
-        .as_ref()
-        .map(|t| t.clone().try_into())
+        .clone()
+        .map(|t| t.validate())
         .transpose()
         .map_err(|e| bad_request(format!("Invalid schema: {}", e)))?;
 

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -502,7 +502,7 @@ export const useJobOutput = (
 };
 
 export const useConnectionTableTest = async (
-  handler: (event: any) => void,
+  handler: (event: TestSourceMessage) => void,
   req: ConnectionTablePost
 ) => {
   const url = `${BASE_URL}/v1/connection_tables/test`;
@@ -516,7 +516,18 @@ export const useConnectionTableTest = async (
   });
 
   if (!response.ok || !response.body) {
-    console.log('Error subscribing to test output');
+    const text = await response.text();
+    let message;
+    try {
+      message = (JSON.parse(text) as { error: string }).error;
+    } catch {
+      message = text;
+    }
+    handler({
+      done: true,
+      error: true,
+      message,
+    });
     return;
   }
 
@@ -538,7 +549,12 @@ export const useConnectionTableTest = async (
     for (const line of lines) {
       const value = line.substring('data:'.length);
       if (value) {
-        handler(value);
+        try {
+          const parsed = JSON.parse(value) as TestSourceMessage;
+          handler(parsed);
+        } catch {
+          console.log('Failed to parse event');
+        }
       }
     }
   }

--- a/arroyo-console/src/routes/connections/ConnectionTester.tsx
+++ b/arroyo-console/src/routes/connections/ConnectionTester.tsx
@@ -62,14 +62,9 @@ export function ConnectionTester({
     return name && /^[_a-zA-Z][a-zA-Z0-9_]*$/.test(name);
   };
 
-  const sseHandler = (event: any) => {
-    try {
-      const parsed = JSON.parse(event) as TestSourceMessage;
-      messages.push(parsed);
-      setMessages(messages);
-    } catch {
-      console.log('Failed to parse event');
-    }
+  const sseHandler = (event: TestSourceMessage) => {
+    messages.push(event);
+    setMessages(messages);
   };
 
   const createRequest: ConnectionTablePost = {

--- a/arroyo-console/src/routes/connections/DefineSchema.tsx
+++ b/arroyo-console/src/routes/connections/DefineSchema.tsx
@@ -133,7 +133,17 @@ const RawStringEditor = ({
       schema: {
         ...state.schema,
         definition: { raw_schema: 'value' },
-        fields: [],
+        fields: [
+          {
+            fieldName: 'value',
+            fieldType: {
+              type: {
+                primitive: 'string',
+              },
+            },
+            nullable: true,
+          },
+        ],
         format: { raw_string: {} },
       },
     });

--- a/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
+++ b/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
@@ -251,7 +251,7 @@ export function CreatePipeline() {
           {name.toUpperCase()}S
         </Text>
         <Stack spacing={4}>
-          {sources.length == 0 ? (
+          {tables.length == 0 ? (
             <Box overflowY="auto" overflowX="hidden">
               <Text>
                 No {name}s have been created. Create one <Link to="/connections/new">here</Link>.

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -16,6 +16,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 nanoid = "0.4"
 utoipa = "3"
+anyhow = "1.0.75"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -404,3 +404,19 @@ INSERT INTO raw_sink
 SELECT bid.channel
 FROM nexmark;
 "}
+
+full_pipeline_codegen! {"raw_string_test_not_null",
+"CREATE TABLE raw_sink (
+  output TEXT NOT NULL
+) WITH (
+  connector = 'kafka',
+  bootstrap_servers = 'localhost:9092',
+  type = 'sink',
+  topic = 'outputs',
+  format = 'raw_string'
+);
+
+INSERT INTO raw_sink
+SELECT 'test'
+FROM nexmark;
+"}

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -348,7 +348,7 @@ full_pipeline_codegen! {"row_number",
 "
   SELECT ROW_NUMBER()  OVER (
       PARTITION BY window
-      ORDER BY price DESC) as row_number, auction, price 
+      ORDER BY price DESC) as row_number, auction, price
   FROM (
     SELECT bid.auction as auction,
            hop(INTERVAL '2' second, INTERVAL '9' second ) as window,
@@ -387,4 +387,20 @@ create table table_two (
 
 SELECT * FROM table_one LEFT OUTER JOIN table_two ON table_one.a_field = table_two.a_field;
 
+"}
+
+full_pipeline_codegen! {"raw_string_test",
+"CREATE TABLE raw_sink (
+  output TEXT
+) WITH (
+  connector = 'kafka',
+  bootstrap_servers = 'localhost:9092',
+  type = 'sink',
+  topic = 'outputs',
+  format = 'raw_string'
+);
+
+INSERT INTO raw_sink
+SELECT bid.channel
+FROM nexmark;
 "}

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -172,12 +172,7 @@ impl ConnectorTable {
             })
             .collect();
 
-        let schema = ConnectionSchema {
-            format,
-            struct_name: None,
-            fields: schema_fields?,
-            definition: None,
-        };
+        let schema = ConnectionSchema::try_new(format, None, schema_fields?, None)?;
 
         let connection = connector.from_options(name, options, Some(&schema))?;
 

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -241,6 +241,26 @@ impl StructDef {
         let schema_data_impl = if self.name.is_none() {
             // generate a SchemaData impl but only for generated types
             let name = self.struct_name();
+
+            let to_raw_string = if self.fields.len() == 1
+                && matches!(
+                    self.fields[0].data_type,
+                    TypeDef::DataType(DataType::Utf8, _)
+                ) {
+                let field = &self.fields[0].field_ident();
+                if self.fields[0].nullable() {
+                    quote! {
+                        self.#field.as_ref().map(|v| v.as_bytes().to_vec())
+                    }
+                } else {
+                    quote! {
+                        self.#field.as_bytes().to_vec()
+                    }
+                }
+            } else {
+                quote! { unimplemented!("to_raw_string is not implemented for this type") }
+            };
+
             Some(quote! {
                 impl arroyo_worker::SchemaData for #struct_type {
                     fn name() -> &'static str {
@@ -250,6 +270,10 @@ impl StructDef {
                     fn schema() -> arrow::datatypes::Schema {
                         let fields: Vec<arrow::datatypes::Field> = vec![#(#schema_initializations,)*];
                         arrow::datatypes::Schema::new(fields)
+                    }
+
+                    fn to_raw_string(&self) -> Option<Vec<u8>> {
+                        #to_raw_string
                     }
                 }
             })

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -254,7 +254,7 @@ impl StructDef {
                     }
                 } else {
                     quote! {
-                        self.#field.as_bytes().to_vec()
+                        Some(self.#field.as_bytes().to_vec())
                     }
                 }
             } else {

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -29,7 +29,7 @@ use super::{client_configs, KafkaConfig, KafkaTable, SinkCommitMode, TableType};
 mod test;
 
 #[derive(StreamNode)]
-pub struct KafkaSinkFunc<K: Key + Serialize, T: SchemaData + Serialize> {
+pub struct KafkaSinkFunc<K: Key + Serialize, T: SchemaData> {
     topic: String,
     bootstrap_servers: String,
     consistency_mode: ConsistencyMode,
@@ -60,7 +60,7 @@ impl From<SinkCommitMode> for ConsistencyMode {
     }
 }
 
-impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
+impl<K: Key + Serialize, T: SchemaData> KafkaSinkFunc<K, T> {
     pub fn new(
         servers: &str,
         topic: &str,
@@ -246,7 +246,9 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
             .map(|k| serde_json::to_string(k).unwrap());
         let v = self.serializer.to_vec(&record.value);
 
-        self.publish(k, v).await;
+        if let Some(v) = v {
+            self.publish(k, v).await;
+        }
     }
 
     async fn handle_commit(&mut self, epoch: u32, ctx: &mut crate::engine::Context<(), ()>) {

--- a/arroyo-worker/src/connectors/kafka/sink/test.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/test.rs
@@ -138,6 +138,10 @@ impl SchemaData for TestOutStruct {
             false,
         )])
     }
+
+    fn to_raw_string(&self) -> Option<Vec<u8>> {
+        unimplemented!()
+    }
 }
 
 struct KafkaSinkWithWrites {


### PR DESCRIPTION
This PR adds support for `raw_string` as an output format, which writes a single string field as UTF-8 encoded bytes.

It can be used like this:

```sql
CREATE TABLE raw_sink (
  output TEXT
) WITH (
  connector = 'kafka',
  bootstrap_servers = 'localhost:9092',
  type = 'sink',
  topic = 'outputs',
  format = 'raw_string'
);

INSERT INTO raw_sink
SELECT bid.channel
FROM nexmark;
```

When combined with UDFs utilizing serde_json functions, this allow serialization of arbitrarily complex structures that are not supported via our normal JSON support. For example, this UDF:

```rust
fn my_to_json(f: f64) -> String {
    let v = serde_json::json!({
        "my_complex": {
            "nested": f
        }
    });

    serde_json::to_string(&v).unwrap()
}
```

with this query:

```sql
INSERT INTO sink
SELECT my_to_json(avg(CAST(price as FLOAT))) from coinbase
WHERE type = 'ticker'
GROUP BY hop(interval '5' second, interval '1 minute');
```

Will produce records like 

```
{"my_complex":{"nested":25900.074265625}}
{"my_complex":{"nested":25899.815841674805}}
```

The implementation is not currently type safe, in the sense that `to_raw_string` is implemented for only valid output types (those that have a single TEXT field in their schema). We validate at the query compilation level that this is correct, but I don't see a way to have the type system enforce it.
