### PR TITLE
Implement json sink for schema registry, use connection types for sinks, add auth for schema registry.

### DIFF
--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -151,9 +151,15 @@ impl Connector for KafkaConnector {
             Some(other) => bail!("unknown auth type '{}'", other),
         };
 
-        let schema_registry = opts
-            .remove("schema_registry.endpoint")
-            .map(|endpoint| SchemaRegistry { endpoint });
+        let schema_registry = opts.remove("schema_registry.endpoint").map(|endpoint| {
+            let api_key = opts.remove("schema_registry.api_key");
+            let api_secret = opts.remove("schema_registry.api_secret");
+            SchemaRegistry {
+                endpoint,
+                api_key,
+                api_secret,
+            }
+        });
 
         let connection = KafkaConfig {
             authentication: auth,

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -28,6 +28,7 @@ function StringWidget({
   description,
   placeholder,
   required,
+  password,
   maxLength,
   value,
   errors,
@@ -39,6 +40,7 @@ function StringWidget({
   placeholder?: string;
   maxLength?: number;
   required?: boolean;
+  password?: boolean;
   value: string;
   errors: any;
   onChange: (e: React.ChangeEvent<any>) => void;
@@ -49,7 +51,7 @@ function StringWidget({
       {maxLength == null || maxLength < 100 ? (
         <Input
           name={path}
-          type="text"
+          type={password ? 'password' : 'text'}
           placeholder={placeholder}
           value={value || ''}
           onChange={e => onChange(e)}
@@ -324,6 +326,8 @@ export function FormInner({
                       title={property.title || key}
                       description={property.description}
                       required={schema.required?.includes(key)}
+                      // @ts-ignore
+                      password={property.isSensitive || false}
                       maxLength={property.maxLength}
                       // @ts-ignore
                       placeholder={property.examples ? (property.examples[0] as string) : undefined}

--- a/arroyo-rpc/src/formats.rs
+++ b/arroyo-rpc/src/formats.rs
@@ -37,6 +37,9 @@ pub struct JsonFormat {
     pub confluent_schema_registry: bool,
 
     #[serde(default)]
+    pub confluent_schema_version: Option<u32>,
+
+    #[serde(default)]
     pub include_schema: bool,
 
     #[serde(default)]
@@ -81,6 +84,7 @@ impl JsonFormat {
 
         Ok(Self {
             confluent_schema_registry,
+            confluent_schema_version: None,
             include_schema,
             debezium,
             unstructured,

--- a/arroyo-rpc/src/formats.rs
+++ b/arroyo-rpc/src/formats.rs
@@ -64,6 +64,10 @@ impl JsonFormat {
             .filter(|t| t == "true")
             .is_some();
 
+        if include_schema && confluent_schema_registry {
+            return Err("can't include schema in message if using schema registry".to_string());
+        }
+
         let unstructured = opts
             .remove("json.unstructured")
             .filter(|t| t == "true")

--- a/arroyo-sql-macro/src/connectors.rs
+++ b/arroyo-sql-macro/src/connectors.rs
@@ -72,6 +72,7 @@ pub fn get_json_schema_source() -> Result<Connection> {
     let connection_schema = ConnectionSchema::try_new(
         Some(Format::Json(JsonFormat {
             confluent_schema_registry: false,
+            confluent_schema_version: None,
             include_schema: false,
             debezium: false,
             unstructured: false,

--- a/arroyo-sql/src/operators.rs
+++ b/arroyo-sql/src/operators.rs
@@ -21,6 +21,7 @@ use syn::{parse_quote, parse_str};
 pub struct Projection {
     pub fields: Vec<(Column, Expression)>,
     pub format: Option<Format>,
+    pub struct_name: Option<String>,
 }
 
 impl Projection {
@@ -28,6 +29,7 @@ impl Projection {
         Self {
             fields,
             format: None,
+            struct_name: None,
         }
     }
 
@@ -72,7 +74,7 @@ impl CodeGenerator<ValuePointerContext, StructDef, syn::Expr> for Projection {
                 StructField::new(col.name.clone(), col.relation.clone(), field_type)
             })
             .collect();
-        StructDef::new(None, true, fields, self.format.clone())
+        StructDef::new(self.struct_name.clone(), true, fields, self.format.clone())
     }
 }
 

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -452,6 +452,7 @@ impl ConnectorTable {
             );
 
             projection.format = Some(format.clone());
+            projection.struct_name = self.type_name.clone();
 
             input = SqlOperator::RecordTransform(
                 Box::new(input),

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -108,8 +108,13 @@ where
         let schema_resolver: Arc<dyn SchemaResolver + Sync> =
             if let Some(schema_registry) = &connection.schema_registry {
                 Arc::new(
-                    ConfluentSchemaResolver::new(&schema_registry.endpoint, &table.topic)
-                        .expect("failed to construct confluent schema resolver"),
+                    ConfluentSchemaResolver::new(
+                        &schema_registry.endpoint,
+                        &table.topic,
+                        schema_registry.api_key.clone(),
+                        schema_registry.api_secret.clone(),
+                    )
+                    .expect("failed to construct confluent schema resolver"),
                 )
             } else {
                 Arc::new(FailingSchemaResolver::new())

--- a/arroyo-worker/src/formats/mod.rs
+++ b/arroyo-worker/src/formats/mod.rs
@@ -180,7 +180,7 @@ impl<T: SchemaData> DataSerializer<T> {
     pub fn to_vec(&self, record: &T) -> Option<Vec<u8>> {
         match &self.format {
             Format::Json(json) => {
-                let mut writer: Vec<u8> = vec![];
+                let mut writer: Vec<u8> = Vec::with_capacity(128);
                 if json.confluent_schema_registry {
                     writer.push(0);
                     writer.extend(json.confluent_schema_version.expect("must have computed schema version to write using confluent schema registry").to_be_bytes());

--- a/arroyo-worker/src/formats/mod.rs
+++ b/arroyo-worker/src/formats/mod.rs
@@ -182,6 +182,9 @@ impl<T: SchemaData> DataSerializer<T> {
             Format::Json(json) => {
                 let mut writer: Vec<u8> = Vec::with_capacity(128);
                 if json.confluent_schema_registry {
+                    if json.include_schema {
+                        unreachable!("can't include schema when writing to confluent schema registry, should've been caught when creating JsonFormat");
+                    }
                     writer.push(0);
                     writer.extend(json.confluent_schema_version.expect("must have computed schema version to write using confluent schema registry").to_be_bytes());
                 }

--- a/connector-schemas/kafka/connection.json
+++ b/connector-schemas/kafka/connection.json
@@ -43,7 +43,8 @@
                         },
                         "password": {
                             "type": "string",
-                            "description": "The password to use for SASL authentication"
+                            "description": "The password to use for SASL authentication",
+                            "isSensitive": true
                         }
                     },
                     "additionalProperties": false
@@ -62,6 +63,23 @@
                         "http://localhost:8081"
                     ],
                     "format": "uri"
+                },
+                "apiKey": {
+                    "title": "API Key",
+                    "type": "string",
+                    "description": "The API key for your Confluent Schema Registry if you have one",
+                    "examples": [
+                        "ABCDEFGHIJK01234"
+                    ]
+                },
+                "apiSecret": {
+                    "title": "API Secret",
+                    "type": "string",
+                    "description": "Secret for your Confluent Schema Registry if you have one",
+                    "isSensitive": true,
+                    "examples": [
+                        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/="
+                    ]
                 }
             },
             "required": ["endpoint"]


### PR DESCRIPTION
This implements a number of features in order to write to a confluent topic which has a JsonSchema in a confluent registry. In particular,
* Add confluent_schema_registry version to JsonFormat. This will be written in the 5 byte header of messages written to kafka for sinks using the schema registry.
* Add an optional `struct_name` to arroyo-sql's Projection, so that it will use structs generated with the correct format.
* Add basic auth for kafka schema registry, currently named "API Key" and "API Secret", which is how Confluent Cloud names them.
* unify treatment of sources and sinks in arroyo-sql as "connections". This means that two queries emitting to the same sink will share a sink node. Also properly tracks dependencies between pipelines and sink connections.