### PR TITLE
arroyo-console: RawString schema's value now submitted as non-nullable.

### DIFF
--- a/arroyo-console/src/routes/connections/DefineSchema.tsx
+++ b/arroyo-console/src/routes/connections/DefineSchema.tsx
@@ -223,7 +223,7 @@ const RawStringEditor = ({
                 primitive: 'string',
               },
             },
-            nullable: true,
+            nullable: false,
           },
         ],
         format: { raw_string: {} },


### PR DESCRIPTION
This was previously fixed in #414, but then accidentally reverted in #403.