### PR TITLE
Remove arroyo-sql-testing's dependency on the controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,6 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
- "arroyo-controller",
  "arroyo-rpc",
  "arroyo-sql",
  "arroyo-sql-macro",

--- a/arroyo-controller/src/job_controller/checkpointer.rs
+++ b/arroyo-controller/src/job_controller/checkpointer.rs
@@ -1,5 +1,5 @@
-use crate::job_controller::checkpoint_state::CheckpointState;
-use crate::job_controller::comitting_state::CommittingState;
+use arroyo_state::checkpoint_state::CheckpointState;
+use arroyo_state::committing_state::CommittingState;
 
 pub enum CheckpointingOrCommittingState {
     Checkpointing(CheckpointState),

--- a/arroyo-sql-testing/Cargo.toml
+++ b/arroyo-sql-testing/Cargo.toml
@@ -18,7 +18,6 @@ bincode_derive = "=2.0.0-rc.3"
 serde = "1.0"
 serde_json = "1.0"
 arroyo-types = { path = "../arroyo-types" }
-arroyo-controller = { path = "../arroyo-controller" }
 arroyo-sql = { path = "../arroyo-sql" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-worker = { path = "../arroyo-worker" }

--- a/arroyo-sql-testing/src/smoke_tests.rs
+++ b/arroyo-sql-testing/src/smoke_tests.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 use std::{env, fmt::Debug, time::SystemTime};
 use tokio::sync::mpsc::Receiver;
 
-use arroyo_controller::job_controller::checkpoint_state::CheckpointState;
 use arroyo_rpc::grpc::{StopMode, TaskCheckpointCompletedReq, TaskCheckpointEventReq};
 use arroyo_rpc::{ControlMessage, ControlResp};
 use arroyo_sql_macro::correctness_run_codegen;
+use arroyo_state::checkpoint_state::CheckpointState;
 use arroyo_types::{to_micros, CheckpointBarrier};
 use arroyo_worker::engine::{Program, RunningEngine};
 use arroyo_worker::{

--- a/arroyo-state/src/lib.rs
+++ b/arroyo-state/src/lib.rs
@@ -22,8 +22,11 @@ use tables::time_key_map::{TimeKeyMap, TimeKeyMapCache};
 use tables::{global_keyed_map, key_time_multi_map, keyed_map, time_key_map};
 use tokio::sync::mpsc::Sender;
 
+pub mod checkpoint_state;
+pub mod committing_state;
 mod metrics;
 pub mod parquet;
+mod subtask_state;
 pub mod tables;
 
 pub const BINCODE_CONFIG: Configuration = bincode::config::standard();

--- a/arroyo-state/src/parquet.rs
+++ b/arroyo-state/src/parquet.rs
@@ -18,7 +18,6 @@ use arroyo_types::{
     CHECKPOINT_URL_ENV, S3_ENDPOINT_ENV, S3_REGION_ENV,
 };
 use bincode::config;
-use bincode::error::DecodeError;
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;

--- a/arroyo-state/src/subtask_state.rs
+++ b/arroyo-state/src/subtask_state.rs
@@ -6,9 +6,9 @@ use arroyo_types::from_micros;
 use std::time::SystemTime;
 
 pub struct SubtaskState {
-    pub(crate) start_time: Option<SystemTime>,
-    pub(crate) finish_time: Option<SystemTime>,
-    pub(crate) metadata: Option<SubtaskCheckpointMetadata>,
+    pub start_time: Option<SystemTime>,
+    pub finish_time: Option<SystemTime>,
+    pub metadata: Option<SubtaskCheckpointMetadata>,
 }
 
 impl SubtaskState {


### PR DESCRIPTION
This required moving the CheckpointState, CommittingState, and SubtaskState to the arroyo-state crate, and untangling those structs from the database queries performed by the controller.