### PR TITLE
kafka: correctly detect errors in topic creation and then retry.

### DIFF
--- a/arroyo-worker/src/connectors/kafka/sink/test.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/test.rs
@@ -40,7 +40,7 @@ impl KafkaTopicTester {
                 .expect("deletion should have worked")[0];
             tokio::time::sleep(Duration::from_secs(1)).await;
             if let Err((topic, err)) = delete_result {
-                if *err == RDKafkaErrorCode::UnknownTopic {
+                if *err == RDKafkaErrorCode::UnknownTopicOrPartition {
                     continue;
                 }
                 println!("failed to delete topic {} with error {:?}", topic, err);

--- a/arroyo-worker/src/connectors/kafka/sink/test.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/test.rs
@@ -196,7 +196,7 @@ async fn test_kafka_checkpoint_flushes() {
     let mut sink_with_writes = kafka_topic_tester.get_sink_with_writes().await;
     let mut consumer = kafka_topic_tester.get_consumer("0");
 
-    for message in 1u32..200 {
+    for message in 1u32..20 {
         let payload_and_key = message.to_string();
         let mut record = Record {
             timestamp: SystemTime::now(),
@@ -220,7 +220,7 @@ async fn test_kafka_checkpoint_flushes() {
         .handle_checkpoint(barrier, &mut sink_with_writes.ctx)
         .await;
 
-    for message in 1u32..200 {
+    for message in 1u32..20 {
         let record = get_data(&mut consumer).await.value;
         let result: TestOutStruct = serde_json::from_str(&record).unwrap();
         assert_eq!(message.to_string(), result.t, "{} {:?}", message, record);


### PR DESCRIPTION
The create_topic and delete_topic APIs return a Result<Vec<Result<>>, and we weren't inspecting that inner result. As such, we would occasionally fail to create a topic and then the KafkaSourceFunc would just emit a Watermark::Idle. This checks the API response and if there's a failure waits a second and retries.