### PR TITLE
Bump versions to 0.9.0-dev in preparation for 0.9 dev cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "bollard",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-api"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-compiler-service"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-rpc",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-connectors"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-datastream",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-controller"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arrow-schema",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-datastream"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-macro",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-formats"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-macro"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-metrics"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arroyo-types",
  "prometheus",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-node"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-rpc",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-openapi"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arroyo-api",
  "reqwest",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-rpc"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-server-common"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arroyo-types",
  "axum",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-sql"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-sql-macro"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-sql-testing"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-state"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-storage"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arroyo-types",
  "async-trait",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-types"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-worker"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "copy-artifacts"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "arroyo-storage",
  "regex",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "integ"
-version = "0.8.0"
+version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-openapi",

--- a/arroyo-api/Cargo.toml
+++ b/arroyo-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-api"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/arroyo-compiler-service/Cargo.toml
+++ b/arroyo-compiler-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-compiler-service"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-connectors"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [features]

--- a/arroyo-controller/Cargo.toml
+++ b/arroyo-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-controller"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [features]

--- a/arroyo-datastream/Cargo.toml
+++ b/arroyo-datastream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-datastream"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 

--- a/arroyo-formats/Cargo.toml
+++ b/arroyo-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-formats"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-macro/Cargo.toml
+++ b/arroyo-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-macro"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [lib]

--- a/arroyo-metrics/Cargo.toml
+++ b/arroyo-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-metrics"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-node/Cargo.toml
+++ b/arroyo-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-node"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-openapi/Cargo.toml
+++ b/arroyo-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-openapi"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-rpc"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/arroyo-server-common/Cargo.toml
+++ b/arroyo-server-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-server-common"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-server-common/src/lib.rs
+++ b/arroyo-server-common/src/lib.rs
@@ -38,7 +38,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 
 pub const BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
 pub const GIT_SHA: &str = env!("VERGEN_GIT_SHA");
-pub const VERSION: &str = "0.8.0";
+pub const VERSION: &str = "0.9.0-dev";
 
 #[cfg(not(target_os = "freebsd"))]
 const PYROSCOPE_SERVER_ADDRESS_ENV: &str = "PYROSCOPE_SERVER_ADDRESS";

--- a/arroyo-sql-macro/Cargo.toml
+++ b/arroyo-sql-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql-macro"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [lib]

--- a/arroyo-sql-testing/Cargo.toml
+++ b/arroyo-sql-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql-testing"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [features]

--- a/arroyo-sql/Cargo.toml
+++ b/arroyo-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-sql"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 

--- a/arroyo-state/Cargo.toml
+++ b/arroyo-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-state"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/arroyo-storage/Cargo.toml
+++ b/arroyo-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-storage"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/arroyo-types/Cargo.toml
+++ b/arroyo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-types"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-worker"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [features]

--- a/arroyo/Cargo.toml
+++ b/arroyo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 authors = ["Arroyo Systems <support@arroyo.systems>"]

--- a/copy-artifacts/Cargo.toml
+++ b/copy-artifacts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copy-artifacts"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/integ/Cargo.toml
+++ b/integ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integ"
-version = "0.8.0"
+version = "0.9.0-dev"
 edition = "2021"
 
 [dependencies]

--- a/k8s/arroyo/Chart.yaml
+++ b/k8s/arroyo/Chart.yaml
@@ -3,8 +3,8 @@ name: arroyo
 description: Helm chart for the Arroyo stream processing engine
 
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.9.0-dev
+appVersion: "0.9.0-dev"
 
 keywords:
   - stream-processing

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -15,7 +15,7 @@ api:
   image:
     repository: ghcr.io/arroyosystems/arroyo-services
     pullPolicy: IfNotPresent
-    tag: "0.8.0"
+    tag: "tip"
   service:
     type: ClusterIP
     httpPort: 80
@@ -31,7 +31,7 @@ controller:
   image:
     repository: ghcr.io/arroyosystems/arroyo-services
     pullPolicy: IfNotPresent
-    tag: "0.8.0"
+    tag: "tip"
   service:
     grpcPort: 9190
     adminPort: 9191
@@ -46,7 +46,7 @@ compiler:
   image:
     repository: ghcr.io/arroyosystems/arroyo-compiler
     pullPolicy: IfNotPresent
-    tag: "0.8.0"
+    tag: "tip"
   service:
     grpcPort: 9000
     adminPort: 9001
@@ -61,7 +61,7 @@ worker:
   image:
     repository: ghcr.io/arroyosystems/arroyo-worker
     pullPolicy: IfNotPresent
-    tag: "0.8.0"
+    tag: "tip"
 
 postgresql:
   # set to true to deploy a postgres instance in-cluster


### PR DESCRIPTION
This PR bumps versions across Arroyo to 0.9-dev, in preparation for the 0.9 dev cycle.