### PR TITLE
Close job event source when possible

### DIFF
--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -498,6 +498,9 @@ export const useJobOutput = (
   }
   const url = `${BASE_URL}/v1/pipelines/${pipelineId}/jobs/${jobId}/output`;
   const eventSource = new EventSource(url);
+  eventSource.onerror = () => {
+    eventSource.close();
+  };
   eventSource.addEventListener('message', handler);
   return eventSource;
 };

--- a/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
+++ b/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
@@ -137,6 +137,9 @@ export function CreatePipeline() {
 
   useEffect(() => {
     if (pipeline && job) {
+      if (outputSource) {
+        outputSource.close();
+      }
       setOutputSource(useJobOutput(sseHandler, pipeline.id, job.id));
     }
   }, [job?.id]);


### PR DESCRIPTION
Make sure that the event source is closed on an error (which includes preview jobs finishing), and before another preview job is started.