### PR TITLE
Bugfix: skip lines from file in `single_file` source

### DIFF
--- a/arroyo-worker/src/connectors/filesystem/single_file/source.rs
+++ b/arroyo-worker/src/connectors/filesystem/single_file/source.rs
@@ -61,10 +61,10 @@ impl<K: Data, T: DeserializeOwned + Data> FileSourceFunc<K, T> {
 
         let mut i = 0;
 
-        'lines: while let Some(s) = lines.next_line().await.unwrap() {
-            while i < self.lines_read {
+        while let Some(s) = lines.next_line().await.unwrap() {
+            if i < self.lines_read {
                 i += 1;
-                continue 'lines;
+                continue;
             }
             let value = serde_json::from_str(&s).unwrap();
             ctx.collector

--- a/arroyo-worker/src/connectors/filesystem/single_file/source.rs
+++ b/arroyo-worker/src/connectors/filesystem/single_file/source.rs
@@ -61,10 +61,10 @@ impl<K: Data, T: DeserializeOwned + Data> FileSourceFunc<K, T> {
 
         let mut i = 0;
 
-        while let Some(s) = lines.next_line().await.unwrap() {
+        'lines: while let Some(s) = lines.next_line().await.unwrap() {
             while i < self.lines_read {
                 i += 1;
-                continue;
+                continue 'lines;
             }
             let value = serde_json::from_str(&s).unwrap();
             ctx.collector


### PR DESCRIPTION
Lines weren't being actually skipped when restoring to previous source state.