### PR TITLE
Include arroyo crate in dockerfiles

### DIFF
--- a/docker/check_dockerfiles.rb
+++ b/docker/check_dockerfiles.rb
@@ -23,7 +23,7 @@ DOCKERFILES.each do |dockerfile|
   File.open(dockerfile, 'r') do |f|
     body = f.read
     members.each do |member|
-      if !body.include?(member)
+      if !body.include?(" #{member} ")
         puts "ERROR: #{dockerfile} does not include #{member}"
         exit 1
       end

--- a/docker/cluster/compiler/Dockerfile
+++ b/docker/cluster/compiler/Dockerfile
@@ -44,6 +44,7 @@ COPY arroyo-controller src/arroyo-controller
 COPY arroyo-console src/arroyo-console
 COPY arroyo-storage src/arroyo-storage
 COPY connector-schemas src/connector-schemas
+COPY arroyo src/arroyo
 
 COPY copy-artifacts src/copy-artifacts
 COPY integ src/integ

--- a/docker/cluster/services/Dockerfile
+++ b/docker/cluster/services/Dockerfile
@@ -40,6 +40,7 @@ COPY arroyo-openapi arroyo-openap
 COPY arroyo-storage arroyo-storage
 COPY docker/refinery.toml refinery.toml
 COPY connector-schemas connector-schemas
+COPY arroyo arroyo
 
 COPY copy-artifacts copy-artifacts
 COPY integ integ

--- a/docker/cluster/worker/Dockerfile
+++ b/docker/cluster/worker/Dockerfile
@@ -30,6 +30,7 @@ COPY integ integ
 COPY docker/refinery.toml refinery.toml
 COPY connector-schemas connector-schemas
 COPY arroyo-openapi arroyo-openapi
+COPY arroyo arroyo
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 

--- a/docker/single/Dockerfile
+++ b/docker/single/Dockerfile
@@ -73,6 +73,7 @@ COPY integ integ
 COPY docker/refinery.toml refinery.toml
 COPY connector-schemas connector-schemas
 COPY arroyo-openapi arroyo-openapi
+COPY arroyo arroyo
 
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock


### PR DESCRIPTION
And fix limitation in the checking script that missed this case due to `arroyo` being a substring of various other crates