### PR TITLE
Support environment variable substitution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6370,14 +6370,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6391,13 +6391,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6417,6 +6417,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "regress"

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -331,7 +331,7 @@ pub(crate) fn nullable_field(name: &str, field_type: SourceFieldType) -> SourceF
     }
 }
 
-fn construct_http_client(endpoint: &str, headers: Option<&String>) -> anyhow::Result<Client> {
+fn construct_http_client(endpoint: &str, headers: Option<String>) -> anyhow::Result<Client> {
     if let Err(e) = reqwest::Url::parse(&endpoint) {
         bail!("invalid endpoint '{}': {:?}", endpoint, e)
     };

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -635,6 +635,7 @@ export function JsonForm({
 }) {
   let ajv = new Ajv();
   ajv.addKeyword('isSensitive');
+  ajv.addFormat('var-str', { validate: () => true });
   const memoAjv = useMemo(() => addFormats(ajv), [schema]);
 
   const formik = useFormik({

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api_types;
 pub mod formats;
 pub mod public_ids;
 pub mod schema_resolver;
+pub mod var_str;
 
 use std::collections::HashMap;
 use std::{fs, time::SystemTime};

--- a/arroyo-rpc/src/var_str.rs
+++ b/arroyo-rpc/src/var_str.rs
@@ -1,0 +1,113 @@
+use anyhow::bail;
+use regex::Regex;
+use serde::de::Visitor;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::sync::OnceLock;
+use std::{env, fmt};
+
+#[derive(Debug, Clone)]
+pub struct VarStr {
+    raw_val: String,
+}
+
+impl Serialize for VarStr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.raw_val)
+    }
+}
+
+struct VarStrVisitor;
+
+impl<'de> Visitor<'de> for VarStrVisitor {
+    type Value = VarStr;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(VarStr {
+            raw_val: value.to_owned(),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for VarStr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(VarStrVisitor)
+    }
+}
+
+impl VarStr {
+    pub fn new(raw_val: String) -> Self {
+        VarStr { raw_val }
+    }
+
+    pub fn sub_env_vars(&self) -> anyhow::Result<String> {
+        // Regex to match patterns like {{ VAR_NAME }}
+        static RE: OnceLock<Regex> = OnceLock::new();
+        let re = RE.get_or_init(|| Regex::new(r"\{\{\s*(\w+)\s*\}\}").unwrap());
+
+        let mut result = self.raw_val.to_string();
+
+        for caps in re.captures_iter(&self.raw_val) {
+            let var_name = caps.get(1).unwrap().as_str();
+            let full_match = caps.get(0).unwrap().as_str();
+
+            match env::var(var_name) {
+                Ok(value) => {
+                    result = result.replace(full_match, &value);
+                }
+                Err(_) => bail!("Environment variable {} not found", var_name),
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_placeholders() {
+        let input = "This is a test string with no placeholders";
+        assert_eq!(
+            VarStr::new(input.to_string()).sub_env_vars().unwrap(),
+            input
+        );
+    }
+
+    #[test]
+    fn test_with_placeholders() {
+        env::set_var("TEST_VAR", "environment variable");
+        let input = "This is a {{ TEST_VAR }}";
+        let expected = "This is a environment variable";
+        assert_eq!(
+            VarStr::new(input.to_string()).sub_env_vars().unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_multiple_placeholders() {
+        env::set_var("VAR1", "first");
+        env::set_var("VAR2", "second");
+        let input = "Here is the {{ VAR1 }} and here is the {{ VAR2 }}";
+        let expected = "Here is the first and here is the second";
+        assert_eq!(
+            VarStr::new(input.to_string()).sub_env_vars().unwrap(),
+            expected
+        );
+    }
+}

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -4,6 +4,7 @@ use bincode::{config, Decode, Encode};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::env;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -812,8 +813,6 @@ pub enum DateTruncPrecision {
     Minute,
     Second,
 }
-
-use std::convert::TryFrom;
 
 impl TryFrom<&str> for DatePart {
     type Error = String;

--- a/arroyo-worker/src/lib.rs
+++ b/arroyo-worker/src/lib.rs
@@ -17,8 +17,8 @@ use arroyo_rpc::grpc::{
 };
 use arroyo_server_common::start_admin_server;
 use arroyo_types::{
-    from_millis, grpc_port, ports, to_micros, CheckpointBarrier, NodeId, WorkerId, JOB_ID_ENV,
-    RUN_ID_ENV,
+    from_millis, grpc_port, ports, string_to_map, to_micros, CheckpointBarrier, NodeId, WorkerId,
+    JOB_ID_ENV, RUN_ID_ENV,
 };
 use lazy_static::lazy_static;
 use local_ip_address::local_ip;
@@ -44,6 +44,7 @@ pub use ordered_float::OrderedFloat;
 
 // re-export avro for use in generated code
 pub use apache_avro;
+use arroyo_rpc::var_str::VarStr;
 
 pub mod connectors;
 pub mod engine;
@@ -621,4 +622,13 @@ impl WorkerGrpc for WorkerServer {
 
         Ok(Response::new(JobFinishedResp {}))
     }
+}
+
+pub fn header_map(headers: Option<VarStr>) -> HashMap<String, String> {
+    string_to_map(
+        &headers
+            .map(|t| t.sub_env_vars().expect("Failed to substitute env vars"))
+            .unwrap_or("".to_string()),
+    )
+    .expect("Invalid header map")
 }

--- a/connector-schemas/kafka/connection.json
+++ b/connector-schemas/kafka/connection.json
@@ -45,8 +45,9 @@
                         },
                         "password": {
                             "type": "string",
-                            "description": "The password to use for SASL authentication",
-                            "isSensitive": true
+                            "description": "The password to use for SASL authentication. May be a [variable](https://doc.arroyo.dev/connectors/variables).",
+                            "isSensitive": true,
+                            "format": "var-str"
                         }
                     },
                     "additionalProperties": false
@@ -81,11 +82,12 @@
                         "apiSecret": {
                             "title": "API Secret",
                             "type": "string",
-                            "description": "Secret for your Confluent Schema Registry",
+                            "description": "Secret for your Confluent Schema Registry. May be a [variable](https://doc.arroyo.dev/connectors/variables).",
                             "isSensitive": true,
                             "examples": [
                                 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/="
-                            ]
+                            ],
+                            "format": "var-str"
                         }
                     },
                     "required": [

--- a/connector-schemas/polling_http/table.json
+++ b/connector-schemas/polling_http/table.json
@@ -12,9 +12,9 @@
     "headers": {
       "title": "Headers",
       "type": "string",
-      "description": "Comma separated list of headers to send with the request",
-      "pattern": "([a-zA-Z0-9-]+: ?.+,)*([a-zA-Z0-9-]+: ?.+)",
-      "examples": ["Authentication: digest 1234,Content-Type: application/json"]
+      "description": "Comma separated list of headers to send with the request. May contain [variables](https://doc.arroyo.dev/connectors/overview#variables).",
+      "examples": ["Authentication: digest 1234,Content-Type: application/json"],
+      "format": "var-str"
     },
     "method": {
       "title": "Method",
@@ -26,7 +26,9 @@
         "PUT",
         "PATCH"
       ],
-      "examples": ["GET"]
+      "examples": [
+        "GET"
+      ]
     },
     "body": {
       "title": "Body",
@@ -37,7 +39,9 @@
       "title": "Polling Interval (ms)",
       "type": "integer",
       "description": "Number of milliseconds to wait between successful polls of the HTTP endpoint",
-      "examples": ["1000"]
+      "examples": [
+        "1000"
+      ]
     },
     "emit_behavior": {
       "title": "Emit Behavior",

--- a/connector-schemas/sse/table.json
+++ b/connector-schemas/sse/table.json
@@ -12,9 +12,9 @@
         "headers": {
             "title": "Headers",
             "type": "string",
-            "description": "Comma separated list of headers to send with the request",
-            "pattern": "([a-zA-Z0-9-]+: ?.+,)*([a-zA-Z0-9-]+: ?.+)",
-            "examples": ["Authentication: digest 1234,Content-Type: application/json"]
+            "description": "Comma separated list of headers to send with the request. May contain [variables](https://doc.arroyo.dev/connectors/overview#variables).",
+            "examples": ["Authentication: digest 1234,Content-Type: application/json"],
+            "format": "var-str"
         },
         "events": {
             "title": "Events",

--- a/connector-schemas/webhook/table.json
+++ b/connector-schemas/webhook/table.json
@@ -14,12 +14,11 @@
         "headers": {
             "title": "Headers",
             "type": "string",
-            "maxLength": 2048,
-            "description": "Optional, comma separated list of headers to send with the webhook",
-            "pattern": "([a-zA-Z0-9-]+: ?.+,)*([a-zA-Z0-9-]+: ?.+)",
+            "description": "Optional, comma separated list of headers to send with the webhook. May contain [variables](https://doc.arroyo.dev/connectors/overview#variables).",
             "examples": [
                 "Authentication: Basic my-auth-secret,Content-Type: application/json"
-            ]
+            ],
+            "format": "var-str"
         }
     },
     "required": [

--- a/connector-schemas/websocket/table.json
+++ b/connector-schemas/websocket/table.json
@@ -14,9 +14,9 @@
         "headers": {
             "title": "Headers",
             "type": "string",
-            "description": "Comma separated list of headers to send with the request",
-            "pattern": "([a-zA-Z0-9-]+: ?.+,)*([a-zA-Z0-9-]+: ?.+)",
-            "examples": ["Authentication: digest 1234,Content-Type: application/json"]
+            "description": "Comma separated list of headers to send with the request. May contain [variables](https://doc.arroyo.dev/connectors/overview#variables).",
+            "examples": ["Authentication: digest 1234,Content-Type: application/json"],
+            "format": "var-str"
         },
         "subscription_message": {
             "title": "Subscription Message",


### PR DESCRIPTION
In the Kafka, Polling HTTP, WebSocket, and SSE sources, support environment variables in the passwords, secrets, and headers fields.

This is done by setting the `format` of the field in the JSON schema to `var-str`, which tells typify to replace the type with the `VarStr` struct, which has a function for substituting environment variables. The `VarStr` struct serializes/deserializes from a JSON string.

---

![Screenshot 2023-11-30 at 1 21 44 PM](https://github.com/ArroyoSystems/arroyo/assets/8881183/5f3bd3c4-53fb-4bd5-8718-c8009271801d)

If the variable is needed for testing the connection and it's missing, it'll look like this:

![Screenshot 2023-11-30 at 1 22 06 PM](https://github.com/ArroyoSystems/arroyo/assets/8881183/65e240cc-973c-4942-ac45-9dc8d26f6f7c)

And in SQL it looks like this:

![image](https://github.com/ArroyoSystems/arroyo/assets/8881183/29e5be1c-8316-4d56-a04c-78ea2b4d77d6)
