### PR TITLE
Connection profiles sql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           cd arroyo-openapi
           lint-openapi --errors-only api-spec.json
       - name: Test
-        run: cargo nextest run --all-features
+        run: cargo nextest run --jobs 4 --all-features
       - name: Integ
         run: |
           mkdir /tmp/arroyo-integ

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -8,7 +8,7 @@ use deadpool_postgres::{Object, Transaction};
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::{jobs, pipelines, types};
+use crate::{connection_profiles, jobs, pipelines, types};
 use arroyo_datastream::{ConnectorOp, Operator, Program};
 use arroyo_rpc::api_types::pipelines::{
     Job, Pipeline, PipelineEdge, PipelineGraph, PipelineNode, PipelinePatch, PipelinePost,
@@ -117,6 +117,13 @@ where
         )?;
 
         schema_provider.add_connector_table(connection);
+    }
+    let profiles = connection_profiles::get_all_connection_profiles(auth_data, tx)
+        .await
+        .map_err(|e| anyhow!(e.message))?;
+
+    for profile in profiles {
+        schema_provider.add_connection_profile(profile);
     }
 
     let (program, connections) = arroyo_sql::parse_and_get_program(

--- a/arroyo-connectors/src/blackhole.rs
+++ b/arroyo-connectors/src/blackhole.rs
@@ -1,7 +1,10 @@
 use anyhow::anyhow;
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use arroyo_rpc::OperatorConfig;
 use axum::response::sse::Event;
+use std::collections::HashMap;
 use std::convert::Infallible;
 
 use crate::{Connection, Connector, EmptyConfig};
@@ -71,10 +74,11 @@ impl Connector for BlackholeConnector {
     fn from_options(
         &self,
         name: &str,
-        _: &mut std::collections::HashMap<String, String>,
-        s: Option<&ConnectionSchema>,
+        _options: &mut HashMap<String, String>,
+        schema: Option<&ConnectionSchema>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, s)
+        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema)
     }
 
     fn from_config(

--- a/arroyo-connectors/src/delta.rs
+++ b/arroyo-connectors/src/delta.rs
@@ -1,9 +1,12 @@
 use anyhow::{anyhow, bail, Result};
 use arroyo_storage::BackendConfig;
 use axum::response::sse::Event;
+use std::collections::HashMap;
 use std::convert::Infallible;
 
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use arroyo_rpc::OperatorConfig;
 
 use crate::filesystem::{
@@ -144,10 +147,11 @@ impl Connector for DeltaLakeConnector {
     fn from_options(
         &self,
         name: &str,
-        opts: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
-    ) -> anyhow::Result<crate::Connection> {
-        let table = file_system_sink_from_options(opts, schema, CommitStyle::DeltaLake)?;
+        _profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let table = file_system_sink_from_options(options, schema, CommitStyle::DeltaLake)?;
 
         self.from_config(None, name, EmptyConfig {}, table, schema)
     }

--- a/arroyo-connectors/src/fluvio.rs
+++ b/arroyo-connectors/src/fluvio.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, bail};
-use arroyo_rpc::api_types::connections::{ConnectionSchema, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema, TestSourceMessage};
 use arroyo_rpc::OperatorConfig;
 use axum::response::sse::Event;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use typify::import_types;
 
@@ -79,8 +80,9 @@ impl Connector for FluvioConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = options.remove("endpoint");
         let topic = pull_opt("topic", options)?;

--- a/arroyo-connectors/src/impulse.rs
+++ b/arroyo-connectors/src/impulse.rs
@@ -1,9 +1,12 @@
 use anyhow::{anyhow, bail};
 use arroyo_rpc::api_types::connections::FieldType::Primitive;
-use arroyo_rpc::api_types::connections::{ConnectionSchema, PrimitiveType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, PrimitiveType, TestSourceMessage,
+};
 use arroyo_rpc::OperatorConfig;
 use axum::response::sse::Event;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::str::FromStr;
 use typify::import_types;
@@ -92,8 +95,9 @@ impl Connector for ImpulseConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut std::collections::HashMap<String, String>,
-        s: Option<&ConnectionSchema>,
+        options: &mut HashMap<String, String>,
+        schema: Option<&ConnectionSchema>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;
@@ -111,7 +115,7 @@ impl Connector for ImpulseConnector {
             .map_err(|_| anyhow!("invalid value for event_time_interval; expected float"))?;
 
         // validate the schema
-        if let Some(s) = s {
+        if let Some(s) = schema {
             if !s.fields.is_empty() && s.fields != impulse_schema().fields {
                 bail!("invalid schema for impulse source");
             }

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context};
 use arroyo_rpc::api_types::connections::{
-    ConnectionSchema, ConnectionType, FieldType, SourceField, SourceFieldType,
+    ConnectionProfile, ConnectionSchema, ConnectionType, FieldType, SourceField, SourceFieldType,
 };
 use arroyo_rpc::primitive_to_sql;
 use arroyo_types::string_to_map;
@@ -120,6 +120,7 @@ pub trait Connector: Send {
         name: &str,
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection>;
 
     fn from_config(
@@ -170,6 +171,7 @@ pub trait ErasedConnector: Send {
         name: &str,
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection>;
 
     fn from_config(
@@ -246,8 +248,9 @@ impl<C: Connector> ErasedConnector for C {
         name: &str,
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        self.from_options(name, options, schema)
+        self.from_options(name, options, schema, profile)
     }
 
     fn from_config(

--- a/arroyo-connectors/src/nexmark.rs
+++ b/arroyo-connectors/src/nexmark.rs
@@ -1,11 +1,13 @@
 use anyhow::{anyhow, bail};
 use arroyo_rpc::api_types::connections::FieldType::Primitive;
 use arroyo_rpc::api_types::connections::{
-    ConnectionSchema, ConnectionType, FieldType, SourceFieldType, StructType, TestSourceMessage,
+    ConnectionProfile, ConnectionSchema, ConnectionType, FieldType, SourceFieldType, StructType,
+    TestSourceMessage,
 };
 use arroyo_rpc::OperatorConfig;
 use axum::response::sse::Event;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::str::FromStr;
 use typify::import_types;
@@ -151,8 +153,9 @@ impl Connector for NexmarkConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;

--- a/arroyo-connectors/src/polling_http.rs
+++ b/arroyo-connectors/src/polling_http.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 
 use anyhow::anyhow;
@@ -8,7 +9,9 @@ use reqwest::{Client, Request};
 use tokio::sync::mpsc::Sender;
 use typify::import_types;
 
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{construct_http_client, pull_opt, pull_option_to_i64, Connection, EmptyConfig};
@@ -136,21 +139,22 @@ impl Connector for PollingHTTPConnector {
     fn from_options(
         &self,
         name: &str,
-        opts: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
-    ) -> anyhow::Result<crate::Connection> {
-        let endpoint = pull_opt("endpoint", opts)?;
-        let headers = opts.remove("headers");
-        let method: Option<Method> = opts
+        _profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let endpoint = pull_opt("endpoint", options)?;
+        let headers = options.remove("headers");
+        let method: Option<Method> = options
             .remove("method")
             .map(|s| s.try_into())
             .transpose()
             .map_err(|_| anyhow!("invalid value for 'method'"))?;
 
-        let body = opts.remove("body");
+        let body = options.remove("body");
 
-        let interval = pull_option_to_i64("poll_interval_ms", opts)?;
-        let emit_behavior: Option<EmitBehavior> = opts
+        let interval = pull_option_to_i64("poll_interval_ms", options)?;
+        let emit_behavior: Option<EmitBehavior> = options
             .remove("emit_behavior")
             .map(|s| s.try_into())
             .transpose()

--- a/arroyo-connectors/src/single_file.rs
+++ b/arroyo-connectors/src/single_file.rs
@@ -1,9 +1,12 @@
 use anyhow::{anyhow, bail, Result};
 use axum::response::sse::Event;
+use std::collections::HashMap;
 use std::convert::Infallible;
 use typify::import_types;
 
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use arroyo_rpc::OperatorConfig;
 use serde::{Deserialize, Serialize};
 
@@ -119,11 +122,12 @@ impl Connector for SingleFileConnector {
     fn from_options(
         &self,
         name: &str,
-        opts: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
-    ) -> anyhow::Result<crate::Connection> {
-        let path = pull_opt("path", opts)?;
-        let Ok(table_type) = pull_opt("type", opts)?.try_into() else {
+        _profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let path = pull_opt("path", options)?;
+        let Ok(table_type) = pull_opt("type", options)?.try_into() else {
             bail!("'type' must be 'source' or 'sink'");
         };
 

--- a/arroyo-connectors/src/sse.rs
+++ b/arroyo-connectors/src/sse.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::time::Duration;
 
@@ -10,7 +11,9 @@ use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
 use typify::import_types;
 
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{pull_opt, Connection, EmptyConfig};
@@ -116,12 +119,13 @@ impl Connector for SSEConnector {
     fn from_options(
         &self,
         name: &str,
-        opts: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
-    ) -> anyhow::Result<crate::Connection> {
-        let endpoint = pull_opt("endpoint", opts)?;
-        let headers = opts.remove("headers");
-        let events = opts.remove("events");
+        _profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let endpoint = pull_opt("endpoint", options)?;
+        let headers = options.remove("headers");
+        let events = options.remove("events");
 
         self.from_config(
             None,

--- a/arroyo-connectors/src/webhook.rs
+++ b/arroyo-connectors/src/webhook.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 
 use anyhow::anyhow;
@@ -9,7 +10,9 @@ use serde_json::json;
 use tokio::sync::mpsc::Sender;
 use typify::import_types;
 
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{construct_http_client, pull_opt, Connection, EmptyConfig};
@@ -167,12 +170,13 @@ impl Connector for WebhookConnector {
     fn from_options(
         &self,
         name: &str,
-        opts: &mut std::collections::HashMap<String, String>,
+        options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
-    ) -> anyhow::Result<crate::Connection> {
-        let endpoint = pull_opt("endpoint", opts)?;
+        _profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let endpoint = pull_opt("endpoint", options)?;
 
-        let headers = opts
+        let headers = options
             .remove("headers")
             .map(|s| s.try_into())
             .transpose()

--- a/arroyo-rpc/src/formats.rs
+++ b/arroyo-rpc/src/formats.rs
@@ -56,7 +56,7 @@ impl JsonFormat {
     fn from_opts(debezium: bool, opts: &mut HashMap<String, String>) -> Result<Self, String> {
         let confluent_schema_registry = opts
             .remove("json.confluent_schema_registry")
-            .filter(|t| t == "true")
+            .filter(|t: &String| t == "true")
             .is_some();
 
         let include_schema = opts

--- a/arroyo-sql-testing/Cargo.toml
+++ b/arroyo-sql-testing/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.7.0"
 edition = "2021"
 
 [features]
-default = ["integration-tests"]
 integration-tests = []
 
 

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -42,7 +42,7 @@ use tables::{schema_defs, ConnectorTable, Insert, Table};
 
 use crate::code_gen::{CodeGenerator, ValuePointerContext};
 use crate::types::{StructDef, StructField, TypeDef};
-use arroyo_rpc::api_types::connections::{ConnectionSchema, ConnectionType};
+use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema, ConnectionType};
 use arroyo_rpc::formats::{Format, JsonFormat};
 use datafusion_common::DataFusionError;
 use prettyplease::unparse;
@@ -75,6 +75,7 @@ pub struct ArroyoSchemaProvider {
     pub functions: HashMap<String, Arc<ScalarUDF>>,
     pub aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     pub connections: HashMap<String, Connection>,
+    profiles: HashMap<String, ConnectionProfile>,
     pub udf_defs: HashMap<String, UdfDef>,
     config_options: datafusion::config::ConfigOptions,
 }
@@ -198,6 +199,7 @@ impl ArroyoSchemaProvider {
             aggregate_functions: HashMap::new(),
             source_defs: HashMap::new(),
             connections: HashMap::new(),
+            profiles: HashMap::new(),
             udf_defs: HashMap::new(),
             config_options: datafusion::config::ConfigOptions::new(),
         }
@@ -212,6 +214,10 @@ impl ArroyoSchemaProvider {
             UniCase::new(connection.name.clone()),
             Table::ConnectorTable(connection.into()),
         );
+    }
+
+    pub fn add_connection_profile(&mut self, profile: ConnectionProfile) {
+        self.profiles.insert(profile.name.clone(), profile);
     }
 
     fn insert_table(&mut self, table: Table) {

--- a/arroyo-sql/src/tables.rs
+++ b/arroyo-sql/src/tables.rs
@@ -6,7 +6,7 @@ use arrow_schema::{DataType, Field};
 use arroyo_connectors::{connector_for_type, Connection};
 use arroyo_datastream::{ConnectorOp, Operator};
 use arroyo_rpc::api_types::connections::{
-    ConnectionSchema, ConnectionType, SchemaDefinition, SourceField,
+    ConnectionProfile, ConnectionSchema, ConnectionType, SchemaDefinition, SourceField,
 };
 use arroyo_rpc::formats::{Format, Framing};
 use datafusion::sql::sqlparser::ast::Query;
@@ -161,6 +161,7 @@ impl ConnectorTable {
         connector: &str,
         mut fields: Vec<FieldSpec>,
         options: &mut HashMap<String, String>,
+        connection_profile: Option<&ConnectionProfile>,
     ) -> Result<Self> {
         // TODO: a more principled way of letting connectors dictate types to use
         if "delta" == connector {
@@ -215,7 +216,8 @@ impl ConnectorTable {
             Some(fields.is_empty()),
         )?;
 
-        let connection = connector.from_options(name, options, Some(&schema))?;
+        let connection =
+            connector.from_options(name, options, Some(&schema), connection_profile)?;
 
         let mut table: ConnectorTable = connection.into();
         if !fields.is_empty() {
@@ -646,10 +648,32 @@ impl Table {
                             .collect(),
                     }))
                 }
-                Some(connector) => Ok(Some(Table::ConnectorTable(
-                    ConnectorTable::from_options(&name, connector, fields, &mut with_map)
+                Some(connector) => {
+                    let connection_profile = match with_map.remove("connection_profile") {
+                        Some(connection_profile_name) => Some(
+                            schema_provider
+                                .profiles
+                                .get(&connection_profile_name)
+                                .ok_or_else(|| {
+                                    anyhow!(
+                                        "connection profile '{}' not found",
+                                        connection_profile_name
+                                    )
+                                })?,
+                        ),
+                        None => None,
+                    };
+                    Ok(Some(Table::ConnectorTable(
+                        ConnectorTable::from_options(
+                            &name,
+                            connector,
+                            fields,
+                            &mut with_map,
+                            connection_profile,
+                        )
                         .map_err(|e| anyhow!("Failed to construct table '{}': {:?}", name, e))?,
-                ))),
+                    )))
+                }
             }
         } else {
             match &produce_optimized_plan(statement, schema_provider) {

--- a/build_dir/pipeline/Cargo.toml
+++ b/build_dir/pipeline/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 arrow = { workspace = true}
 arrow-array = { workspace = true}
 arroyo-types = { path = "../../arroyo-types" }
-arroyo-worker = { path = "../../arroyo-worker" }
+arroyo-worker = { path = "../../arroyo-worker" , features = ["kafka-sasl"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
This lets users specify the name of a saved connection profile via `connection_profile` key in WITH clause. I think we might want to also add a connection profiles view in the UI, as right now it is pretty hidden.