### PR TITLE
sql: Implement Delta Lake Sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#0209c94ea4e3d924936e2127f89a885805aae1b4"
 dependencies = [
  "ahash 0.8.3",
  "arrow-arith",
@@ -233,7 +233,8 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895263144bd4a69751cbe6a34a53f26626e19770b313a9fa792c415cd0e78f11"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -247,7 +248,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#0209c94ea4e3d924936e2127f89a885805aae1b4"
 dependencies = [
  "ahash 0.8.3",
  "arrow-buffer",
@@ -263,7 +264,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#0209c94ea4e3d924936e2127f89a885805aae1b4"
 dependencies = [
  "bytes",
  "half",
@@ -273,7 +274,8 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e8b9990733a9b635f656efda3c9b8308c7a19695c9ec2c7046dd154f9b144b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -290,7 +292,8 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646fbb4e11dd0afb8083e883f53117713b8caadb4413b3c9e63e3f535da3683c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -308,7 +311,8 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da900f31ff01a0a84da0572209be72b2b6f980f3ea58803635de47913191c188"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -319,7 +323,8 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2707a8d7ee2d345d045283ece3ae43416175873483e5d96319c929da542a0b1f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -332,7 +337,8 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1b91a63c356d14eedc778b76d66a88f35ac8498426bb0799a769a49a74a8b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -351,7 +357,8 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584325c91293abbca7aaaabf8da9fe303245d641f5f4a18a6058dc68009c7ebf"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -365,7 +372,8 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e32afc1329f7b372463b21c6ca502b07cf237e1ed420d87706c1770bb0ebd38"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",
@@ -379,7 +387,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#0209c94ea4e3d924936e2127f89a885805aae1b4"
 dependencies = [
  "serde",
 ]
@@ -387,7 +395,8 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b3ca55356d1eae07cf48808d8c462cea674393ae6ad1e0b120f40b422eb2b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -399,7 +408,8 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1433ce02590cae68da0a18ed3a3ed868ffac2c6f24c533ddd2067f7ee04b4a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -815,7 +825,7 @@ dependencies = [
  "bytes",
  "object_store",
  "regex",
- "rusoto_core",
+ "rusoto_core 0.48.0",
  "thiserror",
  "tokio",
  "webpki 0.22.4",
@@ -853,6 +863,7 @@ dependencies = [
  "bincode 2.0.0-rc.3",
  "bytes",
  "chrono",
+ "deltalake",
  "eventsource-client",
  "fluvio",
  "fluvio-future",
@@ -876,7 +887,7 @@ dependencies = [
  "regex",
  "regress",
  "reqwest",
- "rusoto_core",
+ "rusoto_core 0.48.0",
  "rusoto_s3",
  "serde",
  "serde_json",
@@ -2699,6 +2710,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltalake"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f889be5851e2633239a5329f57eac565ef4fc37b5d283d1532ca1aaa8d74c9"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "dynamodb_lock",
+ "errno",
+ "futures",
+ "itertools 0.11.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "num-bigint",
+ "num-traits",
+ "num_cpus",
+ "object_store",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "parquet",
+ "percent-encoding",
+ "rand",
+ "regex",
+ "rusoto_core 0.47.0",
+ "rusoto_credential 0.47.0",
+ "rusoto_dynamodb",
+ "rusoto_sts",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2945,22 @@ name = "dyn-clone"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+
+[[package]]
+name = "dynamodb_lock"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff628406c318f098017c78e203b5b6466e0610fc48be865ebb9ae0eb229b4c8"
+dependencies = [
+ "async-trait",
+ "log",
+ "maplit",
+ "rusoto_core 0.47.0",
+ "rusoto_dynamodb",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "ecdsa"
@@ -4747,6 +4821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "46.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#30a13a193d24c5ea4c954f2092e81ee80a7af134"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=46.0.0/parquet_bytes#0209c94ea4e3d924936e2127f89a885805aae1b4"
 dependencies = [
  "ahash 0.8.3",
  "arrow-array",
@@ -6384,6 +6464,31 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-rustls 0.22.1",
+ "lazy_static",
+ "log",
+ "rusoto_credential 0.47.0",
+ "rusoto_signature 0.47.0",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_core"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
@@ -6398,13 +6503,31 @@ dependencies = [
  "hyper-tls",
  "lazy_static",
  "log",
- "rusoto_credential",
- "rusoto_signature",
+ "rusoto_credential 0.48.0",
+ "rusoto_signature 0.48.0",
  "rustc_version",
  "serde",
  "serde_json",
  "tokio",
  "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -6426,6 +6549,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_dynamodb"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7935e1f9ca57c4ee92a4d823dcd698eb8c992f7e84ca21976ae72cd2b03016e7"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core 0.47.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rusoto_s3"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6434,8 +6571,34 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "rusoto_core",
+ "rusoto_core 0.48.0",
  "xml-rs",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "chrono",
+ "digest 0.9.0",
+ "futures",
+ "hex",
+ "hmac 0.11.0",
+ "http",
+ "hyper",
+ "log",
+ "md-5 0.9.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential 0.47.0",
+ "rustc_version",
+ "serde",
+ "sha2 0.9.9",
+ "tokio",
 ]
 
 [[package]]
@@ -6457,11 +6620,26 @@ dependencies = [
  "md-5 0.9.1",
  "percent-encoding",
  "pin-project-lite",
- "rusoto_credential",
+ "rusoto_credential 0.48.0",
  "rustc_version",
  "serde",
  "sha2 0.9.9",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7edd42473ac006fd54105f619e480b0a94136e7f53cf3fb73541363678fd92"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core 0.47.0",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]

--- a/arroyo-connectors/src/delta.rs
+++ b/arroyo-connectors/src/delta.rs
@@ -1,0 +1,146 @@
+use anyhow::{anyhow, bail, Result};
+use arroyo_storage::BackendConfig;
+use axum::response::sse::Event;
+use std::convert::Infallible;
+
+use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::OperatorConfig;
+
+use crate::filesystem::{
+    file_system_table_from_options, CommitStyle, FileSystemTable, FormatSettings,
+};
+use crate::{Connection, EmptyConfig};
+
+use super::Connector;
+
+const TABLE_SCHEMA: &str = include_str!("../../connector-schemas/filesystem/table.json");
+
+pub struct DeltaLakeConnector {}
+
+impl Connector for DeltaLakeConnector {
+    type ProfileT = EmptyConfig;
+
+    type TableT = FileSystemTable;
+
+    fn name(&self) -> &'static str {
+        "delta"
+    }
+
+    fn metadata(&self) -> arroyo_rpc::api_types::connections::Connector {
+        arroyo_rpc::api_types::connections::Connector {
+            id: "delta".to_string(),
+            name: "Delta Lake".to_string(),
+            icon: "".to_string(),
+            description: "Write to a Delta Lake table".to_string(),
+            enabled: true,
+            source: false,
+            sink: true,
+            testing: false,
+            hidden: true,
+            custom_schemas: true,
+            connection_config: None,
+            table_config: TABLE_SCHEMA.to_owned(),
+        }
+    }
+
+    fn test(
+        &self,
+        _: &str,
+        _: Self::ProfileT,
+        _: Self::TableT,
+        _: Option<&ConnectionSchema>,
+        tx: tokio::sync::mpsc::Sender<Result<Event, Infallible>>,
+    ) {
+        tokio::task::spawn(async move {
+            let message = TestSourceMessage {
+                error: false,
+                done: true,
+                message: "Successfully validated connection".to_string(),
+            };
+            tx.send(Ok(Event::default().json_data(message).unwrap()))
+                .await
+                .unwrap();
+        });
+    }
+
+    fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
+        return ConnectionType::Source;
+    }
+
+    fn from_config(
+        &self,
+        id: Option<i64>,
+        name: &str,
+        config: Self::ProfileT,
+        table: Self::TableT,
+        schema: Option<&ConnectionSchema>,
+    ) -> anyhow::Result<crate::Connection> {
+        // confirm commit style is DeltaLake
+        if let Some(CommitStyle::DeltaLake) = table
+            .file_settings
+            .as_ref()
+            .ok_or_else(|| anyhow!("no file_settings"))?
+            .commit_style
+        {
+            // ok
+        } else {
+            bail!("commit_style must be DeltaLake");
+        }
+
+        let backend_config = BackendConfig::parse_url(&table.write_target.path, true)?;
+        let is_local = match &backend_config {
+            BackendConfig::Local { .. } => true,
+            _ => false,
+        };
+        let (description, operator) = match (&table.format_settings, is_local) {
+            (Some(FormatSettings::Parquet { .. }), true) => (
+                "LocalDeltaLake<Parquet>".to_string(),
+                "connectors::filesystem::LocalParquetFileSystemSink::<#in_k, #in_t, #in_tRecordBatchBuilder>"
+            ),
+            (Some(FormatSettings::Parquet { .. }), false) => (
+                "DeltaLake<Parquet>".to_string(),
+                "connectors::filesystem::ParquetFileSystemSink::<#in_k, #in_t, #in_tRecordBatchBuilder>"
+            ),
+            _ => bail!("Delta Lake sink only supports Parquet format"),
+        };
+
+        let schema = schema
+            .map(|s| s.to_owned())
+            .ok_or_else(|| anyhow!("no schema defined for Delta Lake sink"))?;
+
+        let format = schema
+            .format
+            .as_ref()
+            .map(|t| t.to_owned())
+            .ok_or_else(|| anyhow!("'format' must be set for Delta Lake connection"))?;
+
+        let config = OperatorConfig {
+            connection: serde_json::to_value(config).unwrap(),
+            table: serde_json::to_value(table).unwrap(),
+            rate_limit: None,
+            format: Some(format),
+            framing: schema.framing.clone(),
+        };
+
+        Ok(Connection {
+            id,
+            name: name.to_string(),
+            connection_type: ConnectionType::Sink,
+            schema,
+            operator: operator.to_string(),
+            config: serde_json::to_string(&config).unwrap(),
+            description,
+        })
+    }
+
+    fn from_options(
+        &self,
+        name: &str,
+        opts: &mut std::collections::HashMap<String, String>,
+        schema: Option<&ConnectionSchema>,
+    ) -> anyhow::Result<crate::Connection> {
+        let table = file_system_table_from_options(opts, schema, CommitStyle::DeltaLake)?;
+
+        self.from_config(None, name, EmptyConfig {}, table, schema)
+    }
+}

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -22,6 +22,7 @@ use websocket::WebsocketConnector;
 use self::kafka::KafkaConnector;
 
 pub mod blackhole;
+pub mod delta;
 pub mod filesystem;
 pub mod fluvio;
 pub mod impulse;
@@ -36,6 +37,7 @@ pub mod websocket;
 pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
     let mut m: HashMap<&'static str, Box<dyn ErasedConnector>> = HashMap::new();
     m.insert("blackhole", Box::new(BlackholeConnector {}));
+    m.insert("delta", Box::new(delta::DeltaLakeConnector {}));
     m.insert("filesystem", Box::new(filesystem::FileSystemConnector {}));
     m.insert("fluvio", Box::new(FluvioConnector {}));
     m.insert("impulse", Box::new(ImpulseConnector {}));

--- a/arroyo-macro/src/lib.rs
+++ b/arroyo-macro/src/lib.rs
@@ -529,8 +529,8 @@ fn impl_stream_node_type(
                         match control_message {
                             arroyo_rpc::ControlMessage::Checkpoint(_) => tracing::warn!("shouldn't receive checkpoint"),
                             arroyo_rpc::ControlMessage::Stop { mode: _ } => tracing::warn!("shouldn't receive stop"),
-                            arroyo_rpc::ControlMessage::Commit { epoch } => {
-                                self.handle_commit(epoch, &mut ctx).await;
+                            arroyo_rpc::ControlMessage::Commit { epoch, commit_data } => {
+                                self.handle_commit(epoch, commit_data, &mut ctx).await;
                             },
                             arroyo_rpc::ControlMessage::LoadCompacted { compacted } => {
                                 ctx.load_compacted(compacted).await;
@@ -802,7 +802,7 @@ fn impl_stream_node_type(
 
     if !methods.contains("handle_commit") {
         defs.push(quote! {
-            async fn handle_commit(&mut self, epoch: u32, ctx: &mut Context<#out_k, #out_t>) {
+            async fn handle_commit(&mut self, epoch: u32, commit_data: std::collections::HashMap<char, std::collections::HashMap<u32, Vec<u8>>>, ctx: &mut Context<#out_k, #out_t>) {
                 tracing::warn!("default handling of commit with epoch {:?}", epoch);
             }
         })

--- a/arroyo-rpc/proto/rpc.proto
+++ b/arroyo-rpc/proto/rpc.proto
@@ -224,6 +224,9 @@ message SubtaskCheckpointMetadata {
   uint64 bytes = 7;
 
   repeated BackendData backend_data = 8;
+  // this is data that should be sent along with the commit message
+  // to all subtask. The key is the table name.
+  map<string,bytes> committing_data = 9;
 }
 
 message BackendData {
@@ -246,6 +249,7 @@ message OperatorCheckpointMetadata {
 
   repeated BackendData backend_data = 10;
   uint64 bytes = 11;
+  OperatorCommitData commit_data = 12;
 }
 
 enum TableType {
@@ -315,6 +319,23 @@ message CheckpointReq {
 message CheckpointResp {
 }
 
+message CommitReq {
+  uint32 epoch = 1;
+  map<string, OperatorCommitData> committing_data = 2;
+}
+
+message CommitResp {
+}
+
+message OperatorCommitData {
+  // map from table name to commit data for that table.
+  map<string, TableCommitData> committing_data = 1;
+}
+
+message TableCommitData {
+  map<uint32, bytes> commit_data_by_subtask = 1;  
+}
+
 message LoadCompactedDataReq {
   string operator_id = 1;
   repeated BackendData backend_data_to_drop = 2; // this data got compressed...
@@ -347,6 +368,7 @@ message JobFinishedResp {
 service WorkerGrpc {
   rpc StartExecution(StartExecutionReq) returns (StartExecutionResp);
   rpc Checkpoint(CheckpointReq) returns (CheckpointResp);
+  rpc Commit(CommitReq) returns (CommitResp);
   rpc LoadCompactedData(LoadCompactedDataReq) returns (LoadCompactedDataRes);
   rpc StopExecution(StopExecutionReq) returns (StopExecutionResp);
   rpc JobFinished(JobFinishedReq) returns (JobFinishedResp);

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod formats;
 pub mod public_ids;
 pub mod schema_resolver;
 
+use std::collections::HashMap;
 use std::{fs, time::SystemTime};
 
 use crate::api_types::connections::PrimitiveType;
@@ -33,9 +34,16 @@ pub mod grpc {
 #[derive(Debug)]
 pub enum ControlMessage {
     Checkpoint(CheckpointBarrier),
-    Stop { mode: StopMode },
-    Commit { epoch: u32 },
-    LoadCompacted { compacted: CompactionResult },
+    Stop {
+        mode: StopMode,
+    },
+    Commit {
+        epoch: u32,
+        commit_data: HashMap<char, HashMap<u32, Vec<u8>>>,
+    },
+    LoadCompacted {
+        compacted: CompactionResult,
+    },
     NoOp,
 }
 

--- a/arroyo-sql/src/expressions.rs
+++ b/arroyo-sql/src/expressions.rs
@@ -3616,6 +3616,7 @@ pub struct RustUdafExpression {
     args: Vec<(TypeDef, Expression)>,
     ret_type: TypeDef,
 }
+
 impl RustUdafExpression {
     fn try_from_aggregate_udf(
         ctx: &mut ExpressionContext<'_>,

--- a/arroyo-state/src/committing_state.rs
+++ b/arroyo-state/src/committing_state.rs
@@ -1,15 +1,23 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+use arroyo_rpc::grpc::{OperatorCommitData, TableCommitData};
 
 pub struct CommittingState {
     checkpoint_id: i64,
     subtasks_to_commit: HashSet<(String, u32)>,
+    committing_data: HashMap<String, HashMap<String, HashMap<u32, Vec<u8>>>>,
 }
 
 impl CommittingState {
-    pub fn new(checkpoint_id: i64, subtasks_to_commit: HashSet<(String, u32)>) -> Self {
+    pub fn new(
+        checkpoint_id: i64,
+        subtasks_to_commit: HashSet<(String, u32)>,
+        committing_data: HashMap<String, HashMap<String, HashMap<u32, Vec<u8>>>>,
+    ) -> Self {
         Self {
             checkpoint_id,
             subtasks_to_commit,
+            committing_data,
         }
     }
 
@@ -25,13 +33,35 @@ impl CommittingState {
     pub fn done(&self) -> bool {
         self.subtasks_to_commit.is_empty()
     }
-}
 
-impl From<(i64, HashSet<(String, u32)>)> for CommittingState {
-    fn from((checkpoint_id, subtasks_to_commit): (i64, HashSet<(String, u32)>)) -> Self {
-        Self {
-            checkpoint_id,
-            subtasks_to_commit,
-        }
+    pub fn committing_data(&self) -> HashMap<String, OperatorCommitData> {
+        let operators_to_commit: HashSet<_> = self
+            .subtasks_to_commit
+            .iter()
+            .map(|(operator_id, _subtask_id)| operator_id.clone())
+            .collect();
+        operators_to_commit
+            .into_iter()
+            .map(|operator_id| {
+                let committing_data = self
+                    .committing_data
+                    .get(&operator_id)
+                    .map(|table_map| {
+                        table_map
+                            .iter()
+                            .map(|(table_name, subtask_to_commit_data)| {
+                                (
+                                    table_name.clone(),
+                                    TableCommitData {
+                                        commit_data_by_subtask: subtask_to_commit_data.clone(),
+                                    },
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                (operator_id, OperatorCommitData { committing_data })
+            })
+            .collect()
     }
 }

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -40,6 +40,7 @@ md-5 = "0.10"
 hex = "0.4"
 url = "2.4.0"
 ordered-float = "3"
+deltalake = {version = "0.16.0", features = ["s3", "arrow"] }
 arrow = { workspace = true }
 parquet = { workspace = true, features = ["async"]}
 arrow-array = { workspace = true}

--- a/arroyo-worker/src/connectors/filesystem/delta.rs
+++ b/arroyo-worker/src/connectors/filesystem/delta.rs
@@ -1,0 +1,201 @@
+use super::FinishedFile;
+use anyhow::{Context, Result};
+use arrow::datatypes::Schema;
+use arroyo_storage::{get_current_credentials, StorageProvider};
+use arroyo_types::to_millis;
+use deltalake::{
+    operations::create::CreateBuilder,
+    protocol::{Action, Add, SaveMode},
+    table::{builder::s3_storage_options::AWS_S3_ALLOW_UNSAFE_RENAME, PeekCommit},
+    DeltaTableBuilder,
+};
+use object_store::{aws::AmazonS3ConfigKey, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::SystemTime,
+};
+use tracing::info;
+
+pub(crate) async fn commit_files_to_delta(
+    finished_files: Vec<FinishedFile>,
+    relative_table_path: Path,
+    storage_provider: Arc<StorageProvider>,
+    last_version: i64,
+    schema: Schema,
+) -> Result<Option<i64>> {
+    if finished_files.is_empty() {
+        return Ok(None);
+    }
+
+    let add_actions = create_add_actions(&finished_files, &relative_table_path)?;
+    let table_path = build_table_path(&storage_provider, &relative_table_path);
+    let storage_options = configure_storage_options(&table_path, storage_provider.clone()).await?;
+    let mut table = load_or_create_table(&table_path, storage_options.clone(), &schema).await?;
+
+    if let Some(new_version) = check_existing_files(
+        &mut table,
+        last_version,
+        &finished_files,
+        &relative_table_path,
+    )
+    .await?
+    {
+        return Ok(Some(new_version));
+    }
+
+    let new_version = commit_to_delta(table, add_actions).await?;
+    Ok(Some(new_version))
+}
+
+async fn load_or_create_table(
+    table_path: &str,
+    storage_options: HashMap<String, String>,
+    schema: &Schema,
+) -> Result<deltalake::DeltaTable> {
+    match DeltaTableBuilder::from_uri(table_path)
+        .with_storage_options(storage_options.clone())
+        .load()
+        .await
+    {
+        Ok(table) => Ok(table),
+        Err(deltalake::DeltaTableError::NotATable(_)) => {
+            create_new_table(table_path, storage_options, schema).await
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn create_new_table(
+    table_path: &str,
+    storage_options: HashMap<String, String>,
+    schema: &Schema,
+) -> Result<deltalake::DeltaTable> {
+    let delta_object_store = DeltaTableBuilder::from_uri(table_path)
+        .with_storage_options(storage_options)
+        .build_storage()?;
+    let delta_schema: deltalake::Schema = (schema).try_into()?;
+    CreateBuilder::new()
+        .with_object_store(delta_object_store)
+        .with_columns(delta_schema.get_fields().clone())
+        .await
+        .map_err(Into::into)
+}
+
+async fn configure_storage_options(
+    table_path: &str,
+    storage_provider: Arc<StorageProvider>,
+) -> Result<HashMap<String, String>> {
+    let mut options = storage_provider.storage_options().clone();
+    if table_path.starts_with("s3://") {
+        update_s3_credentials(&mut options).await?;
+    }
+    Ok(options)
+}
+
+async fn update_s3_credentials(options: &mut HashMap<String, String>) -> Result<()> {
+    if !options.contains_key(AmazonS3ConfigKey::SecretAccessKey.as_ref()) {
+        let tmp_credentials = get_current_credentials().await?;
+        options.insert(
+            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
+            tmp_credentials.key_id.clone(),
+        );
+        options.insert(
+            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
+            tmp_credentials.secret_key.clone(),
+        );
+    }
+    options.insert(AWS_S3_ALLOW_UNSAFE_RENAME.to_string(), "true".to_string());
+    Ok(())
+}
+
+fn create_add_actions(
+    finished_files: &[FinishedFile],
+    relative_table_path: &Path,
+) -> Result<Vec<Action>> {
+    finished_files
+        .iter()
+        .map(|file| create_add_action(file, relative_table_path))
+        .collect()
+}
+
+fn create_add_action(file: &FinishedFile, relative_table_path: &Path) -> Result<Action> {
+    info!(
+        "creating add action for file {:?}, relative table path {}",
+        file, relative_table_path
+    );
+    let subpath = file
+        .filename
+        .strip_prefix(&relative_table_path.to_string())
+        .context(format!(
+            "File {} is not in table {}",
+            file.filename,
+            relative_table_path.to_string()
+        ))?;
+    Ok(Action::add(Add {
+        path: subpath.to_string(),
+        size: file.size as i64,
+        partition_values: HashMap::new(),
+        modification_time: to_millis(SystemTime::now()) as i64,
+        data_change: true,
+        ..Default::default()
+    }))
+}
+
+async fn check_existing_files(
+    table: &mut deltalake::DeltaTable,
+    last_version: i64,
+    finished_files: &[FinishedFile],
+    relative_table_path: &Path,
+) -> Result<Option<i64>> {
+    if last_version >= table.version() {
+        return Ok(None);
+    }
+
+    let files: HashSet<_> = finished_files
+        .iter()
+        .map(|file| {
+            file.filename
+                .strip_prefix(&relative_table_path.to_string())
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+
+    let mut version_to_check = last_version;
+    while let PeekCommit::New(version, actions) = table.peek_next_commit(version_to_check).await? {
+        for action in actions {
+            if let Action::add(add) = action {
+                if files.contains(&add.path) {
+                    return Ok(Some(version));
+                }
+            }
+        }
+        version_to_check = version;
+    }
+    Ok(None)
+}
+
+async fn commit_to_delta(table: deltalake::DeltaTable, add_actions: Vec<Action>) -> Result<i64> {
+    deltalake::operations::transaction::commit(
+        table.object_store().as_ref(),
+        &add_actions,
+        deltalake::protocol::DeltaOperation::Write {
+            mode: SaveMode::Append,
+            partition_by: None,
+            predicate: None,
+        },
+        table.get_state(),
+        None,
+    )
+    .await
+    .map_err(Into::into)
+}
+
+fn build_table_path(storage_provider: &StorageProvider, relative_table_path: &Path) -> String {
+    format!(
+        "{}/{}",
+        storage_provider.canonical_url(),
+        relative_table_path
+    )
+}

--- a/arroyo-worker/src/connectors/impulse.rs
+++ b/arroyo-worker/src/connectors/impulse.rs
@@ -167,7 +167,7 @@ impl<K: Data, T: Data> ImpulseSourceFunc<K, T> {
                         }
                     }
                 }
-                Ok(ControlMessage::Commit { epoch: _ }) => {
+                Ok(ControlMessage::Commit { .. }) => {
                     unreachable!("sources shouldn't receive commit messages");
                 }
                 Ok(ControlMessage::LoadCompacted { compacted }) => {

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -251,7 +251,12 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
         }
     }
 
-    async fn handle_commit(&mut self, epoch: u32, ctx: &mut crate::engine::Context<(), ()>) {
+    async fn handle_commit(
+        &mut self,
+        epoch: u32,
+        _commit_data: HashMap<char, HashMap<u32, Vec<u8>>>,
+        ctx: &mut crate::engine::Context<(), ()>,
+    ) {
         let ConsistencyMode::ExactlyOnce {
             next_transaction_index: _,
             producer_to_complete,
@@ -295,8 +300,8 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
         if !self.is_committing() {
             return;
         }
-        if let Some(ControlMessage::Commit { epoch }) = ctx.control_rx.recv().await {
-            self.handle_commit(epoch, ctx).await;
+        if let Some(ControlMessage::Commit { epoch, commit_data }) = ctx.control_rx.recv().await {
+            self.handle_commit(epoch, commit_data, ctx).await;
         } else {
             warn!("no commit message received, not committing")
         }

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -316,7 +316,7 @@ where
                                 }
                             }
                         }
-                        Some(ControlMessage::Commit { epoch: _ }) => {
+                        Some(ControlMessage::Commit { .. }) => {
                             unreachable!("sources shouldn't receive commit messages");
                         }
                         Some(ControlMessage::LoadCompacted {compacted}) => {

--- a/arroyo-worker/src/connectors/kafka/source/test.rs
+++ b/arroyo-worker/src/connectors/kafka/source/test.rs
@@ -252,6 +252,7 @@ async fn test_kafka() {
         tables: source::tables(),
         backend_data: checkpoint_completed.subtask_metadata.backend_data,
         bytes: checkpoint_completed.subtask_metadata.bytes,
+        commit_data: None,
     })
     .await;
 

--- a/arroyo-worker/src/connectors/kinesis/source/mod.rs
+++ b/arroyo-worker/src/connectors/kinesis/source/mod.rs
@@ -450,7 +450,7 @@ impl<K: Data, T: SchemaData> KinesisSourceFunc<K, T> {
                                 }
                             }
                         }
-                        Some(ControlMessage::Commit { epoch: _ }) => {
+                        Some(ControlMessage::Commit { .. }) => {
                             unreachable!("sources shouldn't receive commit messages");
                         }
                         Some(ControlMessage::LoadCompacted { compacted }) => {
@@ -458,7 +458,6 @@ impl<K: Data, T: SchemaData> KinesisSourceFunc<K, T> {
                         },
                         Some(ControlMessage::NoOp ) => {}
                         None => {
-
                         }
                     }
                 }

--- a/arroyo-worker/src/connectors/polling_http.rs
+++ b/arroyo-worker/src/connectors/polling_http.rs
@@ -157,7 +157,7 @@ where
                     }
                 }
             }
-            ControlMessage::Commit { epoch: _ } => {
+            ControlMessage::Commit { .. } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
             ControlMessage::LoadCompacted { compacted } => {

--- a/arroyo-worker/src/connectors/sse.rs
+++ b/arroyo-worker/src/connectors/sse.rs
@@ -136,7 +136,7 @@ where
                     }
                 }
             }
-            ControlMessage::Commit { epoch: _ } => {
+            ControlMessage::Commit { .. } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
             ControlMessage::LoadCompacted { compacted } => {

--- a/arroyo-worker/src/connectors/websocket.rs
+++ b/arroyo-worker/src/connectors/websocket.rs
@@ -133,7 +133,7 @@ where
                     }
                 }
             }
-            ControlMessage::Commit { epoch: _ } => {
+            ControlMessage::Commit { .. } => {
                 unreachable!("sources shouldn't receive commit messages");
             }
             ControlMessage::LoadCompacted { compacted } => {

--- a/connector-schemas/filesystem/table.json
+++ b/connector-schemas/filesystem/table.json
@@ -109,6 +109,14 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "commit_style": {
+                    "title": "Commit Style",
+                    "type": "string",
+                    "enum": [
+                        "direct",
+                        "delta_lake"
+                    ]
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
This integrates with Delta Lake, using the deltalake crate to add parquet files to the commit log. This is done by subtask 0 and required additional message passing between subtasks. This message passing is implemented via the introduction of OperatorCommitData, which committing operators can send back to the controller. This will be written into the checkpoint metadata and broadcast to workers as part of the commit message. Obviously this should be small, not including data. For our purposes, this will be multipart files that are ready to be committed.