### PR TITLE
Generate serializer items for json schema

### DIFF
--- a/arroyo-console/src/routes/connections/Connections.tsx
+++ b/arroyo-console/src/routes/connections/Connections.tsx
@@ -133,8 +133,7 @@ export function Connections() {
         <ModalCloseButton />
         <ModalBody>
           <Code colorScheme="black" width="100%" p={4}>
-            {/* toJson -> parse -> stringify to get around the inabilityof JSON.stringify to handle BigInt */}
-            <pre>{JSON.stringify(selected?.config)}</pre>
+            <pre style={{ overflowX: 'auto' }}>{JSON.stringify(selected?.config, null, 2)}</pre>
           </Code>
         </ModalBody>
         <ModalFooter>

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -25,7 +25,7 @@ use syn::{parse_quote, parse_str, GenericArgument, PathArguments, Type, TypePath
 
 use anyhow::{anyhow, bail, Result};
 
-use crate::Operator::{FlatMapOperator, FusedWasmUDFs};
+use crate::Operator::FusedWasmUDFs;
 use arroyo_rpc::grpc::api::{
     Aggregator, JobEdge, JobGraph, JobNode, PipelineProgram, ProgramNode, WasmFunction,
 };
@@ -2048,7 +2048,7 @@ impl From<Operator> for GrpcApi::operator::Operator {
             }),
             Operator::FlattenOperator { name } => GrpcOperator::Flatten(Flatten { name }),
             Operator::FlatMapOperator { name, expression } => {
-                GrpcOperator::FlatMapOperator({ GrpcApi::FlatMapOperator { name, expression } })
+                GrpcOperator::FlatMapOperator(GrpcApi::FlatMapOperator { name, expression })
             }
             Operator::ArrayMapOperator {
                 name,

--- a/arroyo-sql/src/json_schema.rs
+++ b/arroyo-sql/src/json_schema.rs
@@ -129,6 +129,8 @@ pub fn get_defs(source_name: &str, schema: &str) -> Result<String, String> {
             }
         }).collect();
 
+        let serializer_items = StructDef::new(Some(name.to_string()), true, fields.clone(), None)
+            .generate_serializer_items();
         let name = format_ident!("{}", name);
         defs.push(quote!{
             #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq,  PartialOrd, serde::Serialize, serde::Deserialize)]
@@ -136,6 +138,8 @@ pub fn get_defs(source_name: &str, schema: &str) -> Result<String, String> {
                 #(#struct_fields)
                 ,*
             }
+
+            #serializer_items
         }.to_string());
     }
 

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -68,7 +68,7 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for Projection {
                 StructField::new(col.name.clone(), col.relation.clone(), field_type)
             })
             .collect();
-        StructDef::new(None, fields, self.format.clone())
+        StructDef::new(None, true, fields, self.format.clone())
     }
 }
 
@@ -154,7 +154,7 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for UnnestProjecti
             self.unnest_outer.expression_type(input_context),
         ));
 
-        StructDef::new(None, fields, self.format.clone())
+        StructDef::new(None, true, fields, self.format.clone())
     }
 }
 
@@ -220,7 +220,7 @@ impl CodeGenerator<VecAggregationContext, StructDef, syn::Expr> for AggregatePro
                 .iter()
                 .map(|(struct_field, _expr)| struct_field.clone()),
         );
-        StructDef::new(None, fields, None)
+        StructDef::new(None, true, fields, None)
     }
 }
 

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -357,6 +357,7 @@ impl ConnectorTable {
             id: self.id,
             struct_def: StructDef::new(
                 self.type_name.clone(),
+                self.type_name.is_none(),
                 self.fields
                     .iter()
                     .filter_map(|field| match field {

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -30,6 +30,7 @@ use syn::{parse_quote, parse_str, GenericArgument, Type};
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd)]
 pub struct StructDef {
     pub name: Option<String>,
+    generated: bool,
     pub fields: Vec<StructField>,
     pub format: Option<Format>,
 }
@@ -43,6 +44,7 @@ impl StructDef {
     pub fn for_fields(fields: Vec<StructField>) -> Self {
         Self {
             name: None,
+            generated: true,
             fields,
             format: None,
         }
@@ -50,6 +52,7 @@ impl StructDef {
 
     pub fn for_name(name: Option<String>, fields: Vec<StructField>) -> Self {
         Self {
+            generated: name.is_none(),
             name,
             fields,
             format: None,
@@ -59,14 +62,21 @@ impl StructDef {
     pub fn for_format(fields: Vec<StructField>, format: Option<Format>) -> Self {
         Self {
             name: None,
+            generated: true,
             fields,
             format,
         }
     }
 
-    pub fn new(name: Option<String>, fields: Vec<StructField>, format: Option<Format>) -> Self {
+    pub fn new(
+        name: Option<String>,
+        generated: bool,
+        fields: Vec<StructField>,
+        format: Option<Format>,
+    ) -> Self {
         Self {
             name,
+            generated,
             fields,
             format,
         }
@@ -239,7 +249,7 @@ impl StructDef {
             })
             .collect();
 
-        let schema_data_impl = if self.name.is_none() {
+        let schema_data_impl = if self.generated {
             // generate a SchemaData impl but only for generated types
             let name = self.struct_name();
 

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -155,7 +155,7 @@ where
             }
         };
 
-        let mut last_reported_error = Instant::now();
+        let mut last_reported_error: Option<Instant> = None;
         let mut errors = 0;
 
         let (mut tx, mut rx) = ws_stream.split();
@@ -209,11 +209,11 @@ where
 
                                 if let Err(e) = result {
                                     errors += 1;
-                                    if last_reported_error.elapsed() > Duration::from_secs(30) {
+                                    if last_reported_error.map(|i| i.elapsed() > Duration::from_secs(30)).unwrap_or(true) {
                                         ctx.report_error(format!("{} x {}", e.name, errors),
                                             e.details).await;
                                         errors = 0;
-                                        last_reported_error = Instant::now();
+                                        last_reported_error = Some(Instant::now());
                                     }
                                 };
                             }


### PR DESCRIPTION
#339 introduced a trait bound on SchemaData for source types in order to implement framing. Previously we only had that bound on sink types.

However, json-schema generated structs were not implementing that trait, which meant that they were not able to be used in sources (already they would not have worked in sinks).

This PR fixes that by reusing the serialization-generation code from StructDef.

In the future we should seek to unify the struct generation logic between json schema and struct def to avoid these issues.