### PR TITLE
Add regex dependency to UDF crate

### DIFF
--- a/arroyo-controller/src/compiler.rs
+++ b/arroyo-controller/src/compiler.rs
@@ -172,6 +172,7 @@ bincode = "=2.0.0-rc.3"
 bincode_derive = "=2.0.0-rc.3"
 serde = "1.0"
 serde_json = "1.0"
+regex = "1"
 arrow = {{ workspace = true }}
 parquet = {{ workspace = true }}
 arrow-array = {{ workspace = true }}

--- a/build_dir/udfs/Cargo.toml
+++ b/build_dir/udfs/Cargo.toml
@@ -12,6 +12,7 @@ chrono = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 arroyo-types = { path = "../../arroyo-types" }
+regex = "1"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/docker/build_base/udfs/Cargo.toml
+++ b/docker/build_base/udfs/Cargo.toml
@@ -12,6 +12,7 @@ chrono = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 arroyo-types = { path = "/opt/arroyo/src/arroyo-types" }
+regex = "1"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
This enables regex usage in UDFs without editing the crate dependencies and building a custom image.