### PR TITLE
Support joining updating data

### DIFF
--- a/arroyo-sql-testing/golden_outputs/updating_full_join.json
+++ b/arroyo-sql-testing/golden_outputs/updating_full_join.json
@@ -1,0 +1,7 @@
+{"before":null,"after":{"left_counter":0,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":null,"after":{"left_counter":2,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":{"left_counter":1,"counter_mod_2":null,"right_count":null},"after":{"left_counter":1,"counter_mod_2":0,"right_count":1},"op":"u"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":1,"right_count":1},"op":"c"}
+{"before":{"left_counter":2,"counter_mod_2":null,"right_count":null},"after":{"left_counter":2,"counter_mod_2":0,"right_count":2},"op":"u"}
+{"before":{"left_counter":1,"counter_mod_2":0,"right_count":1},"after":null,"op":"d"}

--- a/arroyo-sql-testing/golden_outputs/updating_inner_join.json
+++ b/arroyo-sql-testing/golden_outputs/updating_inner_join.json
@@ -1,0 +1,4 @@
+{"before":null,"after":{"left_counter":1,"counter_mod_2":0,"right_count":1},"op":"c"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":1,"right_count":1},"op":"c"}
+{"before":null,"after":{"left_counter":2,"counter_mod_2":0,"right_count":2},"op":"c"}
+{"before":{"left_counter":1,"counter_mod_2":0,"right_count":1},"after":null,"op":"d"}

--- a/arroyo-sql-testing/golden_outputs/updating_left_join.json
+++ b/arroyo-sql-testing/golden_outputs/updating_left_join.json
@@ -1,0 +1,7 @@
+{"before":null,"after":{"left_counter":0,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":null,"after":{"left_counter":2,"counter_mod_2":null,"right_count":null},"op":"c"}
+{"before":{"left_counter":1,"counter_mod_2":null,"right_count":null},"after":{"left_counter":1,"counter_mod_2":0,"right_count":1},"op":"u"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":1,"right_count":1},"op":"c"}
+{"before":{"left_counter":2,"counter_mod_2":null,"right_count":null},"after":{"left_counter":2,"counter_mod_2":0,"right_count":2},"op":"u"}
+{"before":{"left_counter":1,"counter_mod_2":0,"right_count":1},"after":null,"op":"d"}

--- a/arroyo-sql-testing/golden_outputs/updating_right_join.json
+++ b/arroyo-sql-testing/golden_outputs/updating_right_join.json
@@ -1,0 +1,4 @@
+{"before":null,"after":{"left_counter":1,"counter_mod_2":0,"right_count":1},"op":"c"}
+{"before":null,"after":{"left_counter":1,"counter_mod_2":1,"right_count":1},"op":"c"}
+{"before":null,"after":{"left_counter":2,"counter_mod_2":0,"right_count":2},"op":"c"}
+{"before":{"left_counter":1,"counter_mod_2":0,"right_count":1},"after":null,"op":"d"}

--- a/arroyo-sql/src/code_gen.rs
+++ b/arroyo-sql/src/code_gen.rs
@@ -227,9 +227,10 @@ impl JoinPairContext {
         let merge_expr = code_generator.generate(self);
         let left_ident = self.left_ident();
         let right_ident = self.right_ident();
+
         parse_quote!({
-            let #left_ident = &record.value.0;
-            let #right_ident = &record.value.1;
+            let (#left_ident, #right_ident) = &record.value.unwrap_append().clone();
+
             arroyo_types::Record {
                 timestamp: record.timestamp.clone(),
                 key: None,

--- a/arroyo-sql/src/pipeline.rs
+++ b/arroyo-sql/src/pipeline.rs
@@ -223,6 +223,12 @@ pub struct JoinOperator {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputsUpdating {
+    pub left: bool,
+    pub right: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JoinType {
     /// Inner Join
     Inner,
@@ -805,9 +811,6 @@ impl<'a> SqlPipelineBuilder<'a> {
     fn insert_join(&mut self, join: &datafusion_expr::logical_plan::Join) -> Result<SqlOperator> {
         let left_input = self.insert_sql_plan(&join.left)?;
         let right_input = self.insert_sql_plan(&join.right)?;
-        if left_input.is_updating() || right_input.is_updating() {
-            bail!("don't support joins with updating inputs");
-        }
         match join.join_constraint {
             JoinConstraint::On => {}
             JoinConstraint::Using => bail!("don't support 'using' in joins"),

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -338,6 +338,13 @@ impl<T: Data> UpdatingData<T> {
             UpdatingData::Append(t) => t.clone(),
         }
     }
+
+    pub fn unwrap_append(&self) -> &T {
+        match self {
+            UpdatingData::Append(t) => t,
+            _ => panic!("UpdatingData is not an append"),
+        }
+    }
 }
 
 #[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]

--- a/arroyo-worker/src/operators/joiners.rs
+++ b/arroyo-worker/src/operators/joiners.rs
@@ -1,0 +1,278 @@
+use crate::operators::join_with_expiration::{
+    Coercer, FullJoinProcessor, InnerJoinProcessor, JoinWithExpiration, LeftJoinProcessor,
+    NoOpProcessor, RightJoinProcessor,
+};
+use arroyo_types::*;
+use std::time::Duration;
+
+pub fn left_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    T2,
+    Coercer<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, Option<T2>)>,
+    LeftJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, LeftJoinProcessor::new())
+}
+
+pub fn left_join_left_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    T2,
+    NoOpProcessor<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, Option<T2>)>,
+    LeftJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, LeftJoinProcessor::new())
+}
+
+pub fn left_join_right_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    UpdatingData<T2>,
+    Coercer<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, Option<T2>)>,
+    LeftJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, LeftJoinProcessor::new())
+}
+
+pub fn left_join_both_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    UpdatingData<T2>,
+    NoOpProcessor<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, Option<T2>)>,
+    LeftJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, LeftJoinProcessor::new())
+}
+
+pub fn right_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    T2,
+    Coercer<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, T2)>,
+    RightJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, RightJoinProcessor::new())
+}
+
+pub fn right_join_left_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    T2,
+    NoOpProcessor<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, T2)>,
+    RightJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, RightJoinProcessor::new())
+}
+
+pub fn right_join_right_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    UpdatingData<T2>,
+    Coercer<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, T2)>,
+    RightJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, RightJoinProcessor::new())
+}
+
+pub fn right_join_both_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    UpdatingData<T2>,
+    NoOpProcessor<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, T2)>,
+    RightJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, RightJoinProcessor::new())
+}
+
+pub fn inner_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    T2,
+    Coercer<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, T2)>,
+    InnerJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, InnerJoinProcessor::new())
+}
+
+pub fn inner_join_left_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    T2,
+    NoOpProcessor<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, T2)>,
+    InnerJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, InnerJoinProcessor::new())
+}
+
+pub fn inner_join_right_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    UpdatingData<T2>,
+    Coercer<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, T2)>,
+    InnerJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, InnerJoinProcessor::new())
+}
+
+pub fn inner_join_both_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    UpdatingData<T2>,
+    NoOpProcessor<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(T1, T2)>,
+    InnerJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, InnerJoinProcessor::new())
+}
+
+pub fn full_join<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    T2,
+    Coercer<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, Option<T2>)>,
+    FullJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, FullJoinProcessor::new())
+}
+
+pub fn full_join_left_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    T2,
+    NoOpProcessor<T1>,
+    Coercer<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, Option<T2>)>,
+    FullJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, FullJoinProcessor::new())
+}
+
+pub fn full_join_right_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    T1,
+    UpdatingData<T2>,
+    Coercer<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, Option<T2>)>,
+    FullJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, FullJoinProcessor::new())
+}
+
+pub fn full_join_both_updating<K: Key, T1: Data, T2: Data>(
+    left_expiration: Duration,
+    right_expiration: Duration,
+) -> JoinWithExpiration<
+    K,
+    UpdatingData<T1>,
+    UpdatingData<T2>,
+    NoOpProcessor<T1>,
+    NoOpProcessor<T2>,
+    T1,
+    T2,
+    UpdatingData<(Option<T1>, Option<T2>)>,
+    FullJoinProcessor<K, T1, T2>,
+> {
+    JoinWithExpiration::new(left_expiration, right_expiration, FullJoinProcessor::new())
+}

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -22,6 +22,7 @@ use wasmtime::{
 pub mod aggregating_window;
 pub mod functions;
 pub mod join_with_expiration;
+pub mod joiners;
 pub mod joins;
 pub mod sinks;
 pub mod sliding_top_n_aggregating_window;


### PR DESCRIPTION
Operators that produce updating data (insert/update/delete) previously could not be upstream from the JoinWithExpiration operator. This change modifies the JoinWithExpiration operator to correctly handle updating data.

All join types, excluding inner joins on non-updating inputs, now produce updating data.

The bulk of the changes are in `join_with_expiration.rs`, where we transforms/coerces all data into updating data so that we reuse the same 4 join processors regardless of input type.

Tested by adding new smoke tests and by running the queries through Flink and checking that the outputs are equivalent.
