### PR TITLE
Make webhook endpoint an env-var

### DIFF
--- a/arroyo-worker/src/connectors/webhook.rs
+++ b/arroyo-worker/src/connectors/webhook.rs
@@ -62,7 +62,7 @@ where
             .collect();
 
         Self {
-            url: Arc::new(table.endpoint),
+            url: Arc::new(table.endpoint.sub_env_vars().unwrap()),
             client: reqwest::ClientBuilder::new()
                 .default_headers(headers)
                 .timeout(Duration::from_secs(5))

--- a/connector-schemas/webhook/table.json
+++ b/connector-schemas/webhook/table.json
@@ -9,7 +9,7 @@
             "examples": [
                 "https://yourdomain.com/api/v1/webhooks"
             ],
-            "format": "uri"
+            "format": "var-str"
         },
         "headers": {
             "title": "Headers",


### PR DESCRIPTION
Some webhook APIs embed an auth token in the URL (e.g., slack webhooks) so it's useful for the endpoint to be an env var