### PR TITLE
Clean up file system table schema and support maps in UI

### DIFF
--- a/arroyo-connectors/src/delta.rs
+++ b/arroyo-connectors/src/delta.rs
@@ -76,9 +76,10 @@ impl Connector for DeltaLakeConnector {
         schema: Option<&ConnectionSchema>,
     ) -> anyhow::Result<crate::Connection> {
         let TableType::Sink {
+            path,
             file_settings,
             format_settings,
-            write_target,
+            ..
         } = &table.type_
         else {
             bail!("Delta Lake connector only supports sink tables");
@@ -94,7 +95,7 @@ impl Connector for DeltaLakeConnector {
             bail!("commit_style must be DeltaLake");
         }
 
-        let backend_config = BackendConfig::parse_url(&write_target.path, true)?;
+        let backend_config = BackendConfig::parse_url(&path, true)?;
         let is_local = match &backend_config {
             BackendConfig::Local { .. } => true,
             _ => false,

--- a/arroyo-connectors/src/filesystem.rs
+++ b/arroyo-connectors/src/filesystem.rs
@@ -89,8 +89,8 @@ impl Connector for FileSystemConnector {
                 ConnectionType::Source,
             ),
             TableType::Sink {
+                ref path,
                 ref format_settings,
-                ref write_target,
                 ref file_settings,
                 ..
             } => {
@@ -103,7 +103,7 @@ impl Connector for FileSystemConnector {
                     bail!("commit_style must be Direct");
                 };
 
-                let backend_config = BackendConfig::parse_url(&write_target.path, true)?;
+                let backend_config = BackendConfig::parse_url(&path, true)?;
                 let is_local = match &backend_config {
                     BackendConfig::Local { .. } => true,
                     _ => false,
@@ -181,10 +181,8 @@ impl Connector for FileSystemConnector {
                     EmptyConfig {},
                     FileSystemTable {
                         type_: TableType::Source {
-                            read_source: Source {
-                                path: storage_url,
-                                storage_options,
-                            },
+                            path: storage_url,
+                            storage_options,
                             compression_format: Some(compression_format),
                             regex_pattern: matching_pattern,
                         },
@@ -255,8 +253,8 @@ pub fn file_system_sink_from_options(
         None
     };
 
-    let filenaming = if prefix.is_some() || suffix.is_some() || strategy.is_some() {
-        Some(Filenaming {
+    let file_naming = if prefix.is_some() || suffix.is_some() || strategy.is_some() {
+        Some(FileNaming {
             prefix,
             suffix,
             strategy,
@@ -273,7 +271,7 @@ pub fn file_system_sink_from_options(
         target_part_size,
         partitioning,
         commit_style: Some(commit_style),
-        filenaming,
+        file_naming,
     });
 
     let format_settings = match schema
@@ -307,10 +305,8 @@ pub fn file_system_sink_from_options(
         type_: TableType::Sink {
             file_settings,
             format_settings,
-            write_target: FolderUrl {
-                path: storage_url,
-                storage_options,
-            },
+            path: storage_url,
+            storage_options,
         },
     })
 }

--- a/arroyo-console/package.json
+++ b/arroyo-console/package.json
@@ -48,6 +48,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
+    "react-markdown": "^9.0.1",
     "react-resizable-panels": "^0.0.55",
     "react-router-dom": "^6.13.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/arroyo-console/pnpm-lock.yaml
+++ b/arroyo-console/pnpm-lock.yaml
@@ -109,6 +109,9 @@ dependencies:
   react-icons:
     specifier: ^4.11.0
     version: 4.11.0(react@18.2.0)
+  react-markdown:
+    specifier: ^9.0.1
+    version: 9.0.1(@types/react@18.2.12)(react@18.2.0)
   react-resizable-panels:
     specifier: ^0.0.55
     version: 0.0.55(react-dom@18.2.0)(react@18.2.0)
@@ -2690,12 +2693,24 @@ packages:
     resolution: {integrity: sha512-rF3yXSwHIrDxEkN6edCE4TXknb5YSEpiXfLaspw1I08grC49ZFuAVGOQCmZGIuLUGoFgcqGlUFBL/XrpgYpQgw==}
     dev: false
 
+  /@types/debug@4.1.12:
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+    dependencies:
+      '@types/ms': 0.7.34
+    dev: false
+
   /@types/geojson@7946.0.10:
     resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==}
     dev: false
 
   /@types/hast@2.3.6:
     resolution: {integrity: sha512-47rJE80oqPmFdVDCD7IheXBrVdwuBgsYwoczFvKmwfo2Mzsnt+V9OONsYauFmICb6lQPpCuXYJWejBNs4pDJRg==}
+    dependencies:
+      '@types/unist': 2.0.8
+    dev: false
+
+  /@types/hast@3.0.3:
+    resolution: {integrity: sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==}
     dependencies:
       '@types/unist': 2.0.8
     dev: false
@@ -2715,6 +2730,16 @@ packages:
 
   /@types/lodash@4.14.200:
     resolution: {integrity: sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==}
+    dev: false
+
+  /@types/mdast@4.0.3:
+    resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: false
+
+  /@types/ms@0.7.34:
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: false
 
   /@types/node@18.16.18:
@@ -2768,6 +2793,10 @@ packages:
 
   /@types/unist@2.0.8:
     resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
+    dev: false
+
+  /@types/unist@3.0.2:
+    resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: false
 
   /@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.42.0)(typescript@4.9.5):
@@ -2899,6 +2928,10 @@ packages:
       '@typescript-eslint/types': 5.59.11
       eslint-visitor-keys: 3.4.1
     dev: true
+
+  /@ungap/structured-clone@1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    dev: false
 
   /@vitejs/plugin-react@3.1.0(vite@4.3.9):
     resolution: {integrity: sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==}
@@ -3091,6 +3124,10 @@ packages:
       resolve: 1.22.2
     dev: false
 
+  /bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+    dev: false
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -3205,6 +3242,10 @@ packages:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
     dev: false
 
+  /character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: false
+
   /character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: false
@@ -3289,6 +3330,10 @@ packages:
 
   /comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+    dev: false
+
+  /comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: false
 
   /commander@7.2.0:
@@ -3641,6 +3686,12 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /decode-named-character-reference@1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: false
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -3664,8 +3715,19 @@ packages:
       robust-predicates: 3.0.2
     dev: false
 
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+    dev: false
+
+  /devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+    dependencies:
+      dequal: 2.0.3
     dev: false
 
   /dir-glob@3.0.1:
@@ -4041,6 +4103,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4348,6 +4414,26 @@ packages:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
     dev: false
 
+  /hast-util-to-jsx-runtime@2.2.0:
+    resolution: {integrity: sha512-wSlp23N45CMjDg/BPW8zvhEi3R+8eRE1qFbjEyAUzMCzu2l1Wzwakq+Tlia9nkCtEl5mDxa7nKHsvYJ6Gfn21A==}
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/unist': 3.0.2
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      style-to-object: 0.4.4
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.2
+    dev: false
+
+  /hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+    dependencies:
+      '@types/hast': 3.0.3
+    dev: false
+
   /hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
     dependencies:
@@ -4370,6 +4456,10 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
+    dev: false
+
+  /html-url-attributes@3.0.0:
+    resolution: {integrity: sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==}
     dev: false
 
   /iconv-lite@0.6.3:
@@ -4406,6 +4496,10 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
+
+  /inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+    dev: false
 
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -4526,6 +4620,11 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -4729,6 +4828,44 @@ packages:
       react: 18.2.0
     dev: false
 
+  /mdast-util-from-markdown@2.0.0:
+    resolution: {integrity: sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==}
+    dependencies:
+      '@types/mdast': 4.0.3
+      '@types/unist': 3.0.2
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-decode-string: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-to-hast@13.0.2:
+    resolution: {integrity: sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==}
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/mdast': 4.0.3
+      '@ungap/structured-clone': 1.2.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.0
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+    dev: false
+
+  /mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+    dependencies:
+      '@types/mdast': 4.0.3
+    dev: false
+
   /memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
     dev: false
@@ -4742,6 +4879,181 @@ packages:
     engines: {node: '>=0.8.0'}
     dependencies:
       d3: 7.8.5
+    dev: false
+
+  /micromark-core-commonmark@2.0.0:
+    resolution: {integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.0
+      micromark-factory-label: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-factory-title: 2.0.0
+      micromark-factory-whitespace: 2.0.0
+      micromark-util-character: 2.0.1
+      micromark-util-chunked: 2.0.0
+      micromark-util-classify-character: 2.0.0
+      micromark-util-html-tag-name: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-factory-destination@2.0.0:
+    resolution: {integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==}
+    dependencies:
+      micromark-util-character: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-factory-label@2.0.0:
+    resolution: {integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-factory-space@2.0.0:
+    resolution: {integrity: sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==}
+    dependencies:
+      micromark-util-character: 2.0.1
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-factory-title@2.0.0:
+    resolution: {integrity: sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==}
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-factory-whitespace@2.0.0:
+    resolution: {integrity: sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==}
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-character@2.0.1:
+    resolution: {integrity: sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-chunked@2.0.0:
+    resolution: {integrity: sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: false
+
+  /micromark-util-classify-character@2.0.0:
+    resolution: {integrity: sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==}
+    dependencies:
+      micromark-util-character: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-combine-extensions@2.0.0:
+    resolution: {integrity: sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==}
+    dependencies:
+      micromark-util-chunked: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-decode-numeric-character-reference@2.0.1:
+    resolution: {integrity: sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: false
+
+  /micromark-util-decode-string@2.0.0:
+    resolution: {integrity: sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-symbol: 2.0.0
+    dev: false
+
+  /micromark-util-encode@2.0.0:
+    resolution: {integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==}
+    dev: false
+
+  /micromark-util-html-tag-name@2.0.0:
+    resolution: {integrity: sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==}
+    dev: false
+
+  /micromark-util-normalize-identifier@2.0.0:
+    resolution: {integrity: sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: false
+
+  /micromark-util-resolve-all@2.0.0:
+    resolution: {integrity: sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==}
+    dependencies:
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-sanitize-uri@2.0.0:
+    resolution: {integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==}
+    dependencies:
+      micromark-util-character: 2.0.1
+      micromark-util-encode: 2.0.0
+      micromark-util-symbol: 2.0.0
+    dev: false
+
+  /micromark-util-subtokenize@2.0.0:
+    resolution: {integrity: sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: false
+
+  /micromark-util-symbol@2.0.0:
+    resolution: {integrity: sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==}
+    dev: false
+
+  /micromark-util-types@2.0.0:
+    resolution: {integrity: sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==}
+    dev: false
+
+  /micromark@4.0.0:
+    resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.3.4
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.1
+      micromark-util-chunked: 2.0.0
+      micromark-util-combine-extensions: 2.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-encode: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /micromatch@4.0.5:
@@ -5012,6 +5324,10 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /property-information@6.4.0:
+    resolution: {integrity: sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==}
+    dev: false
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -5082,6 +5398,28 @@ packages:
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: false
+
+  /react-markdown@9.0.1(@types/react@18.2.12)(react@18.2.0):
+    resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/react': 18.2.12
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.2.0
+      html-url-attributes: 3.0.0
+      mdast-util-to-hast: 13.0.2
+      react: 18.2.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.0.0
+      unified: 11.0.4
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /react-refresh@0.14.0:
@@ -5321,6 +5659,27 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
+  /remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+    dependencies:
+      '@types/mdast': 4.0.3
+      mdast-util-from-markdown: 2.0.0
+      micromark-util-types: 2.0.0
+      unified: 11.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-rehype@11.0.0:
+    resolution: {integrity: sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==}
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/mdast': 4.0.3
+      mdast-util-to-hast: 13.0.2
+      unified: 11.0.4
+      vfile: 6.0.1
+    dev: false
+
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -5448,6 +5807,10 @@ packages:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
     dev: false
 
+  /space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+    dev: false
+
   /state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
     dev: false
@@ -5511,6 +5874,12 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
+
+  /style-to-object@0.4.4:
+    resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
+    dependencies:
+      inline-style-parser: 0.1.1
+    dev: false
 
   /style-value-types@5.0.0:
     resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
@@ -5579,6 +5948,14 @@ packages:
 
   /toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+    dev: false
+
+  /trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    dev: false
+
+  /trough@2.1.0:
+    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
   /tsconfig-paths@3.14.2:
@@ -5652,6 +6029,51 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+    dev: false
+
+  /unified@11.0.4:
+    resolution: {integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==}
+    dependencies:
+      '@types/unist': 3.0.2
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 6.0.1
+    dev: false
+
+  /unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: false
+
+  /unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: false
+
+  /unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: false
+
+  /unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-is: 6.0.0
+    dev: false
+
+  /unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
     dev: false
 
   /update-browserslist-db@1.0.11(browserslist@4.21.8):
@@ -5752,6 +6174,21 @@ packages:
 
   /validate.io-number@1.0.3:
     resolution: {integrity: sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==}
+    dev: false
+
+  /vfile-message@4.0.2:
+    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-stringify-position: 4.0.0
+    dev: false
+
+  /vfile@6.0.1:
+    resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
     dev: false
 
   /vite@4.3.9(@types/node@18.16.18):

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Select,
   Stack,
+  Text,
   Textarea,
 } from '@chakra-ui/react';
 import { JSONSchema7 } from 'json-schema';
@@ -21,6 +22,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import React, { useEffect, useMemo } from 'react';
 import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import Markdown from 'react-markdown';
 
 function StringWidget({
   path,
@@ -67,7 +69,11 @@ function StringWidget({
       {errors[path] ? (
         <FormErrorMessage>{errors[path]}</FormErrorMessage>
       ) : (
-        description && <FormHelperText>{description}</FormHelperText>
+        description && (
+          <FormHelperText>
+            <Markdown>{description}</Markdown>
+          </FormHelperText>
+        )
       )}
     </FormControl>
   );
@@ -114,7 +120,11 @@ function NumberWidget({
       {errors[path] ? (
         <FormErrorMessage>{errors[path]}</FormErrorMessage>
       ) : (
-        description && <FormHelperText>{description}</FormHelperText>
+        description && (
+          <FormHelperText>
+            <Markdown>{description}</Markdown>
+          </FormHelperText>
+        )
       )}
     </FormControl>
   );
@@ -156,7 +166,11 @@ function SelectWidget({
           </option>
         ))}
       </Select>
-      {description && <FormHelperText>{description}</FormHelperText>}
+      {description && (
+        <FormHelperText>
+          <Markdown>{description}</Markdown>
+        </FormHelperText>
+      )}
     </FormControl>
   );
 }
@@ -249,6 +263,134 @@ export function ArrayWidget({
                 />
               </Flex>
             ))}
+            <IconButton mt={1} height={8} aria-label="Add item" onClick={add} icon={<AddIcon />} />
+          </Stack>
+        </FormControl>
+      </fieldset>
+    </Box>
+  );
+}
+
+export function MapWidget({
+  schema,
+  onChange,
+  path,
+  values,
+  errors,
+}: {
+  schema: JSONSchema7;
+  onChange: (e: React.ChangeEvent<any>) => void;
+  path: string;
+  values: any;
+  errors: any;
+}) {
+  interface KeyValuePair {
+    key: string;
+    value: any;
+    error: string | undefined;
+  }
+
+  const initial = values ? Object.entries(values).map(([key, value]) => ({ key, value })) : [];
+  // @ts-ignore
+  const [keyValues, setKeyValues] = React.useState<KeyValuePair[]>(initial);
+
+  const itemsSchema = schema.additionalProperties as JSONSchema7;
+
+  if (itemsSchema.type != 'string') {
+    console.warn('Unsupported map item type', itemsSchema.type);
+    return <></>;
+  }
+
+  const saveKeyValues = (keyValuePairs: KeyValuePair[]) => {
+    let newValues = {};
+    keyValuePairs.forEach(pair => {
+      if (pair.key) {
+        pair.error = undefined;
+        if (pair.key in newValues) {
+          pair.error = 'Must have unique key';
+          setKeyValues(keyValuePairs);
+        } else {
+          // @ts-ignore
+          newValues[pair.key] = pair.value;
+        }
+      }
+    });
+    // @ts-ignore
+    onChange({ target: { name: path, value: newValues } });
+  };
+
+  const deleteItem = (index: number) => {
+    const newKeyValues = keyValues.filter((pair, i) => i != index);
+    setKeyValues(newKeyValues);
+    saveKeyValues(newKeyValues);
+  };
+
+  const add = () => {
+    const newPair: KeyValuePair = { key: '', value: '', error: undefined };
+    const newKeyValues = [...keyValues, newPair];
+    setKeyValues(newKeyValues);
+    saveKeyValues(newKeyValues);
+  };
+
+  const updateKeyValue = (i: number, key: string, value: string, error?: string) => {
+    const newKeyValues = keyValues.map((pair, index) => {
+      if (index == i) {
+        return { key, value, error };
+      } else {
+        return pair;
+      }
+    });
+    setKeyValues(newKeyValues);
+    saveKeyValues(newKeyValues);
+  };
+
+  const mapItem = (pair: KeyValuePair, i: number) => {
+    return (
+      <FormControl isRequired={true} isInvalid={pair.error != undefined}>
+        <Flex gap={2} alignItems={'flex-end'}>
+          <Flex gap={2} flex={1} alignItems={'center'} key={i}>
+            <Input value={pair.key} onChange={e => updateKeyValue(i, e.target.value, pair.value)} />
+            <Text>→</Text>
+            <Input value={pair.value} onChange={e => updateKeyValue(i, pair.key, e.target.value)} />
+          </Flex>
+          <IconButton
+            width={8}
+            height={8}
+            minWidth={0}
+            aria-label="Delete item"
+            onClick={() => deleteItem(i)}
+            icon={<DeleteIcon width={3} />}
+          />
+        </Flex>
+        <FormErrorMessage>{pair.error}</FormErrorMessage>
+      </FormControl>
+    );
+  };
+
+  return (
+    <Box>
+      <fieldset key={schema.title} style={{ border: '1px solid #888', borderRadius: '8px' }}>
+        <legend
+          style={{
+            marginLeft: '8px',
+            paddingLeft: '16px',
+            paddingRight: '16px',
+          }}
+        >
+          {schema.title}
+        </legend>
+        <FormControl isInvalid={errors[path]}>
+          <Stack p={4} gap={2}>
+            {errors[path] ? (
+              <FormErrorMessage>{errors[path]}</FormErrorMessage>
+            ) : (
+              schema.description && (
+                <FormHelperText mt={0} pb={2}>
+                  <Markdown>{schema.description}</Markdown>
+                </FormHelperText>
+              )
+            )}
+            {keyValues.map((pair, index) => mapItem(pair, index))}
             <IconButton mt={1} height={8} aria-label="Add item" onClick={add} icon={<AddIcon />} />
           </Stack>
         </FormControl>
@@ -426,7 +568,7 @@ export function FormInner({
                       </legend>
                       <Box p={4}>
                         <FormInner
-                          path={key}
+                          path={nextPath}
                           // @ts-ignore
                           schema={property}
                           errors={errors}
@@ -436,6 +578,22 @@ export function FormInner({
                       </Box>
                     </fieldset>
                   );
+                } else if (property.additionalProperties) {
+                  return (
+                    <Box>
+                      <MapWidget
+                        path={nextPath}
+                        key={key}
+                        schema={property}
+                        values={traversePath(values, nextPath)}
+                        errors={errors}
+                        onChange={onChange}
+                      />
+                    </Box>
+                  );
+                } else {
+                  console.warn('Unsupported property', property);
+                  return <></>;
                 }
               }
               default: {

--- a/arroyo-console/src/udf_state.ts
+++ b/arroyo-console/src/udf_state.ts
@@ -137,7 +137,7 @@ export const getLocalUdfsContextValue = () => {
       `/*\n` +
       `[dependencies]\n\n` +
       `*/\n\n` +
-      `fn ${functionName}(x: i64) -> i64 {\n` +
+      `pub fn ${functionName}(x: i64) -> i64 {\n` +
       '    // Write your function here\n' +
       '    // Tip: rename the function to something descriptive\n\n' +
       '}';

--- a/arroyo-worker/src/connectors/filesystem/local.rs
+++ b/arroyo-worker/src/connectors/filesystem/local.rs
@@ -21,7 +21,7 @@ use anyhow::{bail, Result};
 
 use super::{
     add_suffix_prefix, delta, get_partitioner_from_file_settings, CommitState, CommitStyle,
-    FileSystemTable, FilenameStrategy, Filenaming, MultiPartWriterStats, RollingPolicy, TableType,
+    FileNaming, FileSystemTable, FilenameStrategy, MultiPartWriterStats, RollingPolicy, TableType,
 };
 
 pub struct LocalFileSystemWriter<K: Key, D: Data + Sync, V: LocalWriter<D>> {
@@ -37,7 +37,7 @@ pub struct LocalFileSystemWriter<K: Key, D: Data + Sync, V: LocalWriter<D>> {
     table_properties: FileSystemTable,
     commit_state: CommitState,
     phantom: PhantomData<(K, D)>,
-    filenaming: Filenaming,
+    filenaming: FileNaming,
 }
 
 impl<K: Key, D: Data + Sync + Serialize, V: LocalWriter<D>> LocalFileSystemWriter<K, D, V> {
@@ -61,8 +61,8 @@ impl<K: Key, D: Data + Sync + Serialize, V: LocalWriter<D>> LocalFileSystemWrite
         let mut filenaming = file_settings
             .clone()
             .unwrap()
-            .filenaming
-            .unwrap_or_else(|| Filenaming {
+            .file_naming
+            .unwrap_or_else(|| FileNaming {
                 strategy: Some(FilenameStrategy::Serial),
                 prefix: None,
                 suffix: None,

--- a/arroyo-worker/src/connectors/filesystem/source/mod.rs
+++ b/arroyo-worker/src/connectors/filesystem/source/mod.rs
@@ -108,18 +108,17 @@ impl<K: Data, T: SchemaData> FileSystemSourceFunc<K, T> {
 
         let (storage_provider, regex_pattern) = match &self.table {
             TableType::Source {
-                read_source,
+                path,
+                storage_options,
                 compression_format: _,
                 regex_pattern,
             } => {
-                let storage_provider = StorageProvider::for_url_with_options(
-                    &read_source.path,
-                    read_source.storage_options.clone(),
-                )
-                .await
-                .map_err(|err| {
-                    UserError::new("failed to create storage provider", err.to_string())
-                })?;
+                let storage_provider =
+                    StorageProvider::for_url_with_options(&path, storage_options.clone())
+                        .await
+                        .map_err(|err| {
+                            UserError::new("failed to create storage provider", err.to_string())
+                        })?;
                 let matcher = regex_pattern
                     .as_ref()
                     .map(|pattern| Regex::new(&pattern))

--- a/arroyo-worker/src/lib.rs
+++ b/arroyo-worker/src/lib.rs
@@ -7,7 +7,7 @@ use crate::network_manager::NetworkManager;
 use anyhow::{bail, Result};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow_array::cast::AsArray;
-use arrow_array::{Array, RecordBatch, StringArray};
+use arrow_array::{RecordBatch, StringArray};
 use arroyo_rpc::grpc::controller_grpc_client::ControllerGrpcClient;
 use arroyo_rpc::grpc::worker_grpc_server::{WorkerGrpc, WorkerGrpcServer};
 use arroyo_rpc::grpc::{

--- a/connector-schemas/filesystem/table.json
+++ b/connector-schemas/filesystem/table.json
@@ -10,76 +10,57 @@
           "type": "object",
           "title": "Source",
           "properties": {
-            "read_source": {
-              "type": "object",
-              "title": "Source",
-              "properties": {
-                "Path": {
-                  "title": "Path",
-                  "type": "string",
-                  "description": "URI of the folder to write to"
-                },
-                "Storage options": {
-                  "type": "object",
-                  "title": "Storage Options",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "Path"
-              ],
-              "additionalProperties": false
+            "path": {
+              "title": "Path",
+              "type": "string",
+              "description": "URI of the folder to write to"
             },
-
-            "compression_format": {
-                "title": "Compression format",
-                "type": "string",
-                "description": "Compression format of the files in S3",
-                "enum": [
-                  "none",
-                  "zstd",
-                  "gzip"
-                  ]     
-              },
-            "regexPattern" : {
+            "compressionFormat": {
+              "title": "Compression format",
+              "type": "string",
+              "description": "Compression format of the files in S3",
+              "enum": [
+                "none",
+                "zstd",
+                "gzip"
+              ]
+            },
+            "regexPattern": {
               "title": "File Regex Pattern",
               "type": "string",
-              "description": "regex matching pattern for files to include in source. Will search everything under the source path."
-              }
+              "description": "Regex matching pattern for files to include in source. Will search everything under the source path."
             },
+            "storageOptions": {
+              "type": "object",
+              "title": "Storage Options",
+              "description": "See the [FileSystem connector docs](https://doc.arroyo.dev/connectors/filesystem) for the full list of options",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
           "required": [
-            "read_source"
+            "path"
           ]
         },
         {
           "type": "object",
           "title": "Sink",
           "properties": {
-            "write_target": {
-              "type": "object",
-              "title": "Folder URL",
-              "properties": {
-                "Path": {
-                  "title": "Path",
-                  "type": "string",
-                  "description": "URI of the folder to write to"
-                },
-                "Storage options": {
-                  "type": "object",
-                  "title": "Storage Options",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "Path"
-              ],
-              "additionalProperties": false
+            "path": {
+              "title": "Path",
+              "type": "string",
+              "description": "URI of the folder to write to"
             },
-            "format_settings": {
+            "storageOptions": {
+              "type": "object",
+              "title": "Storage Options",
+              "description": "See the [FileSystem connector docs](https://doc.arroyo.dev/connectors/filesystem) for the full list of options",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "formatSettings": {
               "type": "object",
               "title": "Format Settings",
               "oneOf": [
@@ -98,11 +79,11 @@
                         "lz4"
                       ]
                     },
-                    "row_batch_size": {
+                    "rowBatchSize": {
                       "title": "Row Batch Size",
                       "type": "integer"
                     },
-                    "row_group_size": {
+                    "rowGroupSize": {
                       "title": "Row Group Size",
                       "type": "integer"
                     }
@@ -116,93 +97,94 @@
                 }
               ]
             },
-            "file_settings": {
+            "fileSettings": {
               "type": "object",
               "title": "File Settings",
               "properties": {
-                "target_part_size": {
+                "targetPartSize": {
                   "title": "Target Part Size",
                   "type": "integer",
-                  "description": "target size for each part of the multipart upload, in bytes"
+                  "description": "Target size for each part of the multipart upload, in bytes"
                 },
-                "max_parts": {
+                "maxParts": {
                   "title": "Max Parts",
                   "type": "integer",
-                  "description": "maximum number of parts to upload in a multipart upload"
+                  "description": "Maximum number of parts to upload in a multipart upload"
                 },
-                "target_file_size": {
+                "targetFileSize": {
                   "title": "Target File Size",
                   "type": "integer",
-                  "description": "target size for each file, in bytes"
+                  "description": "Target size for each file, in bytes"
                 },
-                "rollover_seconds": {
+                "rolloverSeconds": {
                   "title": "Rollover Seconds",
                   "type": "integer",
-                  "description": "number of seconds to wait before rolling over to a new file"
+                  "description": "Number of seconds to wait before rolling over to a new file"
                 },
-                "inactivity_rollover_seconds": {
+                "inactivityRolloverSeconds": {
                   "title": "Inactivity Rollover Seconds",
                   "type": "integer",
-                  "description": "number of seconds of inactivity to wait before rolling over to a new file"
+                  "description": "Number of seconds of inactivity to wait before rolling over to a new file"
                 },
                 "partitioning": {
                   "title": "Partitioning",
                   "type": "object",
                   "properties": {
-                    "time_partition_pattern": {
+                    "timePartitionPattern": {
                       "title": "Time Partition Pattern",
                       "type": "string",
                       "description": "The pattern of the date string"
                     },
-                    "partition_fields": {
+                    "partitionFields": {
                       "title": "Partition Fields",
                       "type": "array",
                       "items": {
+                        "title": "Partition Field",
                         "type": "string"
                       },
-                      "description": "fields to partition the data by"
+                      "description": "Fields to partition the data by"
                     }
                   },
                   "additionalProperties": false
                 },
-                "commit_style": {
-                    "title": "Commit Style",
-                    "type": "string",
-                    "enum": [
-                        "direct",
-                        "delta_lake"
-                    ]
+                "commitStyle": {
+                  "title": "Commit Style",
+                  "type": "string",
+                  "enum": [
+                    "direct",
+                    "delta_lake"
+                  ]
                 },
-                "filenaming": {
-                    "title": "Filenaming",
-                    "type": "object",
-                    "properties": {
-                        "prefix": {
-                            "title": "Filename Prefix",
-                            "type": "string",
-                            "description": "The prefix to use in file name. i.e prefix-<uuid>.parquet"
-                        },
-                        "suffix": {
-                            "title": "Filename Suffix",
-                            "type": "string",
-                            "description": "This will overwrite the default file suffix. i.e .parquet, use with caution"
-                        },
-                        "strategy":{
-                            "title": "Filename Strategy",
-                            "type": "string",
-                            "enum": [
-                                "serial",
-                                "uuid"
-                            ]
-                        }
+                "fileNaming": {
+                  "title": "File naming",
+                  "type": "object",
+                  "properties": {
+                    "prefix": {
+                      "title": "Filename Prefix",
+                      "type": "string",
+                      "description": "The prefix to use in file name. i.e prefix-<uuid>.parquet"
+                    },
+                    "suffix": {
+                      "title": "Filename Suffix",
+                      "type": "string",
+                      "description": "This will overwrite the default file suffix. i.e .parquet, use with caution"
+                    },
+                    "strategy": {
+                      "title": "Filename Strategy",
+                      "type": "string",
+                      "enum": [
+                        "serial",
+                        "uuid"
+                      ]
                     }
+                  }
                 }
               },
               "additionalProperties": false
             }
           },
           "required": [
-            "write_target"
+            "path"
           ]
         }
       ]


### PR DESCRIPTION
Remove some unnecessary nesting in the file system table schema,
standardize the field capitalization, and add a MapWidget component to
support a Storage Options string map. Also renders all helper text in
the JsonForm as markdown so it can include links.


![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/be621ad8-df3d-420f-9a4c-1200146a18f6)


Duplicate keys error handling:
![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/b92e7bae-3c71-4cb6-b301-f33608f04f59)

