### PR TITLE
Checkpointing Robustness

### DIFF
--- a/arroyo-controller/src/job_controller/mod.rs
+++ b/arroyo-controller/src/job_controller/mod.rs
@@ -766,11 +766,7 @@ impl JobController {
         let cur_epoch = self.model.epoch;
 
         tokio::spawn(async move {
-            let checkpoint = StateBackend::load_checkpoint_metadata(&job_id, cur_epoch)
-                .await
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Couldn't find checkpoint for job during cleaning")
-                })?;
+            let checkpoint = StateBackend::load_checkpoint_metadata(&job_id, cur_epoch).await?;
 
             let c = pool.get().await?;
             controller_queries::mark_compacting()

--- a/arroyo-controller/src/states/mod.rs
+++ b/arroyo-controller/src/states/mod.rs
@@ -670,6 +670,8 @@ impl StateMachine {
             if self.send(update).await.is_err() {
                 self.start(status).await;
             }
+        } else {
+            self.restart_if_needed(status).await;
         }
     }
 
@@ -686,6 +688,20 @@ impl StateMachine {
             tx.is_closed()
         } else {
             true
+        }
+    }
+
+    // for states that should be running, check them and restart if needed
+    async fn restart_if_needed(&mut self, status: JobStatus) {
+        match status.state.as_str() {
+            "Running" | "Recovering" | "Rescaling" => {
+                // done() means there isn't a task running, but these states
+                // need to be advanced.
+                if self.done() {
+                    self.start(status).await;
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/arroyo-state/src/checkpoint_state.rs
+++ b/arroyo-state/src/checkpoint_state.rs
@@ -313,7 +313,8 @@ impl CheckpointState {
                         .collect(),
                 }),
         })
-        .await;
+        .await
+        .expect("should be able to write operator checkpoint metadata");
 
         if let Some(op) = self.operator_details.get_mut(&operator_id) {
             op.finish_time = Some(to_micros(finish_time));
@@ -355,7 +356,7 @@ impl CheckpointState {
             min_epoch: self.min_epoch,
             operator_ids: self.completed_operators.iter().cloned().collect(),
         })
-        .await;
+        .await?;
         Ok(())
     }
 }

--- a/arroyo-state/src/lib.rs
+++ b/arroyo-state/src/lib.rs
@@ -117,18 +117,15 @@ pub trait BackingStore {
     /// prepares a checkpoint to be loaded, e.g., by deleting future data
     async fn prepare_checkpoint_load(metadata: &CheckpointMetadata) -> Result<()>;
 
-    /// loads the latest checkpoint metadata for a given job id
-    async fn load_latest_checkpoint_metadata(job_id: &str) -> Option<CheckpointMetadata>;
-
     /// loads the checkpoint metadata for a given job id and epoch
-    async fn load_checkpoint_metadata(job_id: &str, epoch: u32) -> Option<CheckpointMetadata>;
+    async fn load_checkpoint_metadata(job_id: &str, epoch: u32) -> Result<CheckpointMetadata>;
 
     /// loads the operator checkpoint metadata for a given job id, operator id, and epoch
     async fn load_operator_metadata(
         job_id: &str,
         operator_id: &str,
         epoch: u32,
-    ) -> Option<OperatorCheckpointMetadata>;
+    ) -> Result<Option<OperatorCheckpointMetadata>>;
 
     /// creates a new instance of the BackingStore for the given task info.
     async fn new(
@@ -152,10 +149,11 @@ pub trait BackingStore {
     fn task_info(&self) -> &TaskInfo;
 
     /// writes the operator checkpoint metadata to the backing store
-    async fn write_operator_checkpoint_metadata(metadata: OperatorCheckpointMetadata);
+    async fn write_operator_checkpoint_metadata(metadata: OperatorCheckpointMetadata)
+        -> Result<()>;
 
     /// writes the checkpoint metadata to the backing store
-    async fn write_checkpoint_metadata(metadata: CheckpointMetadata);
+    async fn write_checkpoint_metadata(metadata: CheckpointMetadata) -> Result<()>;
 
     /// cleans up a checkpoint by deleting data that is no longer needed
     async fn cleanup_checkpoint(
@@ -598,7 +596,8 @@ mod test {
             bytes: 5,
             commit_data: None,
         })
-        .await;
+        .await
+        .unwrap();
 
         let checkpoint_metadata: CheckpointMetadata = CheckpointMetadata {
             job_id: job_id.to_string(),
@@ -609,7 +608,9 @@ mod test {
             operator_ids: vec![operator_id.to_string()],
         };
 
-        ParquetBackend::write_checkpoint_metadata(checkpoint_metadata.clone()).await;
+        ParquetBackend::write_checkpoint_metadata(checkpoint_metadata.clone())
+            .await
+            .unwrap();
 
         checkpoint_metadata
     }

--- a/arroyo-state/src/tables/key_time_multi_map.rs
+++ b/arroyo-state/src/tables/key_time_multi_map.rs
@@ -123,6 +123,7 @@ impl<K: Key, V: Data> KeyTimeMultiMapCache<K, V> {
             checkpoint_metadata.epoch,
         )
         .await
+        .expect("expect lookup to succeed")
         .expect("expect metadata for restoring from checkpoint");
         let min_valid_time = operator_metadata
             .min_watermark

--- a/arroyo-storage/src/lib.rs
+++ b/arroyo-storage/src/lib.rs
@@ -523,6 +523,29 @@ impl StorageProvider {
         Ok(bytes)
     }
 
+    pub async fn get_if_present<P: Into<String>>(
+        &self,
+        path: P,
+    ) -> Result<Option<Bytes>, StorageError> {
+        let path: String = path.into();
+        match self
+            .object_store
+            .get(&self.qualify_path(&path.into()))
+            .await
+        {
+            Ok(obj) => {
+                let bytes = obj.bytes().await?;
+                Ok(Some(bytes))
+            }
+            Err(err) => {
+                if let object_store::Error::NotFound { .. } = &err {
+                    return Ok(None);
+                }
+                Err(err.into())
+            }
+        }
+    }
+
     pub async fn get_as_stream<P: Into<String>>(
         &self,
         path: P,

--- a/arroyo-worker/src/connectors/kafka/source/test.rs
+++ b/arroyo-worker/src/connectors/kafka/source/test.rs
@@ -262,7 +262,8 @@ async fn test_kafka() {
         bytes: checkpoint_completed.subtask_metadata.bytes,
         commit_data: None,
     })
-    .await;
+    .await
+    .unwrap();
 
     StateBackend::write_checkpoint_metadata(CheckpointMetadata {
         job_id: task_info.job_id.clone(),
@@ -272,7 +273,8 @@ async fn test_kafka() {
         finish_time: 0,
         operator_ids: vec![task_info.operator_id.clone()],
     })
-    .await;
+    .await
+    .unwrap();
 
     reader.assert_next_message_record_value(20).await;
 

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -286,6 +286,7 @@ impl<K: Key, T: Data> Context<K, T> {
                 )
                 .await;
                 metadata
+                    .expect("lookup should succeed")
                     .expect("require metadata")
                     .min_watermark
                     .map(from_micros)
@@ -943,9 +944,10 @@ impl Engine {
             Some(
                 StateBackend::load_checkpoint_metadata(&self.job_id, epoch)
                     .await
-                    .unwrap_or_else(|| {
-                        panic!("failed to load checkpoint metadata for epoch {}", epoch)
-                    }),
+                    .expect(&format!(
+                        "failed to load checkpoint metadata for epoch {}",
+                        epoch
+                    )),
             )
         } else {
             None


### PR DESCRIPTION
This makes Arroyo more robust to transient issues with talking to the state backend, namely S3. Previously there were unwraps in the main control loop which could result in the job being suspended. We fix this with two changes. First, the controller will check that a subset of States have an active Receiver. If not, it will be restarted. Secondly, more of the BackendState methods now return Result<()>, which lets us handle these errors.

There are still a number of places where checkpointing errors are fatal, but that is preferable to them reporting as "Running" yet making no progress.