### PR TITLE
Implement unnest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_json_path",
  "syn 2.0.33",
  "tokio",
  "tracing",
@@ -6735,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json_path"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494fa32f1127343a29297e1cad9d59ccbbe4824be9f546f4f63e86479637ea02"
+checksum = "35c79e076e7e0e91510241afe3c432cb8b5126245153f7141077ffb074d270eb"
 dependencies = [
  "inventory",
  "nom",
@@ -6752,9 +6753,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json_path_core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a570e847edac5b01e66cd9981b5adebf504ceb7e8ba22bd6f7a39fec392ad4"
+checksum = "e774ec1b58d942c47f7abbdc30ba876e5525590c5388760185b1fbe283f9f10c"
 dependencies = [
  "inventory",
  "once_cell",

--- a/arroyo-api/src/optimizations.rs
+++ b/arroyo-api/src/optimizations.rs
@@ -379,7 +379,7 @@ impl Optimizer for FlatMapFusionOptimizer {
                 },
             ) => {
                 let name = format!("flat_fused({},{})", flatten_name, name);
-                let operator = Operator::FlatMapOperator {
+                let operator = Operator::ArrayMapOperator {
                     name,
                     expression: expression.to_string(),
                     return_type: return_type.clone(),

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -2047,7 +2047,9 @@ impl From<Operator> for GrpcApi::operator::Operator {
                 return_type: return_type.into(),
             }),
             Operator::FlattenOperator { name } => GrpcOperator::Flatten(Flatten { name }),
-            Operator::FlatMapOperator { name, expression } => GrpcOperator::FlatMapOperator({ GrpcApi::FlatMapOperator { name, expression } }),
+            Operator::FlatMapOperator { name, expression } => {
+                GrpcOperator::FlatMapOperator({ GrpcApi::FlatMapOperator { name, expression } })
+            }
             Operator::ArrayMapOperator {
                 name,
                 expression,
@@ -2351,7 +2353,9 @@ impl TryFrom<arroyo_rpc::grpc::api::Operator> for Operator {
                     }
                 }
                 GrpcOperator::Flatten(Flatten { name }) => Operator::FlattenOperator { name },
-                GrpcOperator::FlatMapOperator(GrpcApi::FlatMapOperator { name, expression }) => Operator::FlatMapOperator { name, expression },
+                GrpcOperator::FlatMapOperator(GrpcApi::FlatMapOperator { name, expression }) => {
+                    Operator::FlatMapOperator { name, expression }
+                }
                 GrpcOperator::FlattenExpressionOperator(flatten_expression) => {
                     let return_type = flatten_expression.return_type().into();
                     Operator::ArrayMapOperator {

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -25,7 +25,7 @@ use syn::{parse_quote, parse_str, GenericArgument, PathArguments, Type, TypePath
 
 use anyhow::{anyhow, bail, Result};
 
-use crate::Operator::FusedWasmUDFs;
+use crate::Operator::{FlatMapOperator, FusedWasmUDFs};
 use arroyo_rpc::grpc::api::{
     Aggregator, JobEdge, JobGraph, JobNode, PipelineProgram, ProgramNode, WasmFunction,
 };
@@ -347,10 +347,14 @@ pub enum Operator {
     FlattenOperator {
         name: String,
     },
-    FlatMapOperator {
+    ArrayMapOperator {
         name: String,
         expression: String,
         return_type: ExpressionReturnType,
+    },
+    FlatMapOperator {
+        name: String,
+        expression: String,
     },
     SlidingWindowAggregator(SlidingWindowAggregator),
     TumblingWindowAggregator(TumblingWindowAggregator),
@@ -433,11 +437,15 @@ impl Debug for Operator {
                 expression: _,
                 return_type,
             } => write!(f, "expression<{}:{:?}>", name, return_type),
-            Operator::FlatMapOperator {
+            Operator::ArrayMapOperator {
                 name,
                 expression: _,
                 return_type,
-            } => write!(f, "flat_map<{}:{:?}>", name, return_type),
+            } => write!(f, "array_map<{}:{:?}>", name, return_type),
+            Operator::FlatMapOperator {
+                name,
+                expression: _,
+            } => write!(f, "flat_map<{}>", name),
             Operator::SlidingWindowAggregator(SlidingWindowAggregator { width, slide, .. }) => {
                 write!(
                     f,
@@ -1551,10 +1559,10 @@ impl Program {
                 Operator::FlattenOperator { name } => {
                     let k = parse_type(&output.unwrap().weight().key);
                     let t = parse_type(&output.unwrap().weight().value);
-                 quote! {
-                    Box::new(FlattenOperator::<#k, #t>::new(#name.to_string()))
-                }
-            },
+                    quote! {
+                        Box::new(FlattenOperator::<#k, #t>::new(#name.to_string()))
+                    }
+                },
                 Operator::ExpressionOperator { name, expression, return_type } => {
                     let expr : syn::Expr = parse_str(expression).expect(expression);
                     let in_k = parse_type(&input.unwrap().weight().key);
@@ -1589,7 +1597,21 @@ impl Program {
                         },
                     }
                 },
-                Operator::FlatMapOperator { name, expression, return_type } => {
+                Operator::FlatMapOperator { name, expression } => {
+                    let expr : syn::Expr = parse_str(expression).expect(expression);
+                    let in_k = parse_type(&input.unwrap().weight().key);
+                    let in_t = parse_type(&input.unwrap().weight().value);
+                    let out_k = parse_type(&output.unwrap().weight().key);
+                    let out_t = parse_type(&output.unwrap().weight().value);
+                    let func: syn::ExprClosure = parse_quote!(|record, _| {#expr});
+                    quote! {
+                        Box::new(FlatMapOperator::<#in_k, #in_t, #out_k, #out_t>{
+                            name: #name.to_string(),
+                            flat_map: Box::new(#func),
+                        })
+                    }
+                },
+                Operator::ArrayMapOperator { name, expression, return_type } => {
                     let expr : syn::Expr = parse_str(expression).expect(expression);
                     let in_k = parse_type(&input.unwrap().weight().key);
                     let in_t = parse_type(&input.unwrap().weight().value);
@@ -1625,7 +1647,7 @@ impl Program {
                     };
                     let func: syn::ExprClosure = parse_str(&quote!(#closure).to_string()).unwrap();
                     quote! {
-                        Box::new(FlatMapOperator::<#in_k, #in_t, #out_k, #out_t> {
+                        Box::new(ArrayMapOperator::<#in_k, #in_t, #out_k, #out_t> {
                             name: #name.to_string(),
                             map_fn: Box::new(#func),
                         })
@@ -2025,7 +2047,8 @@ impl From<Operator> for GrpcApi::operator::Operator {
                 return_type: return_type.into(),
             }),
             Operator::FlattenOperator { name } => GrpcOperator::Flatten(Flatten { name }),
-            Operator::FlatMapOperator {
+            Operator::FlatMapOperator { name, expression } => GrpcOperator::FlatMapOperator({ GrpcApi::FlatMapOperator { name, expression } }),
+            Operator::ArrayMapOperator {
                 name,
                 expression,
                 return_type,
@@ -2328,9 +2351,10 @@ impl TryFrom<arroyo_rpc::grpc::api::Operator> for Operator {
                     }
                 }
                 GrpcOperator::Flatten(Flatten { name }) => Operator::FlattenOperator { name },
+                GrpcOperator::FlatMapOperator(GrpcApi::FlatMapOperator { name, expression }) => Operator::FlatMapOperator { name, expression },
                 GrpcOperator::FlattenExpressionOperator(flatten_expression) => {
                     let return_type = flatten_expression.return_type().into();
-                    Operator::FlatMapOperator {
+                    Operator::ArrayMapOperator {
                         name: flatten_expression.name,
                         expression: flatten_expression.expression,
                         return_type,

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -83,6 +83,7 @@ message Operator {
     ExpressionOperator expression_operator = 13;
     Flatten flatten = 14;
     FlattenExpressionOperator flatten_expression_operator = 15;
+    FlatMapOperator flat_map_operator = 27;
     SlidingWindowAggregator sliding_window_aggregator = 17;
     TumblingWindowAggregator tumbling_window_aggregator = 18;
     TumblingTopN tumbling_top_n = 19;
@@ -188,6 +189,11 @@ message FlattenExpressionOperator {
   string name = 1;
   string expression= 2;
   ExpressionReturnType return_type = 3;
+}
+
+message FlatMapOperator {
+  string name = 1;
+  string expression = 2;
 }
 
 message SlidingWindowAggregator {

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -445,6 +445,6 @@ from nexmark;
 
 full_pipeline_codegen! {"unnest",
 "
-select cast(unnest(get_json_objects('{"a": [1,2,3]}', '$.a')) as int) + 5, bid.auction
+select cast(unnest(extract_json('{\"a\": [1, 2, 3]}', '$.a[*]')) as int) + 5, bid.auction
 from nexmark;
 "}

--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -442,3 +442,9 @@ full_pipeline_codegen! {"aliases",
 SELECT 'a' as \"1\"
 from nexmark;
 "}
+
+full_pipeline_codegen! {"unnest",
+"
+select cast(unnest(get_json_objects('{"a": [1,2,3]}', '$.a')) as int) + 5, bid.auction
+from nexmark;
+"}

--- a/arroyo-sql/Cargo.toml
+++ b/arroyo-sql/Cargo.toml
@@ -31,3 +31,4 @@ tracing = "0.1.37"
 
 typify = "0.0.13"
 schemars = "0.8"
+serde_json_path = "0.6.3"

--- a/arroyo-sql/src/code_gen.rs
+++ b/arroyo-sql/src/code_gen.rs
@@ -1,6 +1,6 @@
 use arrow_schema::DataType;
-use quote::{format_ident, quote};
 use quote::ToTokens;
+use quote::{format_ident, quote};
 use syn::parse_quote;
 
 use crate::types::{data_type_as_syn_type, StructDef, TypeDef};
@@ -22,7 +22,7 @@ impl ValuePointerContext {
 
     pub fn with_arg(s: &str) -> Self {
         ValuePointerContext {
-            arg: format_ident!("{}", s)
+            arg: format_ident!("{}", s),
         }
     }
 
@@ -49,7 +49,7 @@ impl ValuePointerContext {
 
     pub(crate) fn compile_flatmap_expr<CG: CodeGenerator<Self, StructDef, syn::Expr>>(
         &self,
-        code_generator: &CG
+        code_generator: &CG,
     ) -> syn::Expr {
         let expr = code_generator.generate(self);
         let arg_ident = self.variable_ident();
@@ -195,22 +195,6 @@ impl ValuePointerContext {
             }
         )
     }
-
-    // pub(crate) fn compile_unnest_expression<CG: CodeGenerator<Self, TypeDef, syn::Expr>>(&self,
-    //                                         code_generator: CG) -> syn::Expr {
-    //     let expr = code_generator.generate(self);
-    //     let arg_ident = self.variable_ident();
-    //     parse_quote!(
-    //         let #arg_ident = &record.value;
-    //         let value = #expr;
-    //
-    //         for _unnested in #arg_ident {
-    //             arroyo_types::Record {
-    //             timestamp: record.timestamp,
-    //             key: None,
-    //             value
-    //     })
-    // }
 }
 
 pub struct JoinPairContext {

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -49,7 +49,7 @@ pub enum Expression {
     WrapType(WrapTypeExpression),
     Case(CaseExpression),
     WindowUDF(WindowType),
-    Unnest(Box<Expression>),
+    Unnest(Box<Expression>, bool),
 }
 
 pub struct JoinedPairedStruct {
@@ -251,9 +251,13 @@ impl CodeGenerator<ValuePointerContext, TypeDef, syn::Expr> for Expression {
             Expression::WindowUDF(_window_type) => {
                 unreachable!("window functions shouldn't be computed off of a value pointer")
             }
-            Expression::Unnest(expr) => {
-                let input = expr.generate(input_context);
-                parse_quote!(unnest(#input))
+            Expression::Unnest(_, taken) => {
+                if !taken {
+                    panic!("inner value of unnest should have been taken!");
+                } else {
+                    let ident = input_context.variable_ident();
+                    parse_quote!(#ident)
+                }
             }
         }
     }
@@ -298,7 +302,7 @@ impl CodeGenerator<ValuePointerContext, TypeDef, syn::Expr> for Expression {
             Expression::WindowUDF(_window_type) => {
                 unreachable!("window functions shouldn't be computed off of a value pointer")
             }
-            Expression::Unnest(t) => {
+            Expression::Unnest(t, _) => {
                 match t.expression_type(input_context) {
                     TypeDef::DataType(DataType::List(inner), _) => {
                         TypeDef::DataType(inner.data_type().clone(), false)
@@ -420,7 +424,7 @@ impl Expression {
             | Expression::Json(_)
             | Expression::RustUdf(_)
             | Expression::WrapType(_)
-            | Expression::Unnest(_)
+            | Expression::Unnest(_, _)
             | Expression::Case(_) => Ok(None),
         }
     }
@@ -437,6 +441,109 @@ impl Expression {
                 expression
             ),
         }
+    }
+
+    pub fn traverse_mut<T, F: Fn(&mut T, &mut Expression) -> ()>(&mut self, context: &mut T, f: &F) {
+        match self {
+            Expression::Column(_) => {
+            }
+            Expression::UnaryBoolean(e) => {
+                (&mut *e.input).traverse_mut(context, f);
+            }
+            Expression::Literal(_) => {}
+            Expression::BinaryComparison(e) => {
+                (&mut *e.left).traverse_mut(context, f);
+                (&mut *e.right).traverse_mut(context, f);
+            }
+            Expression::BinaryMath(e) => {
+                (&mut *e.left).traverse_mut(context, f);
+                (&mut *e.right).traverse_mut(context, f);
+            }
+            Expression::StructField(e) => {
+                (&mut *e.struct_expression).traverse_mut(context, f);
+            }
+            Expression::Aggregation(e) => {
+                (&mut *e.producing_expression).traverse_mut(context, f);
+            }
+            Expression::Cast(e) => {
+                (&mut *e.input).traverse_mut(context, f);
+            }
+            Expression::Numeric(e) => {
+                (&mut *e.input).traverse_mut(context, f);
+            }
+            Expression::Date(e) => {
+                match e {
+                    DateTimeFunction::DatePart(_, e) |
+                    DateTimeFunction::DateTrunc(_, e) |
+                    DateTimeFunction::FromUnixTime(e) => {
+                        (&mut *e).traverse_mut(context, f);
+                    }
+                }
+            }
+            Expression::String(e) => {
+                for e in e.expressions() {
+                    e.traverse_mut(context, f);
+                }
+            }
+            Expression::Hash(e) => {
+                (&mut *e.input).traverse_mut(context, f);
+            }
+            Expression::DataStructure(e) => {
+                match e {
+                    DataStructureFunction::Coalesce(exprs) | DataStructureFunction::MakeArray(exprs) => {
+                        for e in exprs {
+                            e.traverse_mut(context, f);
+                        }
+                    }
+                    DataStructureFunction::NullIf { left, right } => {
+                        (&mut *left).traverse_mut(context, f);
+                        (&mut *right).traverse_mut(context, f);
+                    }
+                }
+            }
+            Expression::Json(e) => {
+                (&mut *e.json_string).traverse_mut(context, f);
+                (&mut *e.path).traverse_mut(context, f);
+            }
+            Expression::RustUdf(udf) => {
+                for (_, arg) in &mut udf.args {
+                    arg.traverse_mut(context, f);
+                }
+            }
+            Expression::WrapType(e) => {
+                (&mut *e.arg).traverse_mut(context, f);
+            }
+            Expression::Case(e) => {
+                match e {
+                    CaseExpression::Match { value, matches, default } => {
+                        f(context, &mut *value);
+                        for (l, r) in matches {
+                            (&mut *l).traverse_mut(context, f);
+                            (&mut *r).traverse_mut(context, f);
+                        }
+                        if let Some(default) = default {
+                            default.traverse_mut(context, f);
+                        }
+                    }
+                    CaseExpression::When { condition_pairs, default } => {
+                        for (l, r) in condition_pairs {
+                            (&mut *l).traverse_mut(context, f);
+                            (&mut *r).traverse_mut(context, f);
+                        }
+                        if let Some(default) = default {
+                            (default).traverse_mut(context, f);
+                        }
+                    }
+                }
+            }
+            Expression::WindowUDF(_) => {
+            }
+            Expression::Unnest(n, _) => {
+                (&mut *n).traverse_mut(context, f);
+            }
+        }
+
+        f(context, self);
     }
 }
 
@@ -829,7 +936,7 @@ impl<'a> ExpressionContext<'a> {
                     if args.len() != 1 {
                         bail!("wrong number of arguments for unnest(), expected one");
                     }
-                    Ok(Expression::Unnest(Box::new(self.compile_expr(&args[0])?)))
+                    Ok(Expression::Unnest(Box::new(self.compile_expr(&args[0])?), false))
                 }
                 udf => {
                     // get udf from context
@@ -1967,13 +2074,13 @@ impl SortExpression {
         match sort_expressions.len() {
             0 => parse_quote!(()),
             1 => {
-                let singleton_type = sort_expressions[0].tuple_type(&ValuePointerContext);
+                let singleton_type = sort_expressions[0].tuple_type(&ValuePointerContext::new());
                 parse_quote!((#singleton_type,))
             }
             _ => {
                 let tuple_types: Vec<syn::Type> = sort_expressions
                     .iter()
-                    .map(|sort_expression| sort_expression.tuple_type(&ValuePointerContext))
+                    .map(|sort_expression| sort_expression.tuple_type(&ValuePointerContext::new()))
                     .collect();
                 parse_quote!((#(#tuple_types),*))
             }
@@ -1984,13 +2091,13 @@ impl SortExpression {
         match sort_expressions.len() {
             0 => parse_quote!(()),
             1 => {
-                let singleton_expr = sort_expressions[0].to_syn_expr(&ValuePointerContext);
+                let singleton_expr = sort_expressions[0].to_syn_expr(&ValuePointerContext::new());
                 parse_quote!((#singleton_expr,))
             }
             _ => {
                 let tuple_exprs: Vec<syn::Expr> = sort_expressions
                     .iter()
-                    .map(|sort_expression| sort_expression.to_syn_expr(&ValuePointerContext))
+                    .map(|sort_expression| sort_expression.to_syn_expr(&ValuePointerContext::new()))
                     .collect();
                 parse_quote!((#(#tuple_exprs),*))
             }
@@ -2335,6 +2442,60 @@ impl TryFrom<(BuiltinScalarFunction, Vec<Expression>)> for StringFunction {
 }
 
 impl StringFunction {
+    fn expressions(&mut self) -> Vec<&mut Expression> {
+        match self {
+            StringFunction::Ascii(expr)
+            | StringFunction::BitLength(expr)
+            | StringFunction::CharacterLength(expr)
+            | StringFunction::OctetLength(expr)
+            | StringFunction::Btrim(expr, None)
+            | StringFunction::Lower(expr)
+            | StringFunction::Upper(expr)
+            | StringFunction::Chr(expr)
+            | StringFunction::InitCap(expr)
+            | StringFunction::Ltrim(expr, None)
+            | StringFunction::Rtrim(expr, None)
+            | StringFunction::Trim(expr, None)
+            | StringFunction::RegexpMatch(expr, ..)
+            | StringFunction::Reverse(expr) => vec![&mut *expr],
+
+            StringFunction::StartsWith(expr1, expr2)
+            | StringFunction::Left(expr1, expr2)
+            | StringFunction::Repeat(expr1, expr2)
+            | StringFunction::Right(expr1, expr2)
+            | StringFunction::Btrim(expr1, Some(expr2))
+            | StringFunction::Trim(expr1, Some(expr2))
+            | StringFunction::Ltrim(expr1, Some(expr2))
+            | StringFunction::Rtrim(expr1, Some(expr2))
+            | StringFunction::Substr(expr1, expr2, None)
+            | StringFunction::Lpad(expr1, expr2, None)
+            | StringFunction::Rpad(expr1, expr2, None)
+            | StringFunction::RegexpReplace(expr1, _, expr2, None)
+            | StringFunction::Strpos(expr1, expr2) => {
+                vec![&mut *expr1, &mut *expr2]
+            }
+
+            StringFunction::Substr(expr1, expr2, Some(expr3))
+            | StringFunction::Translate(expr1, expr2, expr3)
+            | StringFunction::Lpad(expr1, expr2, Some(expr3))
+            | StringFunction::Rpad(expr1, expr2, Some(expr3))
+            | StringFunction::Replace(expr1, expr2, expr3)
+            | StringFunction::RegexpReplace(expr1, _, expr2, Some(expr3))
+            | StringFunction::SplitPart(expr1, expr2, expr3) => {
+                vec![&mut *expr1, &mut *expr2, &mut *expr3]
+            },
+
+            StringFunction::Concat(exprs) => {
+                exprs.iter_mut().collect()
+            }
+            StringFunction::ConcatWithSeparator(expr, exprs) => {
+                let mut v = vec![&mut **expr];
+                v.extend(exprs.iter_mut());
+                v
+            }
+        }
+    }
+
     fn expression_type(&self, input_context: &ValuePointerContext) -> TypeDef {
         match self {
             StringFunction::Ascii(expr)
@@ -3409,7 +3570,7 @@ impl CodeGenerator<VecOfPointersContext, TypeDef, syn::Expr> for RustUdafExpress
         let need_early_exit = self.args.iter().any(|(function_arg, incoming_expression)| {
             !function_arg.is_optional()
                 && incoming_expression
-                    .expression_type(&ValuePointerContext)
+                    .expression_type(&ValuePointerContext::new())
                     .is_optional()
         });
 
@@ -3418,10 +3579,10 @@ impl CodeGenerator<VecOfPointersContext, TypeDef, syn::Expr> for RustUdafExpress
             .iter()
             .enumerate()
             .map(|(i, (def, expr))| {
-                let sub_expr = expr.generate(&ValuePointerContext);
+                let sub_expr = expr.generate(&ValuePointerContext::new());
                 let term_expr = match (
                     def.is_optional(),
-                    expr.expression_type(&ValuePointerContext).is_optional(),
+                    expr.expression_type(&ValuePointerContext::new()).is_optional(),
                 ) {
                     (true, true) | (false, false) => parse_quote!(#sub_expr),
                     (true, false) => parse_quote!(Some(#sub_expr)),
@@ -3432,7 +3593,7 @@ impl CodeGenerator<VecOfPointersContext, TypeDef, syn::Expr> for RustUdafExpress
                 (arg_init, term_expr)
             })
             .unzip();
-        let single_value_ident = ValuePointerContext.variable_ident();
+        let single_value_ident = ValuePointerContext::new().variable_ident();
 
         let mut vec_init: Vec<syn::Stmt> = Vec::new();
         let mut vec_push: Vec<syn::Stmt> = Vec::new();

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -146,6 +146,7 @@ impl ArroyoSchemaProvider {
                 make_scalar_function(fn_impl),
             )),
         );
+
         functions.insert(
             "get_json_objects".to_string(),
             Arc::new(create_udf(
@@ -160,6 +161,21 @@ impl ArroyoSchemaProvider {
                 make_scalar_function(fn_impl),
             )),
         );
+        functions.insert(
+            "extract_json".to_string(),
+            Arc::new(create_udf(
+                "extract_json",
+                vec![DataType::Utf8, DataType::Utf8],
+                Arc::new(DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::Utf8,
+                    false,
+                )))),
+                Volatility::Volatile,
+                make_scalar_function(fn_impl),
+            )),
+        );
+
         functions.insert(
             "extract_json_string".to_string(),
             Arc::new(create_udf(

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -121,8 +121,8 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for UnnestProjecti
                 #handle_optional
                 .map(|___unnest| {
                     #output_type {
-                        #(#assignments),*,
                         #unnest_ident: #unnest_expr,
+                        #(#assignments),*
                     }
                 })
         )

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -11,7 +11,7 @@ use petgraph::visit::Dfs;
 use petgraph::Direction::{self, Incoming, Outgoing};
 
 use quote::quote;
-use tracing::info;
+use tracing::debug;
 
 use crate::code_gen::ValueBinMergingContext;
 use crate::operators::{AggregateProjection, Projection, TwoPhaseAggregateProjection};
@@ -379,7 +379,7 @@ impl Optimizer for WindowTopNOptimization {
                 }
             }
             SearchTarget::Limit => {
-                info!("looking for limit, current operator is {:?}", node.operator);
+                debug!("looking for limit, current operator is {:?}", node.operator);
                 if let PlanOperator::RecordTransform(RecordTransform::Filter(filter)) =
                     node.operator
                 {

--- a/arroyo-sql/src/optimizations.rs
+++ b/arroyo-sql/src/optimizations.rs
@@ -22,7 +22,7 @@ use crate::plan_graph::{
 
 pub fn optimize(graph: &mut DiGraph<PlanNode, PlanEdge>) {
     WindowTopNOptimization::default().optimize(graph);
-    ExpressionFusionOptimizer::default().optimize(graph);
+    //ExpressionFusionOptimizer::default().optimize(graph);
     TwoPhaseOptimization {}.optimize(graph);
 }
 
@@ -147,7 +147,9 @@ impl Optimizer for ExpressionFusionOptimizer {
         node: PlanNode,
         graph: &mut DiGraph<PlanNode, PlanEdge>,
     ) -> bool {
-        if matches!(&node.operator, PlanOperator::RecordTransform { .. }) {
+        if matches!(&node.operator, PlanOperator::RecordTransform(RecordTransform::UnnestProjection(_))) {
+            false
+        } else if matches!(&node.operator, PlanOperator::RecordTransform { .. }) {
             if matches!(
                 &node.operator,
                 PlanOperator::RecordTransform(RecordTransform::KeyProjection { .. })
@@ -162,7 +164,7 @@ impl Optimizer for ExpressionFusionOptimizer {
             self.builder.fuse_node(&node);
             self.run.push(_node_index);
             false
-        } else if !self.run.is_empty() {
+        }  else if !self.run.is_empty() {
             self.try_finish_optimization(graph)
         } else {
             false
@@ -212,6 +214,9 @@ impl FusedExpressionOperatorBuilder {
                         self.add_projection(node.output_type.is_updating())
                     }
                     RecordTransform::Filter(_) => self.add_filter(node.output_type.is_updating()),
+                    RecordTransform::UnnestProjection(_) => {
+                        return false;
+                    }
                 }
                 true
             }

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -27,6 +27,7 @@ use crate::{
     types::{interval_month_day_nanos_to_duration, StructDef, StructField, TypeDef},
     ArroyoSchemaProvider,
 };
+use crate::operators::UnnestProjection;
 
 #[derive(Debug, Clone)]
 pub enum SqlOperator {
@@ -44,6 +45,7 @@ pub enum SqlOperator {
 pub enum RecordTransform {
     ValueProjection(Projection),
     KeyProjection(Projection),
+    UnnestProjection(UnnestProjection),
     TimestampAssignment(Expression),
     Filter(Expression),
 }
@@ -75,6 +77,9 @@ impl RecordTransform {
             }
             RecordTransform::KeyProjection(_) | RecordTransform::Filter(_) => input_struct,
             RecordTransform::TimestampAssignment(_) => input_struct,
+            RecordTransform::UnnestProjection(projection) => {
+                projection.expression_type(&ValuePointerContext::new())
+            }
         }
     }
 
@@ -83,30 +88,30 @@ impl RecordTransform {
             RecordTransform::ValueProjection(projection) => {
                 if is_updating {
                     let updating_record_expression =
-                        ValuePointerContext.compile_updating_value_map_expression(projection);
+                        ValuePointerContext::new().compile_updating_value_map_expression(projection);
                     MethodCompiler::optional_record_expression_operator(
                         "updating_value_map",
                         updating_record_expression,
                     )
                 } else {
-                    let record_expression = ValuePointerContext.compile_value_map_expr(projection);
+                    let record_expression = ValuePointerContext::new().compile_value_map_expr(projection);
                     MethodCompiler::record_expression_operator("value_map", record_expression)
                 }
             }
             RecordTransform::KeyProjection(projection) => {
                 if is_updating {
                     let key_closure =
-                        ValuePointerContext.compile_updating_key_map_closure(projection);
+                        ValuePointerContext::new().compile_updating_key_map_closure(projection);
                     MethodCompiler::updating_key_operator("updating_key_map", key_closure)
                 } else {
                     let record_expression =
-                        ValuePointerContext.compile_key_map_expression(projection);
+                        ValuePointerContext::new().compile_key_map_expression(projection);
                     MethodCompiler::record_expression_operator("key_map", record_expression)
                 }
             }
             RecordTransform::Filter(expression) => {
                 if is_updating {
-                    let updating_filter_optional_record_expr = ValuePointerContext
+                    let updating_filter_optional_record_expr = ValuePointerContext::new()
                         .compile_updating_filter_optional_record_expression(expression);
                     MethodCompiler::optional_record_expression_operator(
                         "updating_filter",
@@ -114,18 +119,26 @@ impl RecordTransform {
                     )
                 } else {
                     let filter_expression =
-                        ValuePointerContext.compile_filter_expression(expression);
+                        ValuePointerContext::new().compile_filter_expression(expression);
                     MethodCompiler::predicate_expression_operator("value_filter", filter_expression)
                 }
             }
             RecordTransform::TimestampAssignment(timestamp_expression) => {
                 let timestamp_record_expression =
-                    ValuePointerContext.compile_timestamp_record_expression(timestamp_expression);
+                    ValuePointerContext::new().compile_timestamp_record_expression(timestamp_expression);
 
                 MethodCompiler::record_expression_operator(
                     "timestamp_assigner",
                     timestamp_record_expression,
                 )
+            }
+            RecordTransform::UnnestProjection(p) => {
+                if is_updating {
+                    unreachable!("unnest is not supported for updating data");
+                }
+
+                let record_expression = ValuePointerContext::new().compile_flatmap_expr(p);
+                MethodCompiler::flatmap_operator("flatmap", record_expression)
             }
         }
     }
@@ -136,6 +149,7 @@ impl RecordTransform {
             RecordTransform::KeyProjection(_) => "key_project".into(),
             RecordTransform::Filter(_) => "filter".into(),
             RecordTransform::TimestampAssignment(_) => "timestamp".into(),
+            RecordTransform::UnnestProjection(_) => "unnest_project".into(),
         }
     }
 }
@@ -480,6 +494,31 @@ impl<'a> SqlPipelineBuilder<'a> {
         ))
     }
 
+    fn split_unnest(expr: &mut Expression) -> Result<Option<Expression>> {
+        let mut c: Option<Result<Expression>> = None;
+
+        expr.traverse_mut(&mut c, &|ctx, e| {
+           match e {
+               Expression::Unnest(expr, taken) => {
+                   if *taken {
+                       ctx.replace(Err(anyhow!("expression contains multiple unnests, which is not currently supported")));
+                   } else {
+                       *taken = true;
+                       ctx.replace(Ok(
+                           *expr.clone()
+                       ));
+                   }
+               }
+               _ => {
+
+               }
+           }
+        });
+
+        c.transpose()
+    }
+
+
     fn insert_projection(
         &mut self,
         projection: &datafusion_expr::logical_plan::Projection,
@@ -499,15 +538,39 @@ impl<'a> SqlPipelineBuilder<'a> {
             .schema
             .fields()
             .iter()
-            .map(|field| Column::convert(&field.qualified_column()))
-            .collect();
+            .map(|field| Column::convert(&field.qualified_column()));
 
-        let projection = Projection::new(names, functions);
+        let mut fields: Vec<_> = names.zip(functions).collect();
 
-        Ok(SqlOperator::RecordTransform(
-            Box::new(input),
-            RecordTransform::ValueProjection(projection),
-        ))
+        let mut unnest = None;
+        for (i, (_, expr)) in fields.iter_mut().enumerate(){
+            if let Some(e) = Self::split_unnest(expr)? {
+                if unnest.replace((i, e)).is_some() {
+                    bail!("multiple columns containing unnest functions, which is not currently supported");
+                }
+            }
+        }
+
+        if let Some((i, unnest_inner)) = unnest {
+            println!("found unnest at {}", i);
+            let (unnest_col, unnest_outer) = fields.remove(i);
+
+            Ok(SqlOperator::RecordTransform(Box::new(input),
+                        RecordTransform::UnnestProjection(UnnestProjection {
+                            fields,
+                            unnest_col,
+                            unnest_inner,
+                            unnest_outer,
+                            format: None,
+                        })))
+        } else {
+            let projection = Projection::new(fields);
+
+            Ok(SqlOperator::RecordTransform(
+                Box::new(input),
+                RecordTransform::ValueProjection(projection),
+            ))
+        }
     }
 
     fn insert_aggregation(
@@ -543,7 +606,7 @@ impl<'a> SqlPipelineBuilder<'a> {
                 } else {
                     let data_type = ctx
                         .compile_expr(expr)?
-                        .expression_type(&ValuePointerContext);
+                        .expression_type(&ValuePointerContext::new());
                     (data_type, AggregateResultExtraction::KeyColumn)
                 };
                 if let TypeDef::DataType(DataType::Struct(_), _) = &data_type {
@@ -615,13 +678,6 @@ impl<'a> SqlPipelineBuilder<'a> {
         let field_pairs: Vec<_> = field_pairs.into_iter().flatten().collect();
         let projection = Projection::new(
             field_pairs
-                .iter()
-                .map(|(column, _)| column.clone())
-                .collect(),
-            field_pairs
-                .into_iter()
-                .map(|(_, computation)| computation)
-                .collect(),
         );
 
         Ok(projection)
@@ -773,9 +829,9 @@ impl<'a> SqlPipelineBuilder<'a> {
             .into_iter()
             .unzip();
 
-        let left_key = Projection::new(join_projection_field_names.clone(), left_computations);
+        let left_key = Projection::new(join_projection_field_names.clone().into_iter().zip(left_computations).collect());
 
-        let right_key = Projection::new(join_projection_field_names, right_computations);
+        let right_key = Projection::new(join_projection_field_names.into_iter().zip(right_computations).collect());
 
         Ok(SqlOperator::JoinOperator(
             Box::new(left_input),
@@ -812,17 +868,15 @@ impl<'a> SqlPipelineBuilder<'a> {
                 .map(|t| Column {
                     relation: Some(table_scan.table_name.to_string()),
                     name: t.name.clone(),
-                })
-                .collect();
+                });
 
             let field_computations = fields
                 .iter()
-                .map(|t| Expression::Column(ColumnExpression::new(t.clone())))
-                .collect();
+                .map(|t| Expression::Column(ColumnExpression::new(t.clone())));
 
             return Ok(SqlOperator::RecordTransform(
                 Box::new(source),
-                RecordTransform::ValueProjection(Projection::new(field_names, field_computations)),
+                RecordTransform::ValueProjection(Projection::new(field_names.zip(field_computations).collect())),
             ));
         }
 
@@ -893,8 +947,7 @@ impl<'a> SqlPipelineBuilder<'a> {
                 .map(|(i, _t)| Column {
                     relation: None,
                     name: format!("_{}", i),
-                })
-                .collect();
+                });
 
             let field_computations = w
                 .partition_by
@@ -908,7 +961,7 @@ impl<'a> SqlPipelineBuilder<'a> {
             })
                 .collect::<Result<Vec<_>>>()?;
 
-            let partition = Projection::new(field_names, field_computations);
+            let partition = Projection::new(field_names.zip(field_computations).collect());
             let field_name = window.schema.field_names().last().cloned().unwrap();
 
             return Ok(SqlOperator::Window(
@@ -936,17 +989,15 @@ impl<'a> SqlPipelineBuilder<'a> {
         let field_computations = input_type
             .fields
             .iter()
-            .map(|field| Expression::Column(ColumnExpression::new(field.clone())))
-            .collect();
+            .map(|field| Expression::Column(ColumnExpression::new(field.clone())));
 
         let field_names = subquery_alias
             .schema
             .fields()
             .iter()
-            .map(|field| Column::convert(&field.qualified_column()))
-            .collect();
+            .map(|field| Column::convert(&field.qualified_column()));
 
-        let projection = Projection::new(field_names, field_computations);
+        let projection = Projection::new(field_names.zip(field_computations).collect());
         Ok(SqlOperator::RecordTransform(
             Box::new(input),
             RecordTransform::ValueProjection(projection),
@@ -976,13 +1027,12 @@ impl<'a> SqlPipelineBuilder<'a> {
                                 .map(|f| Column {
                                     relation: None,
                                     name: f.name.clone(),
-                                })
-                                .collect(),
-                            input_struct
-                                .fields
-                                .iter()
-                                .map(|f| Expression::Column(ColumnExpression::new(f.clone())))
-                                .collect(),
+                                }).zip(
+                                input_struct
+                                    .fields
+                                    .iter()
+                                    .map(|f| Expression::Column(ColumnExpression::new(f.clone()))))
+                                    .collect(),
                         ));
                         self.planned_tables.insert(
                             name.clone(),
@@ -1041,6 +1091,13 @@ impl MethodCompiler {
             name: name.to_string(),
             expression: quote!(#expression).to_string(),
             return_type: arroyo_datastream::ExpressionReturnType::Record,
+        }
+    }
+
+    fn flatmap_operator(name: impl ToString, expression: syn::Expr) -> Operator {
+        Operator::FlatMapOperator {
+            name: name.to_string(),
+            expression: quote!(#expression).to_string(),
         }
     }
 

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -150,7 +150,8 @@ impl FusedRecordTransform {
                 RecordTransform::ValueProjection(projection) => {
                     names.push("value_project");
                     let record_type = output_type.record_type();
-                    let record_expression = ValuePointerContext::new().compile_value_map_expr(projection);
+                    let record_expression =
+                        ValuePointerContext::new().compile_value_map_expr(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type =  #record_expression;
                     ));
@@ -174,7 +175,9 @@ impl FusedRecordTransform {
                     ));
                 }
                 RecordTransform::Filter(_) => unreachable!(),
-                RecordTransform::UnnestProjection(p) => unreachable!("unnest projection cannot be fused"),
+                RecordTransform::UnnestProjection(_) => {
+                    unreachable!("unnest projection cannot be fused")
+                }
             }
         }
         let combined: syn::Expr = parse_quote!({
@@ -199,7 +202,8 @@ impl FusedRecordTransform {
                 (RecordTransform::ValueProjection(projection), false) => {
                     names.push("value_project");
                     let record_type = output_type.record_type();
-                    let record_expression = ValuePointerContext::new().compile_value_map_expr(projection);
+                    let record_expression =
+                        ValuePointerContext::new().compile_value_map_expr(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
                     ));
@@ -207,8 +211,8 @@ impl FusedRecordTransform {
                 (RecordTransform::ValueProjection(projection), true) => {
                     names.push("updating_value_project");
                     let record_type = output_type.record_type();
-                    let record_expression =
-                        ValuePointerContext::new().compile_updating_value_map_expression(projection);
+                    let record_expression = ValuePointerContext::new()
+                        .compile_updating_value_map_expression(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression?;
                     ));
@@ -249,7 +253,9 @@ impl FusedRecordTransform {
                             let record: #record_type = #record_expression;
                     ));
                 }
-                (RecordTransform::UnnestProjection(_), _) => unreachable!("unnest projection cannot be fused"),
+                (RecordTransform::UnnestProjection(_), _) => {
+                    unreachable!("unnest projection cannot be fused")
+                }
                 _ => unimplemented!(),
             }
         }
@@ -294,9 +300,7 @@ impl PlanNode {
             RecordTransform::TimestampAssignment(_) | RecordTransform::Filter(_) => {
                 input_type.clone()
             }
-            RecordTransform::UnnestProjection(p) => {
-                input_type.with_value(p.output_struct())
-            }
+            RecordTransform::UnnestProjection(p) => input_type.with_value(p.output_struct()),
         };
         PlanNode {
             operator: PlanOperator::RecordTransform(record_transform),
@@ -754,7 +758,9 @@ impl PlanNode {
                     let bin_type = projection
                         .expression_type(&ValueBinMergingContext::new())
                         .syn_type();
-                    let memory_type = projection.memory_type(&ValuePointerContext::new()).syn_type();
+                    let memory_type = projection
+                        .memory_type(&ValuePointerContext::new())
+                        .syn_type();
                     let memory_add = projection.generate(&MemoryAddingContext::new());
                     let memory_removing_context = MemoryRemovingContext::new();
                     let memory_remove = projection.generate(&memory_removing_context);

--- a/arroyo-sql/src/plan_graph.rs
+++ b/arroyo-sql/src/plan_graph.rs
@@ -127,7 +127,7 @@ impl FusedRecordTransform {
                 panic!("FusedRecordTransform.to_predicate_operator() called on non-predicate expression");
             };
             names.push("filter");
-            predicates.push(predicate.generate(&ValuePointerContext));
+            predicates.push(predicate.generate(&ValuePointerContext::new()));
         }
         let predicate: syn::Expr = parse_quote!( {
             let arg = &record.value;
@@ -150,7 +150,7 @@ impl FusedRecordTransform {
                 RecordTransform::ValueProjection(projection) => {
                     names.push("value_project");
                     let record_type = output_type.record_type();
-                    let record_expression = ValuePointerContext.compile_value_map_expr(projection);
+                    let record_expression = ValuePointerContext::new().compile_value_map_expr(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type =  #record_expression;
                     ));
@@ -159,7 +159,7 @@ impl FusedRecordTransform {
                     names.push("key_project");
                     let record_type = output_type.record_type();
                     let record_expression =
-                        ValuePointerContext.compile_key_map_expression(projection);
+                        ValuePointerContext::new().compile_key_map_expression(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
                     ));
@@ -167,13 +167,14 @@ impl FusedRecordTransform {
                 RecordTransform::TimestampAssignment(timestamp_expression) => {
                     names.push("timestamp_assignment");
                     let record_type = output_type.record_type();
-                    let record_expression = ValuePointerContext
+                    let record_expression = ValuePointerContext::new()
                         .compile_timestamp_record_expression(timestamp_expression);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
                     ));
                 }
                 RecordTransform::Filter(_) => unreachable!(),
+                RecordTransform::UnnestProjection(p) => unreachable!("unnest projection cannot be fused"),
             }
         }
         let combined: syn::Expr = parse_quote!({
@@ -198,7 +199,7 @@ impl FusedRecordTransform {
                 (RecordTransform::ValueProjection(projection), false) => {
                     names.push("value_project");
                     let record_type = output_type.record_type();
-                    let record_expression = ValuePointerContext.compile_value_map_expr(projection);
+                    let record_expression = ValuePointerContext::new().compile_value_map_expr(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
                     ));
@@ -207,7 +208,7 @@ impl FusedRecordTransform {
                     names.push("updating_value_project");
                     let record_type = output_type.record_type();
                     let record_expression =
-                        ValuePointerContext.compile_updating_value_map_expression(projection);
+                        ValuePointerContext::new().compile_updating_value_map_expression(projection);
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression?;
                     ));
@@ -215,7 +216,7 @@ impl FusedRecordTransform {
                 (RecordTransform::KeyProjection(projection), false) => {
                     names.push("key_project");
                     let record_expression =
-                        ValuePointerContext.compile_key_map_expression(projection);
+                        ValuePointerContext::new().compile_key_map_expression(projection);
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
@@ -224,7 +225,7 @@ impl FusedRecordTransform {
                 (RecordTransform::Filter(predicate), false) => {
                     names.push("filter");
                     let predicate_expression =
-                        ValuePointerContext.compile_filter_expression(predicate);
+                        ValuePointerContext::new().compile_filter_expression(predicate);
                     record_expressions.push(parse_quote!(
                         if !#predicate_expression {
                             return None;
@@ -233,7 +234,7 @@ impl FusedRecordTransform {
                 }
                 (RecordTransform::Filter(predicate), true) => {
                     names.push("updating_filter");
-                    let record_expression = ValuePointerContext
+                    let record_expression = ValuePointerContext::new()
                         .compile_updating_filter_optional_record_expression(predicate);
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
@@ -241,13 +242,14 @@ impl FusedRecordTransform {
                 }
                 (RecordTransform::TimestampAssignment(timestamp_expression), false) => {
                     names.push("timestamp_assignment");
-                    let record_expression = ValuePointerContext
+                    let record_expression = ValuePointerContext::new()
                         .compile_timestamp_record_expression(timestamp_expression);
                     let record_type = output_type.record_type();
                     record_expressions.push(parse_quote!(
                             let record: #record_type = #record_expression;
                     ));
                 }
+                (RecordTransform::UnnestProjection(_), _) => unreachable!("unnest projection cannot be fused"),
                 _ => unimplemented!(),
             }
         }
@@ -291,6 +293,9 @@ impl PlanNode {
             }
             RecordTransform::TimestampAssignment(_) | RecordTransform::Filter(_) => {
                 input_type.clone()
+            }
+            RecordTransform::UnnestProjection(p) => {
+                input_type.with_value(p.output_struct())
             }
         };
         PlanNode {
@@ -568,7 +573,7 @@ impl PlanNode {
                     .into_token_stream()
                     .to_string();
                 let bin_type = aggregating_projection
-                    .bin_type(&ValuePointerContext)
+                    .bin_type(&ValuePointerContext::new())
                     .syn_type()
                     .into_token_stream()
                     .to_string();
@@ -595,11 +600,11 @@ impl PlanNode {
                 let sort_tuple = SortExpression::sort_tuple_type(order_by);
                 let sort_key_type = quote!(#sort_tuple).to_string();
 
-                let partition_expr = partition_projection.generate(&ValuePointerContext);
-                let partition_arg = ValuePointerContext.variable_ident();
+                let partition_expr = partition_projection.generate(&ValuePointerContext::new());
+                let partition_arg = ValuePointerContext::new().variable_ident();
                 let partition_function: syn::ExprClosure =
                     parse_quote!(|#partition_arg| {#partition_expr});
-                let projection_expr = converting_projection.generate(&ValuePointerContext);
+                let projection_expr = converting_projection.generate(&ValuePointerContext::new());
 
                 let sort_tokens = SortExpression::sort_tuple_expression(order_by);
 
@@ -749,7 +754,7 @@ impl PlanNode {
                     let bin_type = projection
                         .expression_type(&ValueBinMergingContext::new())
                         .syn_type();
-                    let memory_type = projection.memory_type(&ValuePointerContext).syn_type();
+                    let memory_type = projection.memory_type(&ValuePointerContext::new()).syn_type();
                     let memory_add = projection.generate(&MemoryAddingContext::new());
                     let memory_removing_context = MemoryRemovingContext::new();
                     let memory_remove = projection.generate(&memory_removing_context);
@@ -1237,10 +1242,10 @@ impl PlanGraph {
         }
 
         let strategy = if let Some(watermark_expression) = source_operator.watermark_column {
-            let arg_ident = ValuePointerContext.variable_ident();
-            let expression = watermark_expression.generate(&ValuePointerContext);
+            let arg_ident = ValuePointerContext::new().variable_ident();
+            let expression = watermark_expression.generate(&ValuePointerContext::new());
             let null_checked_expression = if watermark_expression
-                .expression_type(&ValuePointerContext)
+                .expression_type(&ValuePointerContext::new())
                 .is_optional()
             {
                 parse_quote!(#expression.unwrap_or_else(|| std::time::SystemTime::now()))

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -416,11 +416,12 @@ impl ConnectorTable {
                         name: t.name(),
                     })
                     .zip(
-                    output_struct
-                        .fields
-                        .iter()
-                        .map(|t| Expression::Column(ColumnExpression::new(t.clone()))))
-                        .collect(),
+                        output_struct
+                            .fields
+                            .iter()
+                            .map(|t| Expression::Column(ColumnExpression::new(t.clone()))),
+                    )
+                    .collect(),
             );
 
             projection.format = Some(format.clone());


### PR DESCRIPTION
This PR adds initial support for `unnest`, which unrolls an array into individual records. This is often useful when interacting with HTTP apis via the polling http source, as it allows json arrays to be handled as individual records.

For example, emitting on new Github PRs:

```sql
CREATE TABLE prs (
    value TEXT
) WITH (
    connector = 'polling_http',
    endpoint = 'https://api.github.com/repos/ArroyoSystems/arroyo/pulls?per_page=50&state=all',
    poll_interval_ms = '5000',
    emit_behavior = 'changed',
    headers = 'User-Agent:arroyo/0.6',
    format = 'json',
    'json.unstructured' = 'true'
);
 
SELECT distinct(unnest(extract_json(value, '$[*].url'))) as url
from prs;
```

![image](https://github.com/ArroyoSystems/arroyo/assets/100920/8265c94a-f67b-44e7-989a-f62360c33282)


Unnest is currently only implemented for projections. The implementation works by registering unnest as a UDF with datafusion, then looking for it in projection expressions. If it's found, the expression is split into two parts around the unnest. This is then turned into an UnnestProjection, which compiles into a flatmap that maps over the array produced by the inner expression and projects it uses the outer expression, and finally collects it into a vec. This vec is then unrolled by a new FlatMapOperator (the existing, misnamed FlatMapOperator has been renamed to ArrayMapOperator).

This PR also includes a UX improvement to json functions, which now will validate the json path expression at plan time if it's a literal string (previously bad json paths were just ignored leading to a confusing user experience). I've also added a couple of aliases for the json functions to better match other sql dialects.