### PR TITLE
checkpointing: record end time of checkpointing.

### DIFF
--- a/arroyo-controller/src/job_controller/checkpoint_state.rs
+++ b/arroyo-controller/src/job_controller/checkpoint_state.rs
@@ -362,12 +362,17 @@ impl CheckpointState {
         db_checkpoint_state: crate::types::public::CheckpointState,
     ) -> anyhow::Result<()> {
         let c = pool.get().await?;
+        let finish_time = if db_checkpoint_state == crate::types::public::CheckpointState::ready {
+            Some(SystemTime::now().into())
+        } else {
+            None
+        };
         let operator_state = serde_json::to_value(&self.operator_details).unwrap();
         controller_queries::update_checkpoint()
             .bind(
                 &c,
                 &operator_state,
-                &None,
+                &finish_time,
                 &db_checkpoint_state,
                 &self.checkpoint_id,
             )


### PR DESCRIPTION
In the work on state we seem to have stopped recording the finish time of checkpointing. This fixes that regression.