### PR TITLE
fix: offsets picking when using custom group

### DIFF
--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -83,6 +83,7 @@ impl KafkaConnector {
                 TableType::Source {
                     offset: match offset.as_ref().map(|f| f.as_str()) {
                         Some("earliest") => SourceOffset::Earliest,
+                        Some("group") => SourceOffset::Group,
                         None | Some("latest") => SourceOffset::Latest,
                         Some(other) => bail!("invalid value for source.offset '{}'", other),
                     },

--- a/arroyo-worker/src/connectors/kafka/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/mod.rs
@@ -21,6 +21,7 @@ impl SourceOffset {
         match self {
             SourceOffset::Earliest => Offset::Beginning,
             SourceOffset::Latest => Offset::End,
+            SourceOffset::Group => Offset::Stored,
         }
     }
 }

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -190,7 +190,6 @@ where
 
         // did we restore any partitions?
         let has_state = !state.is_empty();
-        let offset_mode = self.offset_mode.get_offset();
 
         let state: HashMap<i32, KafkaState> = state.iter().map(|s| (s.partition, **s)).collect();
         let metadata = consumer.fetch_metadata(Some(&self.topic), Duration::from_secs(30))?;
@@ -208,14 +207,12 @@ where
                         .get(&p.id())
                         .map(|s| Offset::Offset(s.offset))
                         .unwrap_or_else(|| {
-                            if offset_mode == Offset::Stored {
-                                offset_mode
-                            } else if has_state {
+                            if has_state {
                                 // if we've restored partitions and we don't know about this one, that means it's
                                 // new, and we want to start from the beginning so we don't drop data
                                 Offset::Beginning
                             } else {
-                                offset_mode
+                                self.offset_mode.get_offset()
                             }
                         });
 

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -190,7 +190,7 @@ where
 
         // did we restore any partitions?
         let has_state = !state.is_empty();
-        let is_custom_group_id = self.group_id.as_ref().is_empty();
+        let offset_mode = self.offset_mode.get_offset();
 
         let state: HashMap<i32, KafkaState> = state.iter().map(|s| (s.partition, **s)).collect();
         let metadata = consumer.fetch_metadata(Some(&self.topic), Duration::from_secs(30))?;
@@ -208,16 +208,16 @@ where
                         .get(&p.id())
                         .map(|s| Offset::Offset(s.offset))
                         .unwrap_or_else(|| {
-                            if is_custom_group_id {
-                                // We use the offsets when using custom group
-                                Offset::Stored
-                            } else if has_state{
+                            if offset_mode == Offset::Stored{
+                                offset_mode
+                            }
+                            else if has_state{
                                 // if we've restored partitions and we don't know about this one, that means it's
                                 // new, and we want to start from the beginning so we don't drop data
                                 Offset::Beginning
                             }
                             else {
-                                self.offset_mode.get_offset()
+                                offset_mode
                             }
                         });
 

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -208,15 +208,13 @@ where
                         .get(&p.id())
                         .map(|s| Offset::Offset(s.offset))
                         .unwrap_or_else(|| {
-                            if offset_mode == Offset::Stored{
+                            if offset_mode == Offset::Stored {
                                 offset_mode
-                            }
-                            else if has_state{
+                            } else if has_state {
                                 // if we've restored partitions and we don't know about this one, that means it's
                                 // new, and we want to start from the beginning so we don't drop data
                                 Offset::Beginning
-                            }
-                            else {
+                            } else {
                                 offset_mode
                             }
                         });

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -21,7 +21,8 @@
                             "description": "The offset to start reading from",
                             "enum": [
                                 "latest",
-                                "earliest"
+                                "earliest",
+                                "group"
                             ]
                         },
                         "read_mode": {


### PR DESCRIPTION
Based on https://github.com/ArroyoSystems/arroyo/issues/469
Adds a new enum `group` which ensures that stored offsets are picked.

