### PR TITLE
Smoke test compaction and fix compaction logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "arroyo-rpc",
  "arroyo-sql",
  "arroyo-sql-macro",
+ "arroyo-state",
  "arroyo-types",
  "arroyo-worker",
  "bincode 2.0.0-rc.3",

--- a/arroyo-sql-testing/Cargo.toml
+++ b/arroyo-sql-testing/Cargo.toml
@@ -24,6 +24,7 @@ arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-worker = { path = "../arroyo-worker" }
 arroyo-sql-macro = { path = "../arroyo-sql-macro" }
 tokio = { version = "1.16", features = ["full"] }
+arroyo-state = { path = "../arroyo-state" }
 
 arrow = {workspace = true }
 arrow-array = {workspace = true }

--- a/arroyo-state/src/lib.rs
+++ b/arroyo-state/src/lib.rs
@@ -609,7 +609,7 @@ mod test {
         // insert a key/value
 
         let mut ks: KeyedState<usize, i32, _> = ss.get_key_state('t').await;
-        let t1 = SystemTime::now();
+        let t1 = SystemTime::UNIX_EPOCH;
         ks.insert(t1, 1, 1).await;
         assert_eq!(Some(&1), ks.get(&mut 1));
 

--- a/arroyo-state/src/tables/mod.rs
+++ b/arroyo-state/src/tables/mod.rs
@@ -44,7 +44,8 @@ impl Compactor {
                 // keep only the latest entry for each key
                 let mut reduced = HashMap::new();
                 for tuple in tuples.into_iter() {
-                    reduced.insert(tuple.key.clone(), tuple);
+                    let memory_key = (tuple.timestamp, tuple.key.clone());
+                    reduced.insert(memory_key, tuple);
                 }
 
                 reduced.into_values().collect()


### PR DESCRIPTION
Change the existing smoke tests to perform a compaction and load the
compacted data. This uncovered a mistake in the compaction logic for
TimeKeyMap tables.