### PR TITLE
arroyo-console: RawString schema's value now submitted as non-nullable.

### DIFF
--- a/arroyo-console/src/routes/connections/DefineSchema.tsx
+++ b/arroyo-console/src/routes/connections/DefineSchema.tsx
@@ -194,7 +194,7 @@ const RawStringEditor = ({
                 primitive: 'string',
               },
             },
-            nullable: true,
+            nullable: false,
           },
         ],
         format: { raw_string: {} },


### PR DESCRIPTION
The frontend is also providing data about the RawString's schema, and it is wrong. This probably shouldn't be in the frontend at all, but for now this fixes a bug.