### PR TITLE
Add headers and multiple subscription messages to Websocket source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,11 @@ dependencies = [
  "arroyo-storage",
  "arroyo-types",
  "axum",
+ "base64 0.13.1",
  "chrono",
  "eventsource-client",
  "futures",
+ "rand",
  "rdkafka",
  "regress",
  "reqwest",
@@ -8170,9 +8172,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
 ]

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -34,3 +34,5 @@ futures = "0.3.28"
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 axum = {version = "0.6.12"}
 reqwest = "0.11.20"
+rand = "0.8.5"
+base64 = "0.13.1"

--- a/connector-schemas/websocket/table.json
+++ b/connector-schemas/websocket/table.json
@@ -11,14 +11,35 @@
             ],
             "format": "uri"
         },
+        "headers": {
+            "title": "Headers",
+            "type": "string",
+            "description": "Comma separated list of headers to send with the request",
+            "pattern": "([a-zA-Z0-9-]+: ?.+,)*([a-zA-Z0-9-]+: ?.+)",
+            "examples": ["Authentication: digest 1234,Content-Type: application/json"]
+        },
         "subscription_message": {
             "title": "Subscription Message",
             "type": "string",
+            "description": "[Deprecated] An optional message to send after the socket is opened.",
             "maxLength": 2048,
-            "description": "An optional message to send after the socket is opened",
             "examples": [
                 "{\"type\":\"subscribe\",\"channels\":[\"updates\"]}"
-            ]
+            ],
+            "deprecated": true
+        },
+        "subscription_messages": {
+            "title": "Subscription Messages",
+            "type": "array",
+            "description": "An optional array of messages to send after the socket is opened. The messages will be sent in order.",
+            "items": {
+                "title": "Subscription Message",
+                "type": "string",
+                "maxLength": 2048,
+                "examples": [
+                    "{\"type\":\"subscribe\",\"channels\":[\"updates\"]}"
+                ]
+            }
         }
     },
     "required": [


### PR DESCRIPTION
Add headers and subscription_messages fields to the Websocket schema and
include them in the request. The console uses a new ArrayWidget
component to render this type of schema.


---

The subscription messages can be set in sql like this:

```
    "subscription_messages.0" = 'first message',
    "subscription_messages.1" = 'second message',
```

Or if there's only 1, the old way:

```
    subscription_message = 'only message',
```

Or through the form like this:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/5711a2ba-293a-4a52-81ca-f3ea46c4c6f9)



