### PR TITLE
Don't finish pipeline on websocket reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -7616,9 +7616,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -7947,9 +7947,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -30,6 +30,6 @@ tracing = "0.1.37"
 regress = "0.6.0"
 eventsource-client = "0.11.0"
 futures = "0.3.28"
-tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 axum = {version = "0.6.12"}
 reqwest = "0.11.20"

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -64,7 +64,7 @@ regex = "1.8.1"
 anyhow = "1.0.71"
 typify = "0.0.13"
 regress = "0.6.0"
-tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 fluvio = {version = "=0.21", features = ["openssl"]}
 fluvio-future = "0.6.0"
 object_store = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '43.0.0/arroyo_patches', features = ["aws"] }

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -199,7 +199,7 @@ where
                                     },
                                     tungstenite::Message::Close(_) => {
                                         ctx.report_error("Received close frame from server".to_string(), "".to_string()).await;
-                                        return SourceFinishType::Final;
+                                        panic!("Received close frame from server");
                                     },
                                     tungstenite::Message::Frame(_) => {
                                         // this should be captured by tungstenite


### PR DESCRIPTION
Currently we send a final watermark when we receive a close message from a websocket server, finishing the pipeline. However, close messages may be sent for a variety of reasons, and it does not necessarily indicate that processing should stop.

This replaces that with a panic, which will restart the pipeline and re-establish a connection.

Also updates tungstenite (our websocket library) to address a couple of security vulnerabilities.