### PR TITLE
Add autocomplete when creating connections and Kafka topic autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "typify",
- "utoipa",
+ "utoipa 3.5.0",
+ "utoipa 4.1.0",
  "utoipa-swagger-ui",
  "uuid",
 ]
@@ -638,7 +639,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "utoipa",
+ "utoipa 3.5.0",
 ]
 
 [[package]]
@@ -690,7 +691,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "url",
- "utoipa",
+ "utoipa 4.1.0",
 ]
 
 [[package]]
@@ -714,7 +715,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "utoipa",
+ "utoipa 4.1.0",
 ]
 
 [[package]]
@@ -2927,20 +2928,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2951,17 +2943,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -3296,7 +3277,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "derive_builder",
- "dirs 5.0.1",
+ "dirs",
  "event-listener 3.0.0",
  "fluvio-compression",
  "fluvio-future",
@@ -6745,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+checksum = "810294a8a4a0853d4118e3b94bb079905f2107c7fe979d8f0faae98765eb6378"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6756,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.8.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+checksum = "bfc144a1273124a67b8c1d7cd19f5695d1878b31569c0512f6086f0f4676604e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6770,9 +6751,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.8.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+checksum = "816ccd4875431253d6bb54b804bcff4369cbde9bae33defde25fdf6c2ef91d40"
 dependencies = [
  "sha2 0.10.7",
  "walkdir",
@@ -7332,11 +7313,11 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "2.1.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs 4.0.0",
+ "dirs",
 ]
 
 [[package]]
@@ -8592,7 +8573,19 @@ dependencies = [
  "indexmap 2.0.0",
  "serde",
  "serde_json",
- "utoipa-gen",
+ "utoipa-gen 3.5.0",
+]
+
+[[package]]
+name = "utoipa"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen 4.1.0",
 ]
 
 [[package]]
@@ -8608,10 +8601,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-swagger-ui"
-version = "3.1.5"
+name = "utoipa-gen"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84614caa239fb25b2bb373a52859ffd94605ceb256eeb1d63436325cf81e3653"
+checksum = "5f0b6f4667edd64be0e820d6631a60433a269710b6ee89ac39525b872b76d61d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
 dependencies = [
  "axum",
  "mime_guess",
@@ -8619,7 +8624,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "utoipa",
+ "utoipa 4.1.0",
  "zip",
 ]
 

--- a/arroyo-api/Cargo.toml
+++ b/arroyo-api/Cargo.toml
@@ -42,8 +42,8 @@ tower-http = {version = "0.4", features = ["trace", "fs", "cors", "validate-requ
 axum = {version = "0.6.12", features = ["headers", "tokio", "macros"]}
 axum-extra = "0.7.4"
 thiserror = "1.0.40"
-utoipa = "3"
-utoipa-swagger-ui = { version = "3", features = ["axum"] }
+utoipa = "4"
+utoipa-swagger-ui = { version = "4", features = ["axum"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/arroyo-api/src/connection_profiles.rs
+++ b/arroyo-api/src/connection_profiles.rs
@@ -1,10 +1,12 @@
-use std::collections::BTreeMap;
 use axum::extract::{Path, State};
 use axum::Json;
 use axum_extra::extract::WithRejection;
+use std::collections::BTreeMap;
 
 use arroyo_connectors::connector_for_type;
-use arroyo_rpc::api_types::connections::{ConnectionAutocompleteResp, ConnectionProfile, ConnectionProfilePost, TestSourceMessage};
+use arroyo_rpc::api_types::connections::{
+    ConnectionAutocompleteResp, ConnectionProfile, ConnectionProfilePost, TestSourceMessage,
+};
 use arroyo_rpc::api_types::ConnectionProfileCollection;
 use cornucopia_async::GenericClient;
 use tracing::warn;
@@ -209,14 +211,15 @@ pub(crate) async fn get_connection_profile_autocomplete(
 
     let connector = connector_for_type(&connection_profile.r#type).unwrap();
 
-    let result = connector.get_autocomplete(&connection_profile.config).unwrap()
+    let result = connector
+        .get_autocomplete(&connection_profile.config)
+        .unwrap()
         .await
         .map_err(log_and_map)?
         .map_err(|e| bad_request(format!("Failed to get autocomplete suggestions: {}", e)))?;
 
-
     Ok(Json(ConnectionAutocompleteResp {
-        values: BTreeMap::from_iter(result.into_iter())
+        values: BTreeMap::from_iter(result.into_iter()),
     }))
 }
 

--- a/arroyo-api/src/lib.rs
+++ b/arroyo-api/src/lib.rs
@@ -7,6 +7,7 @@ use utoipa::OpenApi;
 use crate::connection_profiles::{
     __path_create_connection_profile, __path_delete_connection_profile,
     __path_get_connection_profiles, __path_test_connection_profile,
+    __path_get_connection_profile_autocomplete
 };
 use crate::connection_tables::{
     __path_create_connection_table, __path_delete_connection_table, __path_get_connection_tables,
@@ -148,6 +149,7 @@ pub(crate) fn to_micros(dt: OffsetDateTime) -> u64 {
         get_connection_profiles,
         test_connection_profile,
         delete_connection_profile,
+        get_connection_profile_autocomplete,
         get_connection_tables,
         create_connection_table,
         create_connection_profile,
@@ -186,6 +188,7 @@ pub(crate) fn to_micros(dt: OffsetDateTime) -> u64 {
         Connector,
         ConnectionProfile,
         ConnectionProfilePost,
+        ConnectionAutocompleteResp,
         ConnectionProfileCollection,
         ConnectionTable,
         ConnectionTablePost,

--- a/arroyo-api/src/lib.rs
+++ b/arroyo-api/src/lib.rs
@@ -6,8 +6,8 @@ use utoipa::OpenApi;
 
 use crate::connection_profiles::{
     __path_create_connection_profile, __path_delete_connection_profile,
-    __path_get_connection_profiles, __path_test_connection_profile,
-    __path_get_connection_profile_autocomplete
+    __path_get_connection_profile_autocomplete, __path_get_connection_profiles,
+    __path_test_connection_profile,
 };
 use crate::connection_tables::{
     __path_create_connection_table, __path_delete_connection_table, __path_get_connection_tables,

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -17,7 +17,10 @@ use tower_http::services::ServeDir;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::connection_profiles::{create_connection_profile, delete_connection_profile, get_connection_profile_autocomplete, get_connection_profiles, test_connection_profile};
+use crate::connection_profiles::{
+    create_connection_profile, delete_connection_profile, get_connection_profile_autocomplete,
+    get_connection_profiles, test_connection_profile,
+};
 use crate::connection_tables::{
     create_connection_table, delete_connection_table, get_connection_tables, test_connection_table,
     test_schema,
@@ -114,7 +117,10 @@ pub fn create_rest_app(pool: Pool, controller_addr: &str) -> Router {
             "/connection_profiles/:id",
             delete(delete_connection_profile),
         )
-        .route("/connection_profiles/:id/autocomplete", get(get_connection_profile_autocomplete))
+        .route(
+            "/connection_profiles/:id/autocomplete",
+            get(get_connection_profile_autocomplete),
+        )
         .route("/connection_tables", get(get_connection_tables))
         .route("/connection_tables", post(create_connection_table))
         .route("/connection_tables/test", post(test_connection_table))

--- a/arroyo-api/src/rest.rs
+++ b/arroyo-api/src/rest.rs
@@ -17,10 +17,7 @@ use tower_http::services::ServeDir;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::connection_profiles::{
-    create_connection_profile, delete_connection_profile, get_connection_profiles,
-    test_connection_profile,
-};
+use crate::connection_profiles::{create_connection_profile, delete_connection_profile, get_connection_profile_autocomplete, get_connection_profiles, test_connection_profile};
 use crate::connection_tables::{
     create_connection_table, delete_connection_table, get_connection_tables, test_connection_table,
     test_schema,
@@ -117,6 +114,7 @@ pub fn create_rest_app(pool: Pool, controller_addr: &str) -> Router {
             "/connection_profiles/:id",
             delete(delete_connection_profile),
         )
+        .route("/connection_profiles/:id/autocomplete", get(get_connection_profile_autocomplete))
         .route("/connection_tables", get(get_connection_tables))
         .route("/connection_tables", post(create_connection_table))
         .route("/connection_tables/test", post(test_connection_table))

--- a/arroyo-connectors/src/confluent.rs
+++ b/arroyo-connectors/src/confluent.rs
@@ -123,7 +123,10 @@ impl Connector for ConfluentConnector {
         }
     }
 
-    fn get_autocomplete(&self, profile: Self::ProfileT) -> Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
+    fn get_autocomplete(
+        &self,
+        profile: Self::ProfileT,
+    ) -> Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
         let profile = profile.into();
         KafkaConnector {}.get_autocomplete(profile)
     }

--- a/arroyo-connectors/src/confluent.rs
+++ b/arroyo-connectors/src/confluent.rs
@@ -123,6 +123,11 @@ impl Connector for ConfluentConnector {
         }
     }
 
+    fn get_autocomplete(&self, profile: Self::ProfileT) -> Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
+        let profile = profile.into();
+        KafkaConnector {}.get_autocomplete(profile)
+    }
+
     fn test(
         &self,
         _: &str,

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::time::{Duration, Instant};
+use futures::TryFutureExt;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
 use tonic::Status;
 use tracing::{error, info, warn};
@@ -196,6 +198,26 @@ impl Connector for KafkaConnector {
         })
     }
 
+    fn get_autocomplete(&self, profile: Self::ProfileT) -> oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
+        let (tx, rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let kafka = KafkaTester {
+                connection: profile,
+            };
+
+            tx.send(kafka.fetch_topics().await
+                .map_err(|e| anyhow!("Failed to fetch topics from Kafka: {:?}", e))
+                .map(|topics| {
+                    let mut map = HashMap::new();
+                    map.insert("topic".to_string(), topics.into_iter().map(|(name, _)| name).collect());
+                    map
+                })).unwrap();
+        });
+
+        rx
+    }
+
     fn test_profile(&self, profile: Self::ProfileT) -> Option<Receiver<TestSourceMessage>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -304,47 +326,65 @@ impl KafkaTester {
 
         let client: BaseConsumer = client_config
             .create()
-            .map_err(|e| format!("Failed to connect: {:?}", e))?;
+            .map_err(|e| format!("invalid kafka config: {:?}", e))?;
 
-        client
-            .fetch_metadata(None, Duration::from_secs(10))
-            .map_err(|e| format!("Failed to connect to Kafka: {:?}", e))?;
+        tokio::task::spawn_blocking(move || {
+            client
+                .fetch_metadata(None, Duration::from_secs(10))
+                .map_err(|e| format!("Failed to connect to Kafka: {:?}", e))?;
 
-        Ok(client)
+            Ok(client)
+        }).await.map_err(|_| "unexpected error while connecting to kafka")?
     }
 
     #[allow(unused)]
     pub async fn topic_metadata(&self, topic: &str) -> Result<TopicMetadata, Status> {
         let client = self.connect().await.map_err(Status::failed_precondition)?;
-        let metadata = client
-            .fetch_metadata(Some(&topic), Duration::from_secs(5))
-            .map_err(|e| {
-                Status::failed_precondition(format!(
-                    "Failed to read topic metadata from Kafka: {:?}",
-                    e
-                ))
+
+        let topic = topic.to_string();
+        tokio::task::spawn_blocking(move || {
+            let metadata = client
+                .fetch_metadata(Some(&topic), Duration::from_secs(5))
+                .map_err(|e| {
+                    Status::failed_precondition(format!(
+                        "Failed to read topic metadata from Kafka: {:?}",
+                        e
+                    ))
+                })?;
+
+            let topic_metadata = metadata.topics().iter().next().ok_or_else(|| {
+                Status::failed_precondition("Metadata response from broker did not include topic")
             })?;
 
-        let topic_metadata = metadata.topics().iter().next().ok_or_else(|| {
-            Status::failed_precondition("Metadata response from broker did not include topic")
-        })?;
+            if let Some(e) = topic_metadata.error() {
+                let err = match e {
+                    rdkafka::types::RDKafkaRespErr::RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED => {
+                        "Not authorized to access topic".to_string()
+                    }
+                    rdkafka::types::RDKafkaRespErr::RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART => {
+                        "Topic does not exist".to_string()
+                    }
+                    _ => format!("Error while fetching topic metadata: {:?}", e),
+                };
+                return Err(Status::failed_precondition(err));
+            }
 
-        if let Some(e) = topic_metadata.error() {
-            let err = match e {
-                rdkafka::types::RDKafkaRespErr::RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED => {
-                    "Not authorized to access topic".to_string()
-                }
-                rdkafka::types::RDKafkaRespErr::RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART => {
-                    "Topic does not exist".to_string()
-                }
-                _ => format!("Error while fetching topic metadata: {:?}", e),
-            };
-            return Err(Status::failed_precondition(err));
-        }
+            Ok(TopicMetadata {
+                partitions: topic_metadata.partitions().len(),
+            })
+        }).map_err(|_| Status::internal("unexpected error while fetching topic metadata")).await?
+    }
 
-        Ok(TopicMetadata {
-            partitions: topic_metadata.partitions().len(),
-        })
+    async fn fetch_topics(&self) -> anyhow::Result<Vec<(String, usize)>> {
+        let client = self.connect().await.map_err(|e| anyhow!("{}", e))?;
+
+        tokio::task::spawn_blocking(move || {
+            let metadata = client
+                .fetch_metadata(None, Duration::from_secs(5))
+                .map_err(|e| anyhow!("Failed to read topic metadata from Kafka: {:?}", e))?;
+
+            Ok(metadata.topics().iter().map(|t| (t.name().to_string(), t.partitions().len())).collect())
+        }).await.map_err(|_| anyhow!("unexpected error while fetching topic metadata"))?
     }
 
     pub async fn test_schema_registry(&self) -> anyhow::Result<()> {

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -218,7 +218,11 @@ impl Connector for KafkaConnector {
                         let mut map = HashMap::new();
                         map.insert(
                             "topic".to_string(),
-                            topics.into_iter().map(|(name, _)| name).collect(),
+                            topics
+                                .into_iter()
+                                .map(|(name, _)| name)
+                                .filter(|name| !name.starts_with("_"))
+                                .collect(),
                         );
                         map
                     }),

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -13,11 +13,11 @@ use nexmark::NexmarkConnector;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
 use sse::SSEConnector;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::time::Duration;
-use serde_json::Value;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tracing::warn;
@@ -121,7 +121,10 @@ pub trait Connector: Send {
     }
 
     #[allow(unused)]
-    fn get_autocomplete(&self, profile: Self::ProfileT) -> oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
+    fn get_autocomplete(
+        &self,
+        profile: Self::ProfileT,
+    ) -> oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
         let (tx, rx) = oneshot::channel();
         tx.send(Ok(HashMap::new())).unwrap();
         rx
@@ -181,7 +184,10 @@ pub trait ErasedConnector: Send {
     /// Returns a map of autocomplete values from key names (with paths separated by dots) to values that should
     /// be used to autocomplete them.
     #[allow(unused)]
-    fn get_autocomplete(&self, profile: &serde_json::Value) ->Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error>;
+    fn get_autocomplete(
+        &self,
+        profile: &serde_json::Value,
+    ) -> Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error>;
 
     fn test_profile(
         &self,
@@ -255,7 +261,11 @@ impl<C: Connector> ErasedConnector for C {
         Ok(self.get_schema(self.parse_config(config)?, self.parse_table(table)?, schema))
     }
 
-    fn get_autocomplete(&self, profile: &Value) -> Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error> {
+    fn get_autocomplete(
+        &self,
+        profile: &Value,
+    ) -> Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error>
+    {
         Ok(self.get_autocomplete(self.parse_config(profile)?))
     }
 

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -17,7 +17,9 @@ use sse::SSEConnector;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::time::Duration;
+use serde_json::Value;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 use tracing::warn;
 use websocket::WebsocketConnector;
 
@@ -118,6 +120,13 @@ pub trait Connector: Send {
         None
     }
 
+    #[allow(unused)]
+    fn get_autocomplete(&self, profile: Self::ProfileT) -> oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>> {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(HashMap::new())).unwrap();
+        rx
+    }
+
     fn test(
         &self,
         name: &str,
@@ -169,10 +178,15 @@ pub trait ErasedConnector: Send {
         schema: Option<&ConnectionSchema>,
     ) -> Result<Option<ConnectionSchema>, serde_json::Error>;
 
+    /// Returns a map of autocomplete values from key names (with paths separated by dots) to values that should
+    /// be used to autocomplete them.
+    #[allow(unused)]
+    fn get_autocomplete(&self, profile: &serde_json::Value) ->Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error>;
+
     fn test_profile(
         &self,
         profile: &serde_json::Value,
-    ) -> Result<Option<tokio::sync::oneshot::Receiver<TestSourceMessage>>, serde_json::Error>;
+    ) -> Result<Option<oneshot::Receiver<TestSourceMessage>>, serde_json::Error>;
 
     fn test(
         &self,
@@ -239,6 +253,10 @@ impl<C: Connector> ErasedConnector for C {
         schema: Option<&ConnectionSchema>,
     ) -> Result<Option<ConnectionSchema>, serde_json::Error> {
         Ok(self.get_schema(self.parse_config(config)?, self.parse_table(table)?, schema))
+    }
+
+    fn get_autocomplete(&self, profile: &Value) -> Result<oneshot::Receiver<anyhow::Result<HashMap<String, Vec<String>>>>, serde_json::Error> {
+        Ok(self.get_autocomplete(self.parse_config(profile)?))
     }
 
     fn test_profile(

--- a/arroyo-console/package.json
+++ b/arroyo-console/package.json
@@ -36,6 +36,7 @@
     "ajv-formats": "^2.1.1",
     "d3": "^7.8.5",
     "dagre": "^0.8.5",
+    "downshift": "^8.2.3",
     "formik": "^2.4.2",
     "framer-motion": "^7.10.3",
     "lodash": "^4.17.21",

--- a/arroyo-console/pnpm-lock.yaml
+++ b/arroyo-console/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   dagre:
     specifier: ^0.8.5
     version: 0.8.5
+  downshift:
+    specifier: ^8.2.3
+    version: 8.2.3(react@18.2.0)
   formik:
     specifier: ^2.4.2
     version: 2.4.2(react@18.2.0)
@@ -3410,6 +3413,10 @@ packages:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
     dev: false
 
+  /compute-scroll-into-view@3.1.0:
+    resolution: {integrity: sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==}
+    dev: false
+
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -3803,6 +3810,19 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.1
       csstype: 3.1.2
+    dev: false
+
+  /downshift@8.2.3(react@18.2.0):
+    resolution: {integrity: sha512-1HkvqaMTZpk24aqnXaRDnT+N5JCbpFpW+dCogB11+x+FCtfkFX0MbAO4vr/JdXi1VYQF174KjNUveBXqaXTPtg==}
+    peerDependencies:
+      react: '>=16.12.0'
+    dependencies:
+      '@babel/runtime': 7.23.6
+      compute-scroll-into-view: 3.1.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 18.2.0
+      tslib: 2.6.2
     dev: false
 
   /dt-sql-parser@4.0.0-beta.4:
@@ -5999,6 +6019,10 @@ packages:
 
   /tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
+    dev: false
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
   /tsutils@3.21.0(typescript@4.9.5):

--- a/arroyo-console/src/gen/api-types.ts
+++ b/arroyo-console/src/gen/api-types.ts
@@ -36,6 +36,13 @@ export interface paths {
      */
     delete: operations["delete_connection_profile"];
   };
+  "/v1/connection_profiles/{id}/autocomplete": {
+    /**
+     * Get autocomplete suggestions for a connection profile 
+     * @description Get autocomplete suggestions for a connection profile
+     */
+    get: operations["get_connection_profile_autocomplete"];
+  };
   "/v1/connection_tables": {
     /**
      * List all connection tables 
@@ -244,6 +251,11 @@ export interface components {
     };
     /** @enum {string} */
     CheckpointSpanType: "alignment" | "sync" | "async" | "committing";
+    ConnectionAutocompleteResp: {
+      values: {
+        [key: string]: (string)[] | undefined;
+      };
+    };
     ConnectionProfile: {
       config: unknown;
       connector: string;
@@ -636,6 +648,22 @@ export interface operations {
     };
     responses: {
       /** @description Deleted connection profile */
+      200: never;
+    };
+  };
+  /**
+   * Get autocomplete suggestions for a connection profile 
+   * @description Get autocomplete suggestions for a connection profile
+   */
+  get_connection_profile_autocomplete: {
+    parameters: {
+      path: {
+        /** @description Connection Profile id */
+        id: string;
+      };
+    };
+    responses: {
+      /** @description Autocomplete suggestions for connection profile */
       200: never;
     };
   };

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -57,6 +57,10 @@ const connectionProfilesKey = () => {
   return { key: 'Connections' };
 };
 
+const connectionProfileAutocompleteKey = (id: string) => {
+  return { key: `ConnectionProfileAutocomplete`, connectionProfileId: id };
+};
+
 const connectionTablesKey = (limit: number) => {
   return (pageIndex: number, previousPageData: schemas['ConnectionTableCollection']) => {
     if (previousPageData && !previousPageData.hasMore) return null;
@@ -80,11 +84,11 @@ const pipelinesKey = (
   if (previousPageData && !previousPageData.hasMore) return null;
 
   if (pageIndex === 0 || !previousPageData) {
-    return { key: 'Piplines', startingAfter: undefined };
+    return { key: 'Pipelines', startingAfter: undefined };
   }
 
   return {
-    key: 'Piplines',
+    key: 'Pipelines',
     startingAfter: previousPageData.data[previousPageData.data.length - 1].id,
   };
 };
@@ -226,6 +230,33 @@ export const useConnectionTables = (limit: number) => {
     mutateConnectionTables: mutate,
     connectionTablesTotalPages: size,
     setConnectionTablesMaxPages: setSize,
+  };
+};
+
+// ConnectionProfile autocomplete
+const connectionProfileAutocompleteFetcher = () => {
+  return async (params: { connectionProfileId: string }) => {
+    const { data, error } = await get('/v1/connection_profiles/{id}/autocomplete', {
+      params: {
+        path: {
+          id: params.connectionProfileId,
+        },
+      },
+    });
+
+    return processResponse(data, error);
+  };
+};
+
+export const useConnectionProfileAutocomplete = (id: string) => {
+  const { data, error } = useSWR<schemas['ConnectionAutocompleteResp']>(
+    connectionProfileAutocompleteKey(id),
+    connectionProfileAutocompleteFetcher()
+  );
+
+  return {
+    autocompleteData: data,
+    autocompleteError: error,
   };
 };
 

--- a/arroyo-console/src/routes/connections/ConfigureConnection.tsx
+++ b/arroyo-console/src/routes/connections/ConfigureConnection.tsx
@@ -1,6 +1,6 @@
 import { Stack } from '@chakra-ui/react';
 import { JsonForm } from './JsonForm';
-import {Connector, useConnectionProfileAutocomplete} from '../../lib/data_fetching';
+import { Connector, useConnectionProfileAutocomplete } from '../../lib/data_fetching';
 import { CreateConnectionState } from './CreateConnection';
 
 export const ConfigureConnection = ({
@@ -14,9 +14,9 @@ export const ConfigureConnection = ({
   state: CreateConnectionState;
   setState: (s: CreateConnectionState) => void;
 }) => {
-  const {autocompleteData, autocompleteError} = state.connectionProfileId ?
-    useConnectionProfileAutocomplete(state.connectionProfileId) :
-    {autocompleteData: undefined, autocompleteError: null};
+  const { autocompleteData, autocompleteError } = state.connectionProfileId
+    ? useConnectionProfileAutocomplete(state.connectionProfileId)
+    : { autocompleteData: undefined, autocompleteError: null };
 
   return (
     <Stack spacing={8}>
@@ -31,7 +31,7 @@ export const ConfigureConnection = ({
           error={null}
           button={'Next'}
           autocompleteData={autocompleteData}
-          autocompleteError={autocompleteError}
+          autocompleteError={autocompleteError?.error}
         />
       </Stack>
     </Stack>

--- a/arroyo-console/src/routes/connections/ConfigureConnection.tsx
+++ b/arroyo-console/src/routes/connections/ConfigureConnection.tsx
@@ -1,7 +1,6 @@
 import { Stack } from '@chakra-ui/react';
-import { useState } from 'react';
 import { JsonForm } from './JsonForm';
-import { Connector, useConnectionProfiles } from '../../lib/data_fetching';
+import {Connector, useConnectionProfileAutocomplete} from '../../lib/data_fetching';
 import { CreateConnectionState } from './CreateConnection';
 
 export const ConfigureConnection = ({
@@ -15,13 +14,9 @@ export const ConfigureConnection = ({
   state: CreateConnectionState;
   setState: (s: CreateConnectionState) => void;
 }) => {
-  let { connectionProfiles, connectionProfilesLoading, mutateConnectionProfiles } =
-    useConnectionProfiles();
-  const [clusterError, setClusterError] = useState<string | null>(null);
-
-  if (connectionProfilesLoading) {
-    return <></>;
-  }
+  const {autocompleteData, autocompleteError} = state.connectionProfileId ?
+    useConnectionProfileAutocomplete(state.connectionProfileId) :
+    {autocompleteData: undefined, autocompleteError: null};
 
   return (
     <Stack spacing={8}>
@@ -30,15 +25,13 @@ export const ConfigureConnection = ({
           schema={JSON.parse(connector.tableConfig)}
           initial={state.table || {}}
           onSubmit={async table => {
-            if (connector?.connectionConfig && state.connectionProfileId == null) {
-              setClusterError('Cluster is required');
-              return;
-            }
             setState({ ...state, table: table });
             onSubmit();
           }}
           error={null}
           button={'Next'}
+          autocompleteData={autocompleteData}
+          autocompleteError={autocompleteError}
         />
       </Stack>
     </Stack>

--- a/arroyo-console/src/routes/connections/ConfigureProfile.tsx
+++ b/arroyo-console/src/routes/connections/ConfigureProfile.tsx
@@ -140,7 +140,7 @@ const ClusterChooser = ({
                 <LinkBox
                   borderRadius={8}
                   w={'100%'}
-                  p={4}
+                  p={c.id == selected ? '15px' : '16px'}
                   borderWidth={c.id == selected ? '2px' : '1px'}
                   borderColor={c.id == selected ? 'blue.300' : 'gray.700'}
                   _hover={{

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -209,9 +209,7 @@ function AutocompleteWidget({
       // @ts-ignore
       onChange({ target: { name: path, value: inputValue } });
       if (inputValue && inputValue?.length > 0) {
-        setItems(
-          allItems.filter(items => items.toLowerCase().startsWith(inputValue.toLowerCase()))
-        );
+        setItems(allItems.filter(items => items.toLowerCase().includes(inputValue.toLowerCase())));
       } else {
         setItems(allItems);
       }
@@ -266,10 +264,11 @@ function AutocompleteWidget({
           borderWidth={'1px'}
           borderRadius={8}
           listStyleType={'none'}
+          maxH={'400px'}
           w={'90%'}
           display={isOpen && items.length > 0 ? 'block' : 'none'}
           opacity={0.95}
-          overflow={'hidden'}
+          overflowY={'scroll'}
         >
           {isOpen &&
             items.map((item, index) => (

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -185,8 +185,16 @@ function AutocompleteWidget({
   };
   autocompleteError?: string;
 }) {
-  const total = autocompleteData?.values[path] || [];
-  const [items, setItems] = React.useState<string[]>(total);
+  const ourItems = autocompleteData?.values[path] || [];
+  const [allItems, setAllItems] = React.useState<string[]>(ourItems);
+  const [items, setItems] = React.useState<string[]>(ourItems);
+
+  useEffect(() => {
+    if (autocompleteData && allItems.length == 0) {
+      setAllItems(ourItems);
+      setItems(ourItems);
+    }
+  }, [autocompleteData]);
 
   const {
     isOpen,
@@ -201,9 +209,11 @@ function AutocompleteWidget({
       // @ts-ignore
       onChange({ target: { name: path, value: inputValue } });
       if (inputValue && inputValue?.length > 0) {
-        setItems(total.filter(items => items.toLowerCase().startsWith(inputValue.toLowerCase())));
+        setItems(
+          allItems.filter(items => items.toLowerCase().startsWith(inputValue.toLowerCase()))
+        );
       } else {
-        setItems(total);
+        setItems(allItems);
       }
     },
     initialInputValue: value,
@@ -233,7 +243,7 @@ function AutocompleteWidget({
         >
           <Button
             {...getToggleButtonProps()}
-            isDisabled={autocompleteError != undefined || total.length == 0}
+            isDisabled={autocompleteError != undefined || allItems.length == 0}
             size={'sm'}
           >
             {autocompleteError ? (

--- a/arroyo-openapi/Cargo.toml
+++ b/arroyo-openapi/Cargo.toml
@@ -14,4 +14,4 @@ reqwest = "0.11.18"
 
 [build-dependencies]
 arroyo-api = { path = "../arroyo-api" }
-utoipa = "3"
+utoipa = "4"

--- a/arroyo-rpc/Cargo.toml
+++ b/arroyo-rpc/Cargo.toml
@@ -15,7 +15,7 @@ bincode = "2.0.0-rc.3"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 nanoid = "0.4"
-utoipa = "3"
+utoipa = "4"
 anyhow = "1.0.75"
 reqwest = { version = "0.11.22", features = ["default", "serde_json", "json"] }
 log = "0.4.20"

--- a/arroyo-rpc/src/api_types/connections.rs
+++ b/arroyo-rpc/src/api_types/connections.rs
@@ -1,4 +1,5 @@
 use crate::formats::{BadData, Format, Framing};
+use std::collections::{BTreeMap};
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -201,6 +202,12 @@ pub struct ConnectionTablePost {
     pub connection_profile_id: Option<String>,
     pub config: serde_json::Value,
     pub schema: Option<ConnectionSchema>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionAutocompleteResp {
+    pub values: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/arroyo-rpc/src/api_types/connections.rs
+++ b/arroyo-rpc/src/api_types/connections.rs
@@ -1,7 +1,7 @@
 use crate::formats::{BadData, Format, Framing};
-use std::collections::{BTreeMap};
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use utoipa::{IntoParams, ToSchema};
 

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -5,7 +5,8 @@
         "topic": {
             "title": "Topic",
             "type": "string",
-            "description": "The Kafka topic to use for this table"
+            "description": "The Kafka topic to use for this table",
+            "format": "autocomplete"
         },
         "type": {
             "type": "object",
@@ -19,8 +20,8 @@
                             "type": "string",
                             "description": "The offset to start reading from",
                             "enum": [
-                                "earliest",
-                                "latest"
+                                "latest",
+                                "earliest"
                             ]
                         },
                         "read_mode": {

--- a/connector-schemas/kinesis/table.json
+++ b/connector-schemas/kinesis/table.json
@@ -24,8 +24,8 @@
                             "type": "string",
                             "description": "The offset to start reading from",
                             "enum": [
-                                "earliest",
-                                "latest"
+                                "latest",
+                                "earliest"
                             ]
                         }
                     },


### PR DESCRIPTION
This PR adds infrastructure for providing autocomplete of connection details, and an initial use case for Kafka topics.

It looks like this:

![image](https://github.com/ArroyoSystems/arroyo/assets/100920/8b344395-1940-441b-b7c6-b10fe8a3ebe7)

There are several pieces to the implementation:
* A method on the Connector trait that allows a connector to provide a map of paths -> completion values
* An API that exposes this, `/connector_profiles/{id}/autocomplete`
* A format `autocomplete` supported by our JsonForm library that renders an Autocomplete widget

The widget shows the status of the autocomplete fetch and reports errors if the fetch failed.