### PR TITLE
Fix how we set subtask metadata has_state

### DIFF
--- a/arroyo-state/src/parquet.rs
+++ b/arroyo-state/src/parquet.rs
@@ -824,7 +824,7 @@ impl ParquetFlusher {
                 subtask_index: self.task_info.task_index as u32,
                 start_time: to_micros(cp.time),
                 finish_time: to_micros(SystemTime::now()),
-                has_state: bytes > 0,
+                has_state: !backend_data.is_empty(),
                 tables: self.table_descriptors.values().cloned().collect(),
                 watermark: cp.watermark.map(to_micros),
                 backend_data,


### PR DESCRIPTION
The subtask metadata has_state was being set based on whether new bytes were written during the epoch being checkpointed, which is insufficient because it's possible for no new bytes to be written. This caused an error later during compaction because when we write operator checkpoint metadata we exclude subtasks that don't have state. The result was files being excluded from the operator metadata.