### PR TITLE
Show job failure message on preview page

### DIFF
--- a/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
+++ b/arroyo-console/src/routes/pipelines/CreatePipeline.tsx
@@ -575,7 +575,7 @@ export function CreatePipeline() {
   } else {
     errorsTab = (
       <TabPanel overflowX="auto" height="100%" position="relative">
-        <Text>Compilation and job errors will appear here.</Text>
+        <Text>Job errors will appear here.</Text>
       </TabPanel>
     );
   }
@@ -608,7 +608,7 @@ export function CreatePipeline() {
   } else if (udfValidationApiError) {
     errorMessage = formatError(udfValidationApiError);
   } else if (job?.state == 'Failed') {
-    errorMessage = 'Job failed. See "Errors" tab for more details.';
+    errorMessage = job.failureMessage ?? 'Job failed.';
   } else {
     errorMessage = '';
   }

--- a/arroyo-controller/src/states/compiling.rs
+++ b/arroyo-controller/src/states/compiling.rs
@@ -42,7 +42,7 @@ impl State for Compiling {
         });
         loop {
             tokio::select! {
-                val = &mut rx => match val.map_err(|err| fatal("could not compile", err.into()))? {
+                val = &mut rx => match val.map_err(|err| fatal("Could not compile", err.into()))? {
                     Ok(res) => {
                         ctx.status.pipeline_path = Some(res.pipeline_path);
                         ctx.status.wasm_path = Some(res.wasm_path);

--- a/arroyo-controller/src/states/running.rs
+++ b/arroyo-controller/src/states/running.rs
@@ -113,7 +113,7 @@ impl State for Running {
                             error!(message = "error while running", error = format!("{:?}", err), job_id = ctx.config.id);
                             if ctx.status.restarts >= RESTARTS_ALLOWED as i32 {
                                 return Err(fatal(
-                                    "too many job failures",
+                                    "Job has restarted too many times",
                                     err
                                 ));
                             }

--- a/arroyo-controller/src/states/scheduling.rs
+++ b/arroyo-controller/src/states/scheduling.rs
@@ -187,7 +187,7 @@ impl Scheduling {
                     );
                     if start.elapsed() > STARTUP_TIME {
                         return Err(fatal(
-                            "could not get enough slots",
+                            "Not enough slots to schedule job",
                             anyhow!("scheduler error -- needed {} slots", slots_needed),
                         ));
                     }


### PR DESCRIPTION
The existing error message is misleading because the Errors tab only shows user errors, not compilation errors.

---

Now it shows this for compilation errors:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/c224ef2a-284f-470f-a75c-03e7b68e84cc)
