### PR TITLE
Add restarting state and pipeline restart API

### DIFF
--- a/arroyo-api/migrations/V16__restart_failed.sql
+++ b/arroyo-api/migrations/V16__restart_failed.sql
@@ -1,0 +1,9 @@
+CREATE TYPE restart_mode as ENUM (
+    'safe', 'force');
+
+ALTER TABLE job_configs
+ADD COLUMN restart_nonce int not null default 0,
+ADD COLUMN restart_mode restart_mode not null default 'safe';
+
+ALTER TABLE job_statuses
+ADD COLUMN restart_nonce int not null default 0;

--- a/arroyo-api/queries/api_queries.sql
+++ b/arroyo-api/queries/api_queries.sql
@@ -179,6 +179,15 @@ SET
    parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides)
 WHERE id = :job_id AND organization_id = :organization_id;
 
+--! restart_job(mode)
+UPDATE job_configs
+SET
+   updated_at = :updated_at,
+   updated_by = :updated_by,
+   restart_nonce = restart_nonce + 1,
+   restart_mode = :mode
+WHERE id = :job_id AND organization_id = :organization_id;
+
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
 (id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros)

--- a/arroyo-api/src/jobs.rs
+++ b/arroyo-api/src/jobs.rs
@@ -169,6 +169,9 @@ pub(crate) fn get_action(state: &str, running_desired: &bool) -> (String, Option
         ("Recovering", true) => ("Stop", Some(Checkpoint), InProgress),
         ("Recovering", false) => ("Stopping", Option::None, InProgress),
 
+        ("Restarting", true) => ("Stop", Some(Checkpoint), InProgress),
+        ("Restarting", false) => ("Stopping", Option::None, InProgress),
+
         ("Stopping", true) => ("Stopping", Some(Checkpoint), InProgress),
         ("Stopping", false) => ("Stopping", Option::None, InProgress),
 

--- a/arroyo-api/src/lib.rs
+++ b/arroyo-api/src/lib.rs
@@ -21,7 +21,7 @@ use crate::pipelines::__path_get_pipelines;
 use crate::pipelines::__path_post_pipeline;
 use crate::pipelines::{
     __path_delete_pipeline, __path_get_pipeline, __path_get_pipeline_jobs, __path_patch_pipeline,
-    __path_validate_query, __path_validate_udfs,
+    __path_restart_pipeline, __path_validate_query, __path_validate_udfs,
 };
 use crate::rest::__path_ping;
 use crate::rest_utils::{bad_request, log_and_map, ErrorResp};
@@ -34,9 +34,10 @@ use arroyo_rpc::types::{
     JobLogMessageCollection, Metric, MetricGroup, MetricNames, OperatorCheckpointGroup,
     OperatorCheckpointGroupCollection, OperatorMetricGroup, OutputData, PaginationQueryParams,
     Pipeline, PipelineCollection, PipelineEdge, PipelineGraph, PipelineNode, PipelinePatch,
-    PipelinePost, PrimitiveType, QueryValidationResult, PipelineRestart, SchemaDefinition, SourceField,
-    SourceFieldType, StopType as StopTypeRest, StructType, SubtaskCheckpointGroup, SubtaskMetrics,
-    TestSourceMessage, Udf, UdfLanguage, UdfValidationResult, ValidateQueryPost, ValidateUdfsPost,
+    PipelinePost, PipelineRestart, PrimitiveType, QueryValidationResult, SchemaDefinition,
+    SourceField, SourceFieldType, StopType as StopTypeRest, StructType, SubtaskCheckpointGroup,
+    SubtaskMetrics, TestSourceMessage, Udf, UdfLanguage, UdfValidationResult, ValidateQueryPost,
+    ValidateUdfsPost,
 };
 
 mod cloud;
@@ -142,6 +143,7 @@ pub(crate) fn to_micros(dt: OffsetDateTime) -> u64 {
         validate_udfs,
         post_pipeline,
         patch_pipeline,
+        restart_pipeline,
         get_pipeline,
         delete_pipeline,
         get_pipelines,

--- a/arroyo-api/src/lib.rs
+++ b/arroyo-api/src/lib.rs
@@ -34,7 +34,7 @@ use arroyo_rpc::types::{
     JobLogMessageCollection, Metric, MetricGroup, MetricNames, OperatorCheckpointGroup,
     OperatorCheckpointGroupCollection, OperatorMetricGroup, OutputData, PaginationQueryParams,
     Pipeline, PipelineCollection, PipelineEdge, PipelineGraph, PipelineNode, PipelinePatch,
-    PipelinePost, PrimitiveType, QueryValidationResult, SchemaDefinition, SourceField,
+    PipelinePost, PrimitiveType, QueryValidationResult, PipelineRestart, SchemaDefinition, SourceField,
     SourceFieldType, StopType as StopTypeRest, StructType, SubtaskCheckpointGroup, SubtaskMetrics,
     TestSourceMessage, Udf, UdfLanguage, UdfValidationResult, ValidateQueryPost, ValidateUdfsPost,
 };
@@ -165,6 +165,7 @@ pub(crate) fn to_micros(dt: OffsetDateTime) -> u64 {
     components(schemas(
         PipelinePost,
         PipelinePatch,
+        PipelineRestart,
         Pipeline,
         PipelineGraph,
         PipelineNode,

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -29,7 +29,7 @@ use crate::jobs::{
 use crate::metrics::get_operator_metric_groups;
 use crate::pipelines::{
     delete_pipeline, get_pipeline, get_pipeline_jobs, get_pipelines, patch_pipeline, post_pipeline,
-    validate_query, validate_udfs,
+    validate_query, validate_udfs, restart_pipeline
 };
 use crate::rest_utils::not_found;
 use crate::ApiDoc;
@@ -124,6 +124,7 @@ pub fn create_rest_app(pool: Pool, controller_addr: &str) -> Router {
         .route("/pipelines/validate_udfs", post(validate_udfs))
         .route("/pipelines/:id", patch(patch_pipeline))
         .route("/pipelines/:id", get(get_pipeline))
+        .route("/pipelines/:id/restart", post(restart_pipeline))
         .route("/pipelines/:id", delete(delete_pipeline))
         .nest("/pipelines/:id/jobs", jobs_routes)
         .fallback(api_fallback);

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -29,7 +29,7 @@ use crate::jobs::{
 use crate::metrics::get_operator_metric_groups;
 use crate::pipelines::{
     delete_pipeline, get_pipeline, get_pipeline_jobs, get_pipelines, patch_pipeline, post_pipeline,
-    validate_query, validate_udfs, restart_pipeline
+    restart_pipeline, validate_query, validate_udfs,
 };
 use crate::rest_utils::not_found;
 use crate::ApiDoc;

--- a/arroyo-console/src/gen/api-types.ts
+++ b/arroyo-console/src/gen/api-types.ts
@@ -135,6 +135,13 @@ export interface paths {
      */
     get: operations["get_pipeline_jobs"];
   };
+  "/v1/pipelines/{id}/restart": {
+    /**
+     * Restart a pipeline 
+     * @description Restart a pipeline
+     */
+    post: operations["restart_pipeline"];
+  };
   "/v1/pipelines/{pipeline_id}/jobs/{job_id}/checkpoints": {
     /**
      * List a job's checkpoints 
@@ -426,6 +433,9 @@ export interface components {
       preview?: boolean | null;
       query: string;
       udfs?: (components["schemas"]["Udf"])[] | null;
+    };
+    PipelineRestart: {
+      force?: boolean | null;
     };
     /** @enum {string} */
     PrimitiveType: "int32" | "int64" | "u_int32" | "u_int64" | "f32" | "f64" | "bool" | "string" | "bytes" | "unix_millis" | "unix_micros" | "unix_nanos" | "date_time" | "json";
@@ -840,6 +850,31 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["JobCollection"];
+        };
+      };
+    };
+  };
+  /**
+   * Restart a pipeline 
+   * @description Restart a pipeline
+   */
+  restart_pipeline: {
+    parameters: {
+      path: {
+        /** @description Pipeline id */
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PipelineRestart"];
+      };
+    };
+    responses: {
+      /** @description Updated pipeline */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Pipeline"];
         };
       };
     };

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -441,6 +441,14 @@ export const usePipeline = (pipelineId?: string, refresh: boolean = false) => {
     await mutate();
   };
 
+  const restartPipeline = async () => {
+    await post('/v1/pipelines/{id}/restart', {
+      params: { path: { id: pipelineId! } },
+      body: {},
+    });
+    await mutate();
+  };
+
   const deletePipeline = async () => {
     const { error } = await del('/v1/pipelines/{id}', {
       params: { path: { id: pipelineId! } },
@@ -455,6 +463,7 @@ export const usePipeline = (pipelineId?: string, refresh: boolean = false) => {
     pipelineLoading: isLoading,
     updatePipeline,
     deletePipeline,
+    restartPipeline,
   };
 };
 

--- a/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
+++ b/arroyo-console/src/routes/pipelines/PipelineDetails.tsx
@@ -63,7 +63,7 @@ export function PipelineDetails() {
 
   let { pipelineId: id } = useParams();
 
-  const { pipeline, pipelineError, updatePipeline } = usePipeline(id, true);
+  const { pipeline, pipelineError, updatePipeline, restartPipeline } = usePipeline(id, true);
   const { jobs, jobsError } = usePipelineJobs(id, true);
   const job = jobs?.length ? jobs[0] : undefined;
   const { checkpoints } = useJobCheckpoints(id, job?.id);
@@ -256,17 +256,29 @@ export function PipelineDetails() {
   let actionButton = <></>;
   if (pipeline) {
     editPipelineButton = <Button onClick={onConfigModalOpen}>Edit</Button>;
-    actionButton = (
-      <Button
-        isDisabled={pipeline.action == null}
-        onClick={async () => {
-          await updateJobState(pipeline.action!);
-        }}
-      >
-        {pipeline.actionInProgress ? <Spinner size="xs" mr={2} /> : null}
-        {pipeline.actionText}
-      </Button>
-    );
+    if (job.state == 'Failed') {
+      actionButton = (
+        <Button
+          onClick={async () => {
+            await restartPipeline();
+          }}
+        >
+          Restart
+        </Button>
+      );
+    } else {
+      actionButton = (
+        <Button
+          isDisabled={pipeline.action == null}
+          onClick={async () => {
+            await updateJobState(pipeline.action!);
+          }}
+        >
+          {pipeline.actionInProgress ? <Spinner size="xs" mr={2} /> : null}
+          {pipeline.actionText}
+        </Button>
+      );
+    }
   }
 
   const headerArea = (

--- a/arroyo-controller/queries/controller_queries.sql
+++ b/arroyo-controller/queries/controller_queries.sql
@@ -16,7 +16,10 @@ SELECT
     restarts,
     run_id,
     pipeline_path,
-    wasm_path
+    wasm_path,
+    job_configs.restart_nonce as config_restart_nonce,
+    job_statuses.restart_nonce as status_restart_nonce,
+    restart_mode
 FROM job_configs
 LEFT JOIN job_statuses ON job_configs.id = job_statuses.id;
 

--- a/arroyo-controller/queries/controller_queries.sql
+++ b/arroyo-controller/queries/controller_queries.sql
@@ -33,7 +33,8 @@ SET state = :state,
     restarts = :restarts,
     pipeline_path = :pipeline_path,
     wasm_path = :wasm_path,
-    run_id = :run_id
+    run_id = :run_id,
+    restart_nonce = :restart_nonce
 WHERE id = :job_id;
 
 --! get_program

--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -50,7 +50,7 @@ include!(concat!(env!("OUT_DIR"), "/controller-sql.rs"));
 
 use crate::schedulers::{nomad::NomadScheduler, NodeScheduler, ProcessScheduler, Scheduler};
 use types::public::LogLevel;
-use types::public::{StopMode, RestartMode};
+use types::public::{RestartMode, StopMode};
 
 pub const CHECKPOINTS_TO_KEEP: u32 = 5;
 
@@ -116,6 +116,7 @@ impl JobStatus {
                 &self.pipeline_path,
                 &self.wasm_path,
                 &self.run_id,
+                &self.restart_nonce,
                 &self.id,
             )
             .await
@@ -631,7 +632,7 @@ impl ControllerServer {
                         restarts: p.restarts,
                         pipeline_path: p.pipeline_path,
                         wasm_path: p.wasm_path,
-                        restart_nonce: p.status_restart_nonce
+                        restart_nonce: p.status_restart_nonce,
                     };
 
                     if let Some(sm) = jobs.get_mut(&config.id) {

--- a/arroyo-controller/src/lib.rs
+++ b/arroyo-controller/src/lib.rs
@@ -50,7 +50,7 @@ include!(concat!(env!("OUT_DIR"), "/controller-sql.rs"));
 
 use crate::schedulers::{nomad::NomadScheduler, NodeScheduler, ProcessScheduler, Scheduler};
 use types::public::LogLevel;
-use types::public::StopMode;
+use types::public::{StopMode, RestartMode};
 
 pub const CHECKPOINTS_TO_KEEP: u32 = 5;
 
@@ -82,6 +82,8 @@ pub struct JobConfig {
     checkpoint_interval: Duration,
     ttl: Option<Duration>,
     parallelism_overrides: HashMap<String, usize>,
+    restart_nonce: i32,
+    restart_mode: RestartMode,
 }
 
 #[derive(Clone, Debug)]
@@ -96,6 +98,7 @@ pub struct JobStatus {
     restarts: i32,
     pipeline_path: Option<String>,
     wasm_path: Option<String>,
+    restart_nonce: i32,
 }
 
 impl JobStatus {
@@ -611,6 +614,8 @@ impl ControllerServer {
                             .into_iter()
                             .map(|(k, v)| (k.clone(), v.as_u64().unwrap() as usize))
                             .collect(),
+                        restart_nonce: p.config_restart_nonce,
+                        restart_mode: p.restart_mode,
                     };
 
                     let mut jobs = jobs.lock().await;
@@ -626,6 +631,7 @@ impl ControllerServer {
                         restarts: p.restarts,
                         pipeline_path: p.pipeline_path,
                         wasm_path: p.wasm_path,
+                        restart_nonce: p.status_restart_nonce
                     };
 
                     if let Some(sm) = jobs.get_mut(&config.id) {

--- a/arroyo-controller/src/states/recovering.rs
+++ b/arroyo-controller/src/states/recovering.rs
@@ -12,7 +12,7 @@ pub struct Recovering {}
 
 impl Recovering {
     // tries, with increasing levels of force, to tear down the existing cluster
-    async fn cleanup<'a>(&mut self, ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
+    pub async fn cleanup<'a>(ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
         let job_controller = ctx.job_controller.as_mut().unwrap();
 
         // first try to stop it gracefully
@@ -92,7 +92,7 @@ impl State for Recovering {
 
     async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
         // tear down the existing cluster
-        if let Err(e) = self.cleanup(ctx).await {
+        if let Err(e) = Self::cleanup(ctx).await {
             return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
         }
 

--- a/arroyo-controller/src/states/restarting.rs
+++ b/arroyo-controller/src/states/restarting.rs
@@ -1,0 +1,83 @@
+use crate::states::recovering::Recovering;
+use crate::states::scheduling::Scheduling;
+use crate::states::stop_if_desired_non_running;
+use crate::types::public::RestartMode;
+use crate::JobMessage;
+
+use super::{JobContext, State, StateError, Transition};
+
+#[derive(Debug)]
+pub struct Restarting {
+    pub mode: RestartMode,
+}
+
+#[async_trait::async_trait]
+impl State for Restarting {
+    fn name(&self) -> &'static str {
+        "Restarting"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        let job_controller = ctx.job_controller.as_mut().unwrap();
+
+        match self.mode {
+            RestartMode::safe => {
+                if let Err(e) = job_controller.checkpoint(true).await {
+                    return Err(ctx.retryable(self, "failed to initiate final checkpoint", e, 10));
+                }
+
+                loop {
+                    match job_controller.checkpoint_finished().await {
+                        Ok(done) => {
+                            if done && job_controller.finished() {
+                                return Ok(Transition::next(*self, Scheduling {}));
+                            }
+                        }
+                        Err(e) => {
+                            return Err(ctx.retryable(
+                                self,
+                                "failed while monitoring final checkpoint",
+                                e,
+                                10,
+                            ));
+                        }
+                    }
+
+                    match ctx.rx.recv().await.expect("channel closed while receiving") {
+                        JobMessage::RunningMessage(msg) => {
+                            if let Err(e) = job_controller.handle_message(msg).await {
+                                return Err(ctx.retryable(
+                                    self,
+                                    "failed while waiting for job finish",
+                                    e,
+                                    10,
+                                ));
+                            }
+                        }
+                        JobMessage::ConfigUpdate(c) => {
+                            if c.restart_mode == RestartMode::force {
+                                return Ok(Transition::next(
+                                    *self,
+                                    Restarting {
+                                        mode: RestartMode::force,
+                                    },
+                                ));
+                            }
+                            stop_if_desired_non_running!(self, &c);
+                        }
+                        _ => {
+                            // ignore other messages
+                        }
+                    }
+                }
+            }
+            RestartMode::force => {
+                if let Err(e) = Recovering::cleanup(ctx).await {
+                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
+                }
+
+                Ok(Transition::next(*self, Scheduling {}))
+            }
+        }
+    }
+}

--- a/arroyo-rpc/src/types.rs
+++ b/arroyo-rpc/src/types.rs
@@ -53,6 +53,12 @@ pub struct PipelinePatch {
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct PipelineRestart {
+    pub force: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Pipeline {
     pub id: String,
     pub name: String,

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -191,6 +191,11 @@ where
                 .collect()
         };
 
+        info!(
+            "partition map for {}-{}: {:?}",
+            self.topic, ctx.task_info.task_index, our_partitions
+        );
+
         let topic_partitions = TopicPartitionList::from_topic_map(&our_partitions)?;
 
         consumer.assign(&topic_partitions)?;


### PR DESCRIPTION
This PR adds a new state `Restarting` and a new api `POST /pipeline/{id}/restart` which together allowing restarting pipelines. This can be used to restart a running pipeline (sometimes useful if it gets into some bad state that the system isn't able to automatically detect). But it can also be used for failed jobs, which currently cannot be recovered (without editing the db).

Now, a failed pipeline can be restarted via the API like this:

```
$ curl -XPOST localhost:8000/api/v1/pipelines/pl_OZWnhLx5I3/restart -d "{}" \
  -H "Content-Type: application/json"
```

There is also UI support to restart failed pipelines:

![image](https://github.com/ArroyoSystems/arroyo/assets/100920/e0cc9a25-1b65-46d3-bbf6-51cd057a61bc)


---

Restarting is a bit awkward to model in a reconciliation-based system like the controller; in general reconciliation requires a change to drive an operation. But for restarting, we want to force a state transition without actually changing any configuration.

This PR accomplishes that by adding `restart_nonce` fields on the job_configs and job_statuses tables. This is a number that can be incrementing in order to change the config while leaving everything the same.