### PR TITLE
Switch rust builds to ubicloud runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: ruby docker/check_dockerfiles.rb
 
   build-rust:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubicloud-standard-16
     env:
       DATABASE_URL: "postgres://arroyo:arroyo@localhost:5432/arroyo"
       DATABASE_USER: arroyo


### PR DESCRIPTION
This is a 10x cost savings over github's runners