### PR TITLE
Fix confusion around schema registry ids vs version

### DIFF
--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -24,7 +24,7 @@ use arroyo_rpc::api_types::{ConnectionTableCollection, PaginationQueryParams};
 use arroyo_rpc::formats::{AvroFormat, Format, JsonFormat};
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_rpc::schema_resolver::{
-    ConfluentSchemaRegistry, ConfluentSchemaResponse, ConfluentSchemaType,
+    ConfluentSchemaRegistry, ConfluentSchemaSubjectResponse, ConfluentSchemaType,
 };
 use arroyo_sql::avro;
 use arroyo_sql::json_schema::convert_json_schema;
@@ -539,7 +539,7 @@ async fn get_schema(
     connector: &str,
     table_config: &Value,
     profile_config: &Value,
-) -> Result<ConfluentSchemaResponse, ErrorResp> {
+) -> Result<ConfluentSchemaSubjectResponse, ErrorResp> {
     if connector != "kafka" {
         return Err(bad_request(
             "confluent schema registry can only be used for Kafka connections",
@@ -573,7 +573,7 @@ async fn get_schema(
                 ))
             })?;
 
-    resolver.get_schema(None).await.map_err(|e| {
+    resolver.get_schema_for_version(None).await.map_err(|e| {
         bad_request(format!(
             "failed to fetch schemas from schema repository: {}",
             e

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -186,17 +186,18 @@ async fn try_register_confluent_schema(
 
     match config.format.clone() {
         Some(Format::Avro(mut avro)) => {
-            if avro.confluent_schema_registry && avro.schema_version.is_none() {
+            if avro.confluent_schema_registry && avro.schema_id.is_none() {
                 let fields: Vec<Field> = schema.fields.iter().map(|f| f.clone().into()).collect();
 
                 let schema = arrow_to_avro_schema(&schema.struct_name_ident(), &fields.into());
 
-                let version = schema_registry
+                let id = schema_registry
                     .write_schema(schema.canonical_form(), ConfluentSchemaType::Avro)
                     .await
                     .map_err(|e| anyhow!("Failed to write schema to schema registry: {}", e))?;
 
-                avro.schema_version = Some(version as u32);
+                println!("Fetched id = {}", id);
+                avro.schema_id = Some(id as u32);
                 config.format = Some(Format::Avro(avro))
             }
         }
@@ -209,6 +210,8 @@ async fn try_register_confluent_schema(
     }
 
     sink.config = serde_json::to_string(&config).unwrap();
+
+    println!("config = {}", sink.config);
 
     Ok(())
 }

--- a/arroyo-formats/src/avro.rs
+++ b/arroyo-formats/src/avro.rs
@@ -97,7 +97,7 @@ pub fn to_vec<T: SchemaData>(
     record: &T,
     format: &AvroFormat,
     schema: &Schema,
-    version: Option<i32>,
+    version: Option<u32>,
 ) -> Vec<u8> {
     let v = record.to_avro(schema);
 
@@ -705,7 +705,7 @@ mod tests {
             raw_datums: false,
             into_unstructured_json: false,
             reader_schema: None,
-            schema_version: None,
+            schema_id: None,
         };
 
         let schema = arrow_to_avro_schema("ArroyoAvroRoot", &ArroyoAvroRoot::schema().fields());

--- a/arroyo-formats/src/lib.rs
+++ b/arroyo-formats/src/lib.rs
@@ -344,7 +344,7 @@ pub struct DataSerializer<T: SchemaData> {
     #[allow(unused)]
     json_schema: Value,
     avro_schema: apache_avro::schema::Schema,
-    schema_id: Option<i32>,
+    schema_id: Option<u32>,
     format: Format,
     _t: PhantomData<T>,
 }
@@ -355,8 +355,11 @@ impl<T: SchemaData> DataSerializer<T> {
             kafka_schema: json::arrow_to_kafka_json(T::name(), T::schema().fields()),
             json_schema: json::arrow_to_json_schema(T::schema().fields()),
             avro_schema: avro::arrow_to_avro_schema(T::name(), T::schema().fields()),
+            schema_id: match &format {
+                Format::Avro(avro) => avro.schema_id,
+                _ => None,
+            },
             format,
-            schema_id: Some(1),
             _t: PhantomData,
         }
     }

--- a/arroyo-rpc/src/formats.rs
+++ b/arroyo-rpc/src/formats.rs
@@ -178,7 +178,7 @@ pub struct AvroFormat {
 
     #[serde(default)]
     #[schema(read_only)]
-    pub schema_version: Option<u32>,
+    pub schema_id: Option<u32>,
 }
 
 impl AvroFormat {
@@ -192,7 +192,7 @@ impl AvroFormat {
             raw_datums,
             into_unstructured_json,
             reader_schema: None,
-            schema_version: None,
+            schema_id: None,
         }
     }
 


### PR DESCRIPTION
Fixes some confusion around schema registry ids vs. versions, where we would incorrectly treat an id as a version and fail to fetch the schema from the registry.