### PR TITLE
poc for code gen in connectors.

### DIFF
--- a/arroyo-connectors/src/blackhole.rs
+++ b/arroyo-connectors/src/blackhole.rs
@@ -97,6 +97,7 @@ impl Connector for BlackholeConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Sink,
             schema: s.cloned().unwrap_or_else(|| ConnectionSchema {
                 format: None,

--- a/arroyo-connectors/src/delta.rs
+++ b/arroyo-connectors/src/delta.rs
@@ -125,6 +125,7 @@ impl Connector for DeltaLakeConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Sink,
             schema,
             operator: operator.to_string(),

--- a/arroyo-connectors/src/fluvio.rs
+++ b/arroyo-connectors/src/fluvio.rs
@@ -154,6 +154,7 @@ impl Connector for FluvioConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: typ,
             schema,
             operator: operator.to_string(),

--- a/arroyo-connectors/src/impulse.rs
+++ b/arroyo-connectors/src/impulse.rs
@@ -164,6 +164,7 @@ impl Connector for ImpulseConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Source,
             schema: impulse_schema(),
             operator: "connectors::impulse::ImpulseSourceFunc".to_string(),

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -101,6 +101,7 @@ impl Connector for KafkaConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: typ,
             schema,
             operator: operator.to_string(),

--- a/arroyo-connectors/src/kinesis.rs
+++ b/arroyo-connectors/src/kinesis.rs
@@ -114,6 +114,7 @@ impl Connector for KinesisConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type,
             schema: schema,
             operator: operator.to_string(),

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -66,6 +66,7 @@ pub struct EmptyConfig {}
 pub struct Connection {
     pub id: Option<i64>,
     pub name: String,
+    pub connector_name: String,
     pub connection_type: ConnectionType,
     pub schema: ConnectionSchema,
     pub operator: String,

--- a/arroyo-connectors/src/nexmark.rs
+++ b/arroyo-connectors/src/nexmark.rs
@@ -197,6 +197,7 @@ impl Connector for NexmarkConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Source,
             schema: nexmark_schema(),
             operator: "connectors::nexmark::NexmarkSourceFunc".to_string(),

--- a/arroyo-connectors/src/polling_http.rs
+++ b/arroyo-connectors/src/polling_http.rs
@@ -212,6 +212,7 @@ impl Connector for PollingHTTPConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Source,
             schema,
             operator: "connectors::polling_http::PollingHttpSourceFunc".to_string(),

--- a/arroyo-connectors/src/redis.rs
+++ b/arroyo-connectors/src/redis.rs
@@ -362,6 +362,7 @@ impl Connector for RedisConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Sink,
             schema,
             operator: "connectors::redis::sink::RedisSinkFunc::<#in_k, #in_t>".to_string(),

--- a/arroyo-connectors/src/single_file.rs
+++ b/arroyo-connectors/src/single_file.rs
@@ -108,6 +108,7 @@ impl Connector for SingleFileConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type,
             schema,
             operator,

--- a/arroyo-connectors/src/sse.rs
+++ b/arroyo-connectors/src/sse.rs
@@ -105,6 +105,7 @@ impl Connector for SSEConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Source,
             schema,
             operator: "connectors::sse::SSESourceFunc".to_string(),

--- a/arroyo-connectors/src/webhook.rs
+++ b/arroyo-connectors/src/webhook.rs
@@ -156,6 +156,7 @@ impl Connector for WebhookConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Sink,
             schema,
             operator: "connectors::webhook::WebhookSinkFunc::<#in_k, #in_t>".to_string(),

--- a/arroyo-connectors/src/websocket.rs
+++ b/arroyo-connectors/src/websocket.rs
@@ -241,6 +241,7 @@ impl Connector for WebsocketConnector {
         Ok(Connection {
             id,
             name: name.to_string(),
+            connector_name: self.name().to_string(),
             connection_type: ConnectionType::Source,
             schema,
             operator: "connectors::websocket::WebsocketSourceFunc".to_string(),

--- a/arroyo-datastream/src/lib.rs
+++ b/arroyo-datastream/src/lib.rs
@@ -280,7 +280,7 @@ pub enum ImpulseSpec {
     EventsPerSecond(f32),
 }
 
-#[derive(Clone, Encode, Decode, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize, PartialEq)]
 pub struct ConnectorOp {
     // path of the operator that this will compile into (like `crate::sources::kafka::KafkaSource`)
     pub operator: String,

--- a/arroyo-sql/src/external.rs
+++ b/arroyo-sql/src/external.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use arroyo_datastream::Operator;
 
@@ -25,6 +25,7 @@ pub struct SqlSink {
     pub struct_def: StructDef,
     pub operator: Operator,
     pub updating_type: SinkUpdateType,
+    pub named_code_blocks: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -467,6 +467,7 @@ pub fn parse_and_get_program_sync(
         let sink = Table::ConnectorTable(ConnectorTable {
             id: None,
             name: "web".to_string(),
+            connector_name: "grpc".to_string(),
             connection_type: ConnectionType::Sink,
             fields: struct_def.fields.into_iter().map(|f| f.into()).collect(),
             type_name: None,

--- a/build_dir/pipeline/Cargo.toml
+++ b/build_dir/pipeline/Cargo.toml
@@ -17,6 +17,7 @@ arrow = { workspace = true}
 arrow-array = { workspace = true}
 arroyo-types = { path = "../../arroyo-types" }
 arroyo-worker = { path = "../../arroyo-worker" }
+dynamodb_lock = "=0.4.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/connector-schemas/filesystem/table.json
+++ b/connector-schemas/filesystem/table.json
@@ -106,6 +106,11 @@
                                 "type": "string"
                             },
                             "description": "fields to partition the data by"
+                        },
+                        "partitioner_name": {
+                            "title": "Partitioner Name",
+                            "type": "string",
+                            "description": "name of the partitioner to use"
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
This is a first pass at implementing code generation that can be used by connectors. There's definitely some hackery here, but the basic concept is that the connection's table.json can have a field plugged in which will be used in the operator field to pass in generics. In order to do this I need to be able to extract the connectors specific table out and modify it. I did my best to avoid having arroyo-sql stuff pollute the connectors, but it still is kinda awkward. Open to other ways to structure this.