### PR TITLE
Fix regression that hid actual errors in console

### DIFF
--- a/arroyo-console/src/lib/util.ts
+++ b/arroyo-console/src/lib/util.ts
@@ -171,7 +171,7 @@ export function relativeTime(timestamp: number): string {
 }
 
 export const formatError = (error: any) => {
-  if ('error' in Object.keys(error) && typeof error.error === 'string') {
+  if (error.error != undefined && typeof error.error === 'string') {
     return error.error;
   } else {
     return 'Something went wrong.';

--- a/arroyo-sql/src/types.rs
+++ b/arroyo-sql/src/types.rs
@@ -21,7 +21,6 @@ use arroyo_rpc::{
 use datafusion::sql::sqlparser::ast::{DataType as SQLDataType, ExactNumberInfo, TimezoneInfo};
 
 use datafusion_common::ScalarValue;
-use datafusion_expr::type_coercion::other;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use regex::Regex;


### PR DESCRIPTION
This prevented the actual error from the API from being shown in the console, for example when deleting a running pipeline the user would see `Something went wrong` instead of 

```
Pipeline's jobs must be in a terminal state (stopped, finished, or failed) before it can be deleted
```