### PR TITLE
Fix main layout overflow issue

### DIFF
--- a/arroyo-console/src/App.tsx
+++ b/arroyo-console/src/App.tsx
@@ -103,7 +103,7 @@ function App() {
   const localUdfsContextValue = getLocalUdfsContextValue();
 
   let content = (
-    <GridItem className="main" area={'main'}>
+    <GridItem className="main" area={'main'} overflow={'auto'}>
       {<Outlet />}
     </GridItem>
   );


### PR DESCRIPTION
The create connection page was overflowing the main content container which meant the sidebar wasn't displaying when scrolling down.