### PR TITLE
arroyo-storage: make the StorageProvider's get() and put() calls relative to the full path.

### DIFF
--- a/arroyo-worker/src/connectors/filesystem/delta.rs
+++ b/arroyo-worker/src/connectors/filesystem/delta.rs
@@ -195,7 +195,7 @@ async fn commit_to_delta(table: deltalake::DeltaTable, add_actions: Vec<Action>)
 fn build_table_path(storage_provider: &StorageProvider, relative_table_path: &Path) -> String {
     format!(
         "{}/{}",
-        storage_provider.canonical_url(),
+        storage_provider.object_store_base_url(),
         relative_table_path
     )
 }


### PR DESCRIPTION
This modifies the behavior of a StorageProvider so that get() and put() will be relative to the path specified in the originating URL. I've confirmed for local and S3 storage providers that this change works across filesystem sinks, the compiler service, and checkpointing.