### PR TITLE
Have async operators flush on close(). Emit watermarks in order.

### DIFF
--- a/arroyo-worker/src/connectors/kafka/sink/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/sink/mod.rs
@@ -329,7 +329,11 @@ impl<K: Key + Serialize, T: SchemaData + Serialize> KafkaSinkFunc<K, T> {
             .expect("sent commit event");
     }
 
-    async fn on_close(&mut self, ctx: &mut crate::engine::Context<(), ()>) {
+    async fn on_close(
+        &mut self,
+        ctx: &mut crate::engine::Context<(), ()>,
+        _final_message: &Option<Message<(), ()>>,
+    ) {
         if !self.is_committing() {
             return;
         }

--- a/arroyo-worker/src/connectors/two_phase_committer.rs
+++ b/arroyo-worker/src/connectors/two_phase_committer.rs
@@ -8,7 +8,7 @@ use arroyo_rpc::{
     CheckpointEvent, ControlMessage,
 };
 use arroyo_state::tables::global_keyed_map::GlobalKeyedState;
-use arroyo_types::{Data, Key, Record, TaskInfo, Watermark};
+use arroyo_types::{Data, Key, Message, Record, TaskInfo, Watermark};
 use async_trait::async_trait;
 use bincode::config;
 use tracing::warn;
@@ -140,7 +140,11 @@ impl<K: Key, T: Data + Sync, TPC: TwoPhaseCommitter<K, T>> TwoPhaseCommitterOper
             .expect("record inserted");
     }
 
-    async fn on_close(&mut self, ctx: &mut crate::engine::Context<(), ()>) {
+    async fn on_close(
+        &mut self,
+        ctx: &mut crate::engine::Context<(), ()>,
+        _final_message: &Option<Message<(), ()>>,
+    ) {
         if let Some(ControlMessage::Commit { epoch, commit_data }) = ctx.control_rx.recv().await {
             self.handle_commit(epoch, commit_data, ctx).await;
         } else {

--- a/arroyo-worker/src/operators/mod.rs
+++ b/arroyo-worker/src/operators/mod.rs
@@ -178,13 +178,15 @@ impl<K: Key, D: Data> PeriodicWatermarkGenerator<K, D> {
         self.state_cache = state;
     }
 
-    async fn on_close(&mut self, ctx: &mut Context<K, D>) {
-        // send final watermark on close
-        ctx.collector
-            .broadcast(Message::Watermark(Watermark::EventTime(from_millis(
-                u64::MAX,
-            ))))
-            .await;
+    async fn on_close(&mut self, ctx: &mut Context<K, D>, final_message: &Option<Message<K, D>>) {
+        if let Some(Message::EndOfData) = final_message {
+            // send final watermark on end of data
+            ctx.collector
+                .broadcast(Message::Watermark(Watermark::EventTime(from_millis(
+                    u64::MAX,
+                ))))
+                .await;
+        }
     }
 
     async fn process_element(&mut self, record: &Record<K, D>, ctx: &mut Context<K, D>) {

--- a/arroyo-worker/src/operators/sinks/mod.rs
+++ b/arroyo-worker/src/operators/sinks/mod.rs
@@ -60,7 +60,11 @@ impl<K: Key, T: Data + Serialize> GrpcSink<K, T> {
             .unwrap();
     }
 
-    async fn on_close(&mut self, ctx: &mut Context<(), ()>) {
+    async fn on_close(
+        &mut self,
+        ctx: &mut Context<(), ()>,
+        _final_message: &Option<Message<(), ()>>,
+    ) {
         self.client
             .as_mut()
             .unwrap()


### PR DESCRIPTION
This addresses a couple of async udf issues, namely
* Flush the futures when EndOfData is encountered.
* Hold operator watermarks until all records received before them have been emitted.
* Pass down the final_message to on_close so operators can distinguish between Stop and EndOfData.