### PR TITLE
Don't convert select distinct into an update

### DIFF
--- a/arroyo-sql-testing/src/full_query_tests.rs
+++ b/arroyo-sql-testing/src/full_query_tests.rs
@@ -455,3 +455,19 @@ select extract_json_string(unnested, '$.a'), extract_json_string(unnested, '$.b'
   select unnest(extract_json(bid.url, '$.a[*]')) as unnested
   from nexmark);
 "}
+
+full_pipeline_codegen! {"non_updating_select_distinct",
+"CREATE TABLE non_updating_sink (
+   url TEXT
+) WITH (
+  connector = 'kafka',
+  bootstrap_servers = 'localhost:9092',
+  type = 'sink',
+  topic = 'outputs',
+  format = 'json'
+);
+
+INSERT INTO non_updating_sink
+select distinct(bid.url)
+from nexmark;
+"}

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -337,7 +337,10 @@ impl SqlOperator {
             SqlOperator::Source(source) => source.source.processing_mode == ProcessingMode::Update,
             SqlOperator::Aggregator(input, aggregate_operator) => {
                 input.is_updating()
-                    || (!input.has_window() && aggregate_operator.window == WindowType::Instant)
+                    || (!input.has_window() && aggregate_operator.window == WindowType::Instant
+                        // non-windowed aggregates without aggregate functions are not updating, as
+                        // they cannot have retractions
+                        && !aggregate_operator.aggregating.aggregates.is_empty())
             }
             SqlOperator::JoinOperator(left, right, join_operator) => {
                 // the join will be updating if one of the sides is updating or if a non-window side is nullable.

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -384,14 +384,14 @@ impl ConnectorTable {
     pub fn as_sql_sink(&self, mut input: SqlOperator) -> Result<SqlOperator> {
         match self.connection_type {
             ConnectionType::Source => {
-                bail!("Inserting into a source is not allowed")
+                bail!("inserting into a source is not allowed")
             }
             ConnectionType::Sink => {}
         }
 
         if self.has_virtual_fields() {
             // TODO: I think it would be reasonable and possibly useful to support this
-            bail!("Virtual fields are not currently supported in sinks");
+            bail!("virtual fields are not currently supported in sinks");
         }
 
         let updating_type = if self.is_update() {
@@ -401,7 +401,7 @@ impl ConnectorTable {
         };
 
         if updating_type == SinkUpdateType::Disallow && input.is_updating() {
-            bail!("Sink does not support update messages, cannot be used with an updating query");
+            bail!("sink does not support update messages, cannot be used with an updating query");
         }
 
         if let Some(format) = &self.format {

--- a/arroyo-state/src/tables/mod.rs
+++ b/arroyo-state/src/tables/mod.rs
@@ -135,7 +135,6 @@ impl Compactor {
 mod test {
     use crate::tables::{BlindDataTuple, Compactor};
     use crate::{DataOperation, DeleteTimeKeyOperation, DeleteTimeRangeOperation};
-    use arroyo_types::to_micros;
     use std::time::{Duration, SystemTime};
 
     #[tokio::test]

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -319,6 +319,18 @@ pub enum UpdatingData<T: Data> {
     Append(T),
 }
 
+impl<T: Data> UpdatingData<T> {
+    pub fn lower(&self) -> T {
+        match self {
+            UpdatingData::Retract(_) => {
+                panic!("cannot lower retractions")
+            }
+            UpdatingData::Update { new, .. } => new.clone(),
+            UpdatingData::Append(t) => t.clone(),
+        }
+    }
+}
+
 #[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(try_from = "DebeziumShadow<T>")]
 pub struct Debezium<T: Data> {


### PR DESCRIPTION
Currently all non-windowed aggregates are planned as updating queries, which means that they can only be inserted into updating sinks (generally requiring that the output format be debezium). This is mostly a neccessary restriction, as updating queries produce retractions that must be handled.

However, queries like this are also planned as updates:

```sql
select distinct(bid.url)
from nexmark;
```

despite the fact that there is no way to end up with a retraction for that query (we can only add new distinct urls, not remove them).

This is a pretty big limitation in practice, as there are many cases where a select distinct is useful.

This PR relaxes that restriction for select distinct queries, by "lowering" out of an updating context for non-windowed aggregations that have no aggregate expressions.