### PR TITLE
Fix #252 kafka sink user error

### DIFF
--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -209,7 +209,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
                         .send(ControlResp::Error {
                             operator_id: ctx.task_info.operator_id.clone(),
                             task_index: ctx.task_info.task_index,
-                            message: format!("{}", e),
+                            message: format!("Unhandled kafka error"),
                             details: format!("{}", e),
                         })
                         .await
@@ -244,7 +244,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
                         .send(ControlResp::Error {
                             operator_id: ctx.task_info.operator_id.clone(),
                             task_index: ctx.task_info.task_index,
-                            message: format!("{}", e),
+                            message: format!("Unhandled kafka error"),
                             details: format!("{}", e),
                         })
                         .await

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -5,7 +5,7 @@ use arroyo_formats::SchemaData;
 use arroyo_macro::process_fn;
 use arroyo_rpc::formats::Format;
 use arroyo_rpc::grpc::{TableDeleteBehavior, TableDescriptor, TableWriteBehavior};
-use arroyo_rpc::{CheckpointEvent, ControlMessage, OperatorConfig};
+use arroyo_rpc::{CheckpointEvent, ControlMessage, OperatorConfig, ControlResp};
 use arroyo_types::*;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -174,7 +174,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
     }
 
     async fn handle_checkpoint(&mut self, _: &CheckpointBarrier, ctx: &mut Context<(), ()>) {
-        self.flush().await;
+        self.flush(ctx).await;
         if let ConsistencyMode::ExactlyOnce {
             next_transaction_index,
             producer_to_complete,
@@ -191,7 +191,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
         }
     }
 
-    async fn flush(&mut self) {
+    async fn flush(&mut self, ctx: &mut Context<(), ()>) {
         self.producer
             .as_ref()
             .unwrap()
@@ -205,13 +205,23 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
             match future.await.expect("Kafka producer shut down") {
                 Ok(_) => {}
                 Err((e, _)) => {
+                    ctx.control_tx
+                        .send(ControlResp::Error {
+                            operator_id: ctx.task_info.operator_id.clone(),
+                            task_index: ctx.task_info.task_index,
+                            message: format!("{}", e),
+                            details: format!("{}", e),
+                        })
+                        .await
+                        .unwrap();
+
                     panic!("Unhandled kafka error: {:?}", e);
                 }
             }
         }
     }
 
-    async fn publish(&mut self, k: Option<String>, v: Vec<u8>) {
+    async fn publish(&mut self, k: Option<String>, v: Vec<u8>, ctx: &mut Context<(), ()>) {
         let mut rec = {
             if let Some(k) = k.as_ref() {
                 FutureRecord::to(&self.topic).key(k).payload(&v)
@@ -230,6 +240,16 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
                     rec = f;
                 }
                 Err((e, _)) => {
+                    ctx.control_tx
+                        .send(ControlResp::Error {
+                            operator_id: ctx.task_info.operator_id.clone(),
+                            task_index: ctx.task_info.task_index,
+                            message: format!("{}", e),
+                            details: format!("{}", e),
+                        })
+                        .await
+                        .unwrap();
+
                     panic!("Unhandled kafka error: {:?}", e);
                 }
             }
@@ -239,7 +259,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
         }
     }
 
-    async fn process_element(&mut self, record: &Record<K, T>, _ctx: &mut Context<(), ()>) {
+    async fn process_element(&mut self, record: &Record<K, T>, ctx: &mut Context<(), ()>) {
         let k = record
             .key
             .as_ref()
@@ -247,7 +267,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
         let v = self.serializer.to_vec(&record.value);
 
         if let Some(v) = v {
-            self.publish(k, v).await;
+            self.publish(k, v, ctx).await;
         }
     }
 

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -219,7 +219,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
 
         // ensure all messages were delivered before finishing the checkpoint
         for future in self.write_futures.drain(..) {
-            future.await.expect("").map_err(|e| UserError::new("Kafka producer shut down", format!("{:?}", e)))?;
+            future.await.unwrap().map_err(|e| UserError::new("Kafka producer shut down", format!("{:?}", e)))?;
         }
         Ok(())
     }

--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -202,7 +202,7 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
                     .await
                     .unwrap();
 
-                panic!("Unhandled kafka error: {:?}", e);
+                panic!("{}: {}", e.name, e.details);
             }
         }
     }


### PR DESCRIPTION
Closes #252 by communicating the error to the controller (following [the pattern in the Kafka source](https://github.com/ArroyoSystems/arroyo/blob/master/arroyo-worker/src/connectors/kafka/source/mod.rs#L237-L252)). 

When running in development with a basic job that plugs data from the nexmark source to a (badly configured) kafka sink, i.e.:
```sql
insert into badkaf
select process_string(person.name) from nex where person.name is not null;
```
(where `process_string` simply ensures a `String` is always returned, rather than an `Option<String>` -- as my `badkaf` sink expects a raw string.)

Arroyo seems to immediately attempt to go into a checkpoint, and eventually (after several minutes) times out through a failed `self.flush`.  When this happens, the error is appropriately displayed in the UX in my setup:

![pic-selected-240102-0422-39](https://github.com/ArroyoSystems/arroyo/assets/16495856/f8b91169-7ab9-4b36-b359-e8c722abeedf)

I am not familiar enough with the lifecycle to understand how to test the error code path in `self.process_element` given that the setup described seems to immediately go into a checkmark. I would appreciate guidance on how to do this, and will be happy to update the PR accordingly. 

I haven't added a test to catch this error/panic specifically, as from what I can tell the testing in connectors only confirms happy path.