### PR TITLE
Fix: incorrect redis url regex pattern

### DIFF
--- a/connector-schemas/redis/connection.json
+++ b/connector-schemas/redis/connection.json
@@ -13,7 +13,7 @@
                             "type": "string",
                             "description": "The address of your Redis server",
                             "examples": ["redis://localhost:6379"],
-                            "pattern": "^redis://[a-zA-Z0-9.]+:[0-9]+$"
+                            "pattern": "^redis://.*$"
                         }
                     },
                     "additionalProperties": false,
@@ -36,7 +36,7 @@
                                 "type": "string",
                                 "title": "Address",
                                 "examples": ["redis://localhost:6379"],
-                                "pattern": "^redis://[a-zA-Z0-9.]+:[0-9]+$"
+                                "pattern": "^redis://.*$"
                             }
                         }
                     },


### PR DESCRIPTION
The url `redis://redis-22.c21.ap-southeast-2-1.ec2.cloud.redislabs.com:11682` is not valid when adding a redis connection.

This PR changes the regex to only ensure the url starts with `redis://`.

![Screen Shot 2023-12-18 at 19 24 43](https://github.com/ArroyoSystems/arroyo/assets/16362377/e97b33e1-6320-47c1-a8e6-8ca0f11df5e1)
