### PR TITLE
Fix preview race condition

### DIFF
--- a/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
+++ b/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
@@ -136,11 +136,11 @@ export function CreatePipeline() {
   };
 
   useEffect(() => {
-    if (pipeline && job) {
+    if (pipelineId && job) {
       if (outputSource) {
         outputSource.close();
       }
-      setOutputSource(useJobOutput(sseHandler, pipeline.id, job.id));
+      setOutputSource(useJobOutput(sseHandler, pipelineId, job.id));
     }
   }, [job?.id]);
 


### PR DESCRIPTION
Since the API calls to get the pipeline and job object are made in parallel, if the job call returned first it would trigger the effect to get the job output and short-circuit.