### PR TITLE
Add arroyo cli crate (`arroyo`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,8 @@ dependencies = [
  "anyhow",
  "bollard",
  "clap 4.4.5",
+ "open",
+ "reqwest",
  "tokio",
  "tokio-stream",
 ]
@@ -4063,6 +4065,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,6 +4082,16 @@ dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.13",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -5123,6 +5144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5364,6 +5396,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "arroyo"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "bollard",
+ "clap 4.4.5",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "arroyo-api"
 version = "0.6.0"
 dependencies = [
@@ -1600,6 +1611,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+dependencies = [
+ "base64 0.21.4",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.43.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.2",
@@ -1775,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1957,7 +2008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d21d8c5cf5940c13b1d82977fc5d4230714ce76d991c5c00b8a1c791c691dcf"
 dependencies = [
  "chumsky",
- "clap 4.4.3",
+ "clap 4.4.5",
  "codegen_template",
  "heck",
  "indexmap 1.9.3",
@@ -3864,6 +3915,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -6690,6 +6754,17 @@ checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "arroyo",
     "arroyo-api",
     "arroyo-compiler-service",
     "arroyo-controller",

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ You can get started with a single node Arroyo cluster by running the following d
 $ docker run -p 8000:8000 ghcr.io/arroyosystems/arroyo-single:latest
 ```
 
+or if you have Cargo installed, you can use the `arroyo` cli:
+
+```
+$ cargo install arroyo
+$ arroyo start
+```
+
 Then, load the Web UI at http://localhost:8000.
 
 For a more in-depth guide, see the [getting started guide](https://doc.arroyo.dev/getting-started).

--- a/arroyo/Cargo.toml
+++ b/arroyo/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "arroyo"
+version = "0.6.0"
+edition = "2021"
+
+authors = ["Arroyo Systems <support@arroyo.systems>"]
+
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/ArroyoSystems/arroyo"
+homepage = "https://arroyo.dev"
+description = """
+Arroyo is a distributed stream processor that lets users ask complex questions of high-volume real-time data by writing SQL.
+
+This CLI can be used to run Arroyo clusters in Docker
+"""
+
+categories = ["database-implementations", "web-programming"]
+
+keywords = ["streaming", "data", "sql", "event-processing"]
+
+
+[dependencies]
+anyhow = "1.0.75"
+bollard = "0"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1.32.0", features = ["full"] }
+tokio-stream = "0.1.14"

--- a/arroyo/Cargo.toml
+++ b/arroyo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 authors = ["Arroyo Systems <support@arroyo.systems>"]
 
 license = "MIT OR Apache-2.0"
-readme = "README.md"
+readme = "../README.md"
 repository = "https://github.com/ArroyoSystems/arroyo"
 homepage = "https://arroyo.dev"
 description = """

--- a/arroyo/Cargo.toml
+++ b/arroyo/Cargo.toml
@@ -21,8 +21,10 @@ keywords = ["streaming", "data", "sql", "event-processing"]
 
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = {version = "1.0.75", features = ["backtrace"]}
 bollard = "0"
 clap = { version = "4", features = ["derive"] }
+open = "5.0.0"
+reqwest = "0.11.20"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-stream = "0.1.14"

--- a/arroyo/src/main.rs
+++ b/arroyo/src/main.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use bollard::container::{Config, CreateContainerOptions, StartContainerOptions};
+use bollard::image::CreateImageOptions;
+use bollard::Docker;
+use clap::{Parser, Subcommand};
+use tokio_stream::StreamExt;
+
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Starts an Arroyo cluster in Docker
+    Start {
+        /// Set the tag to run (defaults to `latest`, the most recent release version)
+        #[arg(short, long)]
+        tag: Option<String>,
+    },
+}
+
+#[tokio::main]
+pub async fn main() {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Start { tag } => {
+            start(tag.clone()).await.unwrap();
+            return;
+        }
+    }
+}
+
+pub async fn start(tag: Option<String>) -> Result<()> {
+    let docker = Docker::connect_with_local_defaults()?;
+
+    let tag = tag.as_ref().map(|t| t.as_str()).unwrap_or("latest");
+    let image = format!("arroyo-single:{}", tag);
+
+    docker
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: image.clone(),
+                repo: "ghcr.io/arroyosystems".to_string(),
+                ..Default::default()
+            }),
+            None,
+            None,
+        )
+        .next()
+        .await
+        .unwrap()?;
+
+    let config = Config {
+        image: Some(image.clone()),
+        ..Default::default()
+    };
+
+    docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name: "arroyo-single",
+                platform: None,
+            }),
+            config,
+        )
+        .await?;
+
+    docker
+        .start_container("arroyo-single", None::<StartContainerOptions<String>>)
+        .await?;
+
+    println!("Started container");
+
+    Ok(())
+}

--- a/arroyo/src/main.rs
+++ b/arroyo/src/main.rs
@@ -1,9 +1,18 @@
-use anyhow::Result;
-use bollard::container::{Config, CreateContainerOptions, StartContainerOptions};
+use anyhow::{bail, Context, Result};
+use bollard::container::{CreateContainerOptions, LogOutput, LogsOptions, StartContainerOptions};
 use bollard::image::CreateImageOptions;
-use bollard::Docker;
+use bollard::models::{ContainerStateStatusEnum, HostConfig, PortBinding};
+use bollard::{container, Docker};
 use clap::{Parser, Subcommand};
+use std::collections::HashMap;
+use std::io;
+use std::io::Write;
+use std::process::exit;
+use std::time::Duration;
+use tokio::signal::unix::{signal, SignalKind};
 use tokio_stream::StreamExt;
+
+const CONTAINER_NAME: &str = "arroyo-cli-single";
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -19,7 +28,14 @@ enum Commands {
         /// Set the tag to run (defaults to `latest`, the most recent release version)
         #[arg(short, long)]
         tag: Option<String>,
+
+        /// If set, will run in the background
+        #[arg(short, long)]
+        daemon: bool,
     },
+
+    /// Stops a running Arroyo cluster
+    Stop {},
 }
 
 #[tokio::main]
@@ -27,24 +43,27 @@ pub async fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Start { tag } => {
-            start(tag.clone()).await.unwrap();
-            return;
+        Commands::Start { tag, daemon } => {
+            start(tag.clone(), *daemon).await.unwrap();
+        }
+        Commands::Stop {} => {
+            stop().await.unwrap();
         }
     }
+
+    exit(0);
 }
 
-pub async fn start(tag: Option<String>) -> Result<()> {
-    let docker = Docker::connect_with_local_defaults()?;
+async fn get_docker() -> anyhow::Result<Docker> {
+    Ok(Docker::connect_with_local_defaults()
+        .context("Failed to connect to docker -- is it running?")?)
+}
 
-    let tag = tag.as_ref().map(|t| t.as_str()).unwrap_or("latest");
-    let image = format!("arroyo-single:{}", tag);
-
+async fn create_image(docker: &Docker, image: &str) -> Result<String> {
     docker
         .create_image(
             Some(CreateImageOptions {
                 from_image: image.clone(),
-                repo: "ghcr.io/arroyosystems".to_string(),
                 ..Default::default()
             }),
             None,
@@ -52,28 +71,209 @@ pub async fn start(tag: Option<String>) -> Result<()> {
         )
         .next()
         .await
-        .unwrap()?;
+        .unwrap()
+        .context("Failed to pull image")?;
 
-    let config = Config {
+    // wait for the image to be available
+
+    println!("Waiting for image to be available...");
+    loop {
+        match docker.inspect_image(&image).await {
+            Ok(metadata) => {
+                println!();
+                return Ok(metadata.id.unwrap());
+            }
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => {
+                // wait
+            }
+            Err(e) => {
+                bail!("Failed while fetching image metadata from docker: {:?}", e);
+            }
+        }
+
+        print!(".");
+        io::stdout().flush().unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn create_container(docker: &Docker, image: &str) -> Result<bool> {
+    let mut ports = HashMap::new();
+    ports.insert("8000/tcp", HashMap::new());
+
+    let mut port_map = HashMap::new();
+    port_map.insert(
+        "8000/tcp".to_string(),
+        Some(vec![PortBinding {
+            host_ip: Some("0.0.0.0".to_string()),
+            host_port: Some("8000".to_string()),
+        }]),
+    );
+
+    let config = container::Config {
         image: Some(image.clone()),
+        exposed_ports: Some(ports),
+        host_config: Some(HostConfig {
+            port_bindings: Some(port_map),
+            ..Default::default()
+        }),
         ..Default::default()
     };
 
-    docker
+    match docker
         .create_container(
             Some(CreateContainerOptions {
-                name: "arroyo-single",
+                name: CONTAINER_NAME,
                 platform: None,
             }),
             config,
         )
-        .await?;
+        .await
+    {
+        Ok(_) => {}
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 409, ..
+        }) => {
+            // if the container already exists, check if it's running
+            if docker
+                .inspect_container(CONTAINER_NAME, None)
+                .await
+                .context("Failed to inspect container")?
+                .state
+                .unwrap()
+                .status
+                .unwrap()
+                == ContainerStateStatusEnum::RUNNING
+            {
+                println!("Container already running");
+                return Ok(false);
+            }
+        }
+        Err(e) => {
+            bail!("Failed to create container: {:?}", e);
+        }
+    }
+
+    Ok(true)
+}
+
+async fn tail_logs(docker: &Docker) -> Result<()> {
+    let opts: LogsOptions<String> = LogsOptions {
+        follow: true,
+        stdout: true,
+        stderr: true,
+        ..Default::default()
+    };
+
+    let mut tail = docker.logs(CONTAINER_NAME, Some(opts.clone()));
+
+    while let Some(log) = tail.next().await {
+        match log.context("Failed while tailing logs")? {
+            LogOutput::StdErr { message } => {
+                eprint!("{}", String::from_utf8_lossy(&message));
+            }
+            LogOutput::StdOut { message } => {
+                print!("{}", String::from_utf8_lossy(&message));
+            }
+            LogOutput::StdIn { .. } => {}
+            LogOutput::Console { .. } => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn start(tag: Option<String>, damon: bool) -> Result<()> {
+    let docker = get_docker().await?;
+
+    let tag = tag.as_ref().map(|t| t.as_str()).unwrap_or("latest");
+    let image = format!("ghcr.io/arroyosystems/arroyo-single:{}", tag);
+
+    let image_id = create_image(&docker, &image).await?;
+    println!("Pulled image {}", image_id);
+
+    if !create_container(&docker, &image).await? {
+        return Ok(());
+    }
 
     docker
-        .start_container("arroyo-single", None::<StartContainerOptions<String>>)
+        .start_container(CONTAINER_NAME, None::<StartContainerOptions<String>>)
         .await?;
 
-    println!("Started container");
+    println!("Started container. Waiting for API to come up...");
+
+    // wait for port
+    loop {
+        match reqwest::get("http://localhost:8000").await {
+            Ok(_) => {
+                break;
+            }
+            Err(_) => {}
+        }
+        print!(".");
+        io::stdout().flush().unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    println!();
+
+    match open::that("http://localhost:8000") {
+        Ok(_) => println!("Opened webui in browser"),
+        Err(_) => println!("Failed to open browser... navigate to http://localhost:8000 for webui"),
+    }
+
+    if damon {
+        return Ok(());
+    }
+
+    println!("Tailing logs...\n----------------------");
+
+    let mut sigint = signal(SignalKind::interrupt()).unwrap();
+    {
+        let docker = docker.clone();
+        tokio::spawn(async move {
+            match sigint.recv().await {
+                None => {}
+                Some(_) => {
+                    print!("Stopping container...");
+                    match docker.stop_container(CONTAINER_NAME, None).await {
+                        Ok(_) => {
+                            println!("Container stopped");
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to stop container: {:?}", e);
+                        }
+                    }
+                    exit(0);
+                }
+            }
+        });
+    }
+
+    tail_logs(&docker).await?;
+
+    println!("Container exited");
+
+    Ok(())
+}
+
+async fn stop() -> anyhow::Result<()> {
+    let docker = get_docker().await?;
+
+    match docker.stop_container(CONTAINER_NAME, None).await {
+        Ok(_) => {
+            println!("Container stopped");
+        }
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => {
+            println!("Container does not exist")
+        }
+        Err(e) => {
+            bail!("Encountered an error while stopping: {:?}", e);
+        }
+    }
 
     Ok(())
 }

--- a/arroyo/src/main.rs
+++ b/arroyo/src/main.rs
@@ -194,7 +194,7 @@ pub async fn start(tag: Option<String>, damon: bool) -> Result<()> {
     let image_id = create_image(&docker, &image).await?;
     println!("Pulled image {}", image_id);
 
-    if !create_container(&docker, &image).await? {
+    if !create_container(&docker, &image_id).await? {
         return Ok(());
     }
 


### PR DESCRIPTION
This will allow users to install arroyo with cargo `$ cargo install arroyo`.

```
$ arroyo
Arroyo is a distributed stream processor that lets users ask complex questions of high-volume real-time 
data by writing SQL.

This CLI can be used to run Arroyo clusters in Docker


Usage: arroyo <COMMAND>

Commands:
  start  Starts an Arroyo cluster in Docker
  stop
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

The initial version is able to manage local Arroyo clusters running in docker.