### PR TITLE
Fix issues with enums in json form

### DIFF
--- a/connector-schemas/kafka/connection.json
+++ b/connector-schemas/kafka/connection.json
@@ -63,6 +63,13 @@
             "oneOf": [
                 {
                     "type": "object",
+                    "title": "None",
+                    "properties": {
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
                     "title": "Confluent Schema Registry",
                     "properties": {
                         "endpoint": {
@@ -99,13 +106,6 @@
                     "sensitive": [
                         "apiSecret"
                     ]
-                },
-                {
-                    "type": "object",
-                    "title": "None",
-                    "properties": {
-                    },
-                    "additionalProperties": false
                 }
             ]
         }

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -28,8 +28,8 @@
                             "title": "read mode",
                             "description": "Controls whether the source will wait for messages to be committed; use `read_committed` for transactional sources.",
                             "enum": [
-                                "read_committed",
-                                "read_uncommitted"
+                                "read_uncommitted",
+                                "read_committed"
                             ]
                         },
                         "group_id": {

--- a/connector-schemas/redis/table.json
+++ b/connector-schemas/redis/table.json
@@ -68,8 +68,8 @@
                                             "title": "List Operation",
                                             "description": "How values are pushed onto the list",
                                             "enum": [
-                                                "Prepend",
-                                                "Append"
+                                                "Append",
+                                                "Prepend"
                                             ]
                                         }
                                     },


### PR DESCRIPTION
Formik was not properly setting the values when switching between JSON shema 'oneof' variants. This adds a call to reset the field when switching variants.

This change also removes the option of leaving optional enums as null, and instead defaults it to the 'default_value' (for string enums if defined), or the first oneof variant.


For example:

<img width="749" alt="image" src="https://github.com/ArroyoSystems/arroyo/assets/8881183/c2e7c942-8d67-4db8-8758-65cd8cf7b32f">
