### PR TITLE
Support multiple projections from a single unnest

### DIFF
--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -448,3 +448,10 @@ full_pipeline_codegen! {"unnest",
 select cast(unnest(extract_json('{\"a\": [1, 2, 3]}', '$.a[*]')) as int) + 5, bid.auction
 from nexmark;
 "}
+
+full_pipeline_codegen! {"unnest_multiple_projections",
+"
+select extract_json_string(unnested, '$.a'), extract_json_string(unnested, '$.b') FROM (
+  select unnest(extract_json(bid.url, '$.a[*]')) as unnested
+  from nexmark);
+"}

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -256,7 +256,7 @@ impl CodeGenerator<ValuePointerContext, TypeDef, syn::Expr> for Expression {
                     panic!("unnest appeared in a non-projection context");
                 } else {
                     let ident = input_context.variable_ident();
-                    parse_quote!(#ident)
+                    parse_quote!(#ident.clone())
                 }
             }
         }

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -73,11 +73,15 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for Projection {
 }
 
 #[derive(Debug, Clone)]
+pub enum UnnestFieldType {
+    Default,
+    UnnestOuter,
+}
+
+#[derive(Debug, Clone)]
 pub struct UnnestProjection {
-    pub fields: Vec<(Column, Expression)>,
-    pub unnest_col: Column,
+    pub fields: Vec<(Column, Expression, UnnestFieldType)>,
     pub unnest_inner: Expression,
-    pub unnest_outer: Expression,
     pub format: Option<Format>,
 }
 
@@ -101,37 +105,34 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for UnnestProjecti
             quote!()
         };
 
+        let unnest_context = ValuePointerContext::with_arg("___unnest");
+
         let assignments: Vec<_> = self
             .fields
             .iter()
-            .map(|(col, expr)| {
+            .map(|(col, expr, typ)| {
                 let name = &col.name;
                 let alias = &col.relation;
-                let data_type = expr.expression_type(input_context);
+                let ctx = match typ {
+                    UnnestFieldType::Default => input_context,
+                    UnnestFieldType::UnnestOuter => &unnest_context,
+                };
+
+                let data_type = expr.expression_type(ctx);
+
                 let field_ident =
                     StructField::new(name.clone(), alias.clone(), data_type).field_ident();
-                let expr = expr.generate(input_context);
+                let expr = expr.generate(ctx);
                 quote!(#field_ident : #expr)
             })
             .collect();
         let output_type = self.expression_type(input_context).get_type();
-
-        let unnest_ctx = ValuePointerContext::with_arg("___unnest");
-        let unnest_expr = self.unnest_outer.generate(&unnest_ctx);
-
-        let unnest_ident = StructField::new(
-            self.unnest_col.name.clone(),
-            self.unnest_col.relation.clone(),
-            self.unnest_outer.expression_type(&unnest_ctx),
-        )
-        .field_ident();
 
         parse_quote!(
             #array_creating_expr.into_iter()
                 #handle_optional
                 .map(|___unnest| {
                     #output_type {
-                        #unnest_ident: #unnest_expr,
                         #(#assignments),*
                     }
                 })
@@ -139,20 +140,14 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for UnnestProjecti
     }
 
     fn expression_type(&self, input_context: &ValuePointerContext) -> StructDef {
-        let mut fields: Vec<_> = self
+        let fields: Vec<_> = self
             .fields
             .iter()
-            .map(|(col, computation)| {
+            .map(|(col, computation, _)| {
                 let field_type = computation.expression_type(&input_context);
                 StructField::new(col.name.clone(), col.relation.clone(), field_type)
             })
             .collect();
-
-        fields.push(StructField::new(
-            self.unnest_col.name.clone(),
-            self.unnest_col.relation.clone(),
-            self.unnest_outer.expression_type(input_context),
-        ));
 
         StructDef::new(None, true, fields, self.format.clone())
     }

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -19,7 +19,7 @@ use quote::quote;
 use crate::code_gen::{CodeGenerator, ValuePointerContext, VecAggregationContext};
 use crate::expressions::{AggregateComputation, AggregateResultExtraction, ExpressionContext};
 use crate::external::{ProcessingMode, SqlSink, SqlSource};
-use crate::operators::UnnestProjection;
+use crate::operators::{UnnestFieldType, UnnestProjection};
 use crate::schemas::window_type_def;
 use crate::tables::{Insert, Table};
 use crate::{
@@ -553,32 +553,38 @@ impl<'a> SqlPipelineBuilder<'a> {
             .iter()
             .map(|field| Column::convert(&field.qualified_column()));
 
-        let mut fields: Vec<_> = names.zip(functions).collect();
+        let fields: Vec<_> = names.zip(functions).collect();
 
         let mut unnest = None;
-        for (i, (_, expr)) in fields.iter_mut().enumerate() {
-            if let Some(e) = Self::split_unnest(expr)? {
-                if unnest.replace((i, e)).is_some() {
-                    bail!("multiple columns containing unnest functions, which is not currently supported");
-                }
-            }
-        }
+        let fields = fields
+            .into_iter()
+            .map(|(col, mut expr)| {
+                let typ = if let Some(e) = Self::split_unnest(&mut expr)? {
+                    if let Some(prev) = unnest.replace(e) {
+                        if &prev != unnest.as_ref().unwrap() {
+                            bail!("multiple unnested values, which is not currently supported");
+                        }
+                    }
+                    UnnestFieldType::UnnestOuter
+                } else {
+                    UnnestFieldType::Default
+                };
 
-        if let Some((i, unnest_inner)) = unnest {
-            let (unnest_col, unnest_outer) = fields.remove(i);
+                Ok((col, expr, typ))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
+        if let Some(unnest_inner) = unnest {
             Ok(SqlOperator::RecordTransform(
                 Box::new(input),
                 RecordTransform::UnnestProjection(UnnestProjection {
                     fields,
-                    unnest_col,
                     unnest_inner,
-                    unnest_outer,
                     format: None,
                 }),
             ))
         } else {
-            let projection = Projection::new(fields);
+            let projection = Projection::new(fields.into_iter().map(|(a, b, _)| (a, b)).collect());
 
             Ok(SqlOperator::RecordTransform(
                 Box::new(input),


### PR DESCRIPTION
This PR relaxes a restriction in the initial unnest implementation (#354) to allow multiple projection columns to reference the same unnested value.

This query is now allowed:

```sql
create table events AS (
    select 
        extract_json_string(event, '$.id') as id,
        extract_json_string(event, '$.type') as type, 
        extract_json_string(event, '$.actor.login') as "user",
        extract_json_string(event, '$.repo.name') as repo 
    FROM
        (select unnest(extract_json(value, '$[*]')) as event from raw_events));


select distinct(id), type, "user", repo
from events;
```