### PR TITLE
Validate schema and encoding issues when testing kafka connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ version = "0.9.0-dev"
 dependencies = [
  "anyhow",
  "arroyo-datastream",
+ "arroyo-formats",
  "arroyo-rpc",
  "arroyo-storage",
  "arroyo-types",

--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -604,8 +604,7 @@ async fn get_schema(
         "confluent" => {
             let c: ConfluentProfile =
                 serde_json::from_value(profile_config.clone()).expect("invalid confluent config");
-            c.try_into()
-                .expect("unable to convert confluent config into kafka config")
+            c.into()
         }
         _ => {
             return Err(bad_request(
@@ -640,7 +639,11 @@ async fn get_schema(
     resolver.get_schema_for_version(None).await.map_err(|e| {
         bad_request(format!(
             "failed to fetch schemas from schema repository: {}",
-            e
+            e.chain()
+                .into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(": ")
         ))
     })
 }

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -12,6 +12,7 @@ arroyo-types = { path = "../arroyo-types" }
 arroyo-storage = { path = "../arroyo-storage" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-datastream = { path = "../arroyo-datastream" }
+arroyo-formats = { path = "../arroyo-formats" }
 
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/arroyo-connectors/src/confluent.rs
+++ b/arroyo-connectors/src/confluent.rs
@@ -136,7 +136,7 @@ impl Connector for ConfluentConnector {
         _: &str,
         config: Self::ProfileT,
         mut table: Self::TableT,
-        _: Option<&ConnectionSchema>,
+        schema: Option<&ConnectionSchema>,
         tx: Sender<Result<Event, Infallible>>,
     ) {
         table
@@ -146,7 +146,7 @@ impl Connector for ConfluentConnector {
             connection: config.into(),
         };
 
-        tester.start(table, tx);
+        tester.start(table, schema.cloned(), tx);
     }
 
     fn test_profile(&self, profile: Self::ProfileT) -> Option<Receiver<TestSourceMessage>> {

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -497,7 +497,7 @@ impl KafkaTester {
                         .await
                         .map_err(|e|
                             if msg[0] == 0 {
-                                anyhow!("Failed to parse message are regular Avro. It may be encoded as SR-Avro, but the schema registry is not enabled. Ensure that the format and schema type are correct.")
+                                anyhow!("Failed to parse message as regular Avro. It may be encoded as SR-Avro, but the schema registry is not enabled. Ensure that the format and schema type are correct.")
                             } else {
                                 anyhow!("Failed to parse message as Avro: {:?}. Ensure that the format and schema type are correct.", e)
                             })?;

--- a/arroyo-console/src/components/StartPipelineModal.tsx
+++ b/arroyo-console/src/components/StartPipelineModal.tsx
@@ -37,7 +37,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps> = ({
   start,
 }) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size={startError ? '4xl' : 'xl'}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Start Pipeline</ModalHeader>
@@ -47,7 +47,9 @@ const StartPipelineModal: React.FC<StartPipelineModalProps> = ({
             {startError ? (
               <Alert status="error">
                 <AlertIcon />
-                <AlertDescription>{startError}</AlertDescription>
+                <AlertDescription overflowY={'auto'} maxH={400} whiteSpace={'pre-wrap'}>
+                  {startError}
+                </AlertDescription>
               </Alert>
             ) : null}
 

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -150,7 +150,7 @@ const pingFetcher = async () => {
 
 export const usePing = () => {
   const { data, error, isLoading } = useSWR('ping', pingFetcher, {
-    refreshInterval: 100000000,
+    refreshInterval: 1000,
     onErrorRetry: (error, key, config, revalidate, {}) => {
       // explicitly define this function to override the exponential backoff
       setTimeout(() => revalidate(), 1000);
@@ -251,7 +251,10 @@ const connectionProfileAutocompleteFetcher = () => {
 export const useConnectionProfileAutocomplete = (id: string) => {
   const { data, error } = useSWR<schemas['ConnectionAutocompleteResp']>(
     connectionProfileAutocompleteKey(id),
-    connectionProfileAutocompleteFetcher()
+    connectionProfileAutocompleteFetcher(),
+    {
+      revalidateOnMount: true,
+    }
   );
 
   return {

--- a/arroyo-console/src/lib/data_fetching.ts
+++ b/arroyo-console/src/lib/data_fetching.ts
@@ -150,7 +150,7 @@ const pingFetcher = async () => {
 
 export const usePing = () => {
   const { data, error, isLoading } = useSWR('ping', pingFetcher, {
-    refreshInterval: 1000,
+    refreshInterval: 100000000,
     onErrorRetry: (error, key, config, revalidate, {}) => {
       // explicitly define this function to override the exponential backoff
       setTimeout(() => revalidate(), 1000);

--- a/arroyo-console/src/routes/connections/ConfluentSchemaEditor.tsx
+++ b/arroyo-console/src/routes/connections/ConfluentSchemaEditor.tsx
@@ -13,7 +13,9 @@ export function ConfluentSchemaEditor({
 }) {
   return (
     <Stack spacing={4} maxW="lg">
-      <Text>Schemas will be loaded from the configured Confluent Schema Registry</Text>
+      <Text>
+        Schemas will be loaded from and written to the configured Confluent Schema Registry
+      </Text>
 
       <Button colorScheme="green" onClick={() => next()}>
         Continue

--- a/arroyo-console/src/routes/connections/CreateProfile.tsx
+++ b/arroyo-console/src/routes/connections/CreateProfile.tsx
@@ -27,7 +27,7 @@ export const CreateProfile = ({
   const [error, setError] = useState<string | null>(null);
   const [valid, setValid] = useState<boolean | null>(null);
   const [validating, setValidating] = useState<boolean>(false);
-  const [state, setState] = useState<any | null>(null);
+  const state = useRef<any | null>(null);
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef<any>();
@@ -67,7 +67,7 @@ export const CreateProfile = ({
       await validate(d);
       return;
     }
-    setState(d);
+    state.current = d;
 
     if (!valid) {
       onOpen();
@@ -84,9 +84,9 @@ export const CreateProfile = ({
     setError(null);
     const { data: connectionProfile, error } = await post('/v1/connection_profiles', {
       body: {
-        name: state.name,
+        name: state.current.name,
         connector: connector.id,
-        config: state,
+        config: state.current,
       },
     });
 
@@ -117,7 +117,7 @@ export const CreateProfile = ({
             setError(null);
             setValid(null);
           }
-          setState(values);
+          state.current = values;
         }}
         inProgress={validating}
       />

--- a/arroyo-console/src/routes/connections/JsonForm.tsx
+++ b/arroyo-console/src/routes/connections/JsonForm.tsx
@@ -64,7 +64,7 @@ function StringWidget({
         <Input
           name={path}
           type={password ? 'password' : 'text'}
-          placeholder={placeholder}
+          placeholder={readonly ? undefined : placeholder}
           value={value || ''}
           onChange={e => onChange(e)}
           readOnly={readonly}

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -182,3 +182,11 @@ impl Default for OperatorConfig {
         }
     }
 }
+
+pub fn error_chain(e: anyhow::Error) -> String {
+    e.chain()
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ")
+}

--- a/arroyo-rpc/src/schema_resolver.rs
+++ b/arroyo-rpc/src/schema_resolver.rs
@@ -231,7 +231,11 @@ impl ConfluentSchemaRegistryClient {
 
             match status {
                 StatusCode::CONFLICT => {
-                    bail!("{}", body)
+                    bail!(
+                        "there is already an existing schema for this topic which is \
+                    incompatible with the new schema being registered:\n\n{}",
+                        body
+                    )
                 }
                 StatusCode::UNPROCESSABLE_ENTITY => {
                     bail!("invalid schema: {}", body);
@@ -333,7 +337,7 @@ impl ConfluentSchemaRegistry {
         self.client
             .write_schema(self.topic_endpoint(), schema, schema_type)
             .await
-            .context(format!("failed to write schema for topic '{}'", self.topic))
+            .context(format!("topic '{}'", self.topic))
     }
 
     pub async fn get_schema_for_id(


### PR DESCRIPTION
At the end of the connection creation flow we have a testing process, which currently for Kafka is able to validate issues connecting to and reading messages. However, it does not currently validate that the messages themselves are well-formed according to the format that's been configured.

This adds such support, which can catch issues like the wrong format being selected or incorrectly selecting/not selecting confluent schema registry.