### PR TITLE
writing to file:/// should write to absolute paths.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "anyhow",
  "arroyo-datastream",
  "arroyo-rpc",
+ "arroyo-storage",
  "arroyo-types",
  "axum",
  "eventsource-client",

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -9,6 +9,7 @@ kafka-sasl = ["rdkafka/sasl", "rdkafka/ssl-vendored"]
 
 [dependencies]
 arroyo-types = { path = "../arroyo-types" }
+arroyo-storage = { path = "../arroyo-storage" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-datastream = { path = "../arroyo-datastream" }
 

--- a/arroyo-connectors/src/filesystem.rs
+++ b/arroyo-connectors/src/filesystem.rs
@@ -135,7 +135,14 @@ impl Connector for FileSystemConnector {
         schema: Option<&ConnectionSchema>,
     ) -> anyhow::Result<crate::Connection> {
         let write_target = if let Some(path) = opts.remove("path") {
-            Destination::FolderUri { path }
+            if path.starts_with("file:///") {
+                let trimmed_path = path.trim_start_matches("file://");
+                Destination::LocalFilesystem {
+                    local_directory: trimmed_path.to_string(),
+                }
+            } else {
+                Destination::FolderUri { path }
+            }
         } else if let (Some(s3_bucket), Some(s3_directory), Some(aws_region)) = (
             opts.remove("s3_bucket"),
             opts.remove("s3_directory"),

--- a/arroyo-connectors/src/filesystem.rs
+++ b/arroyo-connectors/src/filesystem.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Result};
+use arroyo_storage::BackendConfig;
 use axum::response::sse::Event;
 use std::convert::Infallible;
 use typify::import_types;
@@ -135,10 +136,9 @@ impl Connector for FileSystemConnector {
         schema: Option<&ConnectionSchema>,
     ) -> anyhow::Result<crate::Connection> {
         let write_target = if let Some(path) = opts.remove("path") {
-            if path.starts_with("file:///") {
-                let trimmed_path = path.trim_start_matches("file://");
+            if let BackendConfig::Local(local_config) = BackendConfig::parse_url(&path, false)? {
                 Destination::LocalFilesystem {
-                    local_directory: trimmed_path.to_string(),
+                    local_directory: local_config.path,
                 }
             } else {
                 Destination::FolderUri { path }

--- a/arroyo-storage/src/lib.rs
+++ b/arroyo-storage/src/lib.rs
@@ -127,8 +127,8 @@ pub struct GCSConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalConfig {
-    path: String,
-    key: Option<String>,
+    pub path: String,
+    pub key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Apparently converting `"file:///my/absolute/path"` to an ObjectStore Path will result in `my/absolute/path`. I've reworked how the path is managed so that it writes to an absolute location.