### PR TITLE
Record batch session windows

### DIFF
--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -55,7 +55,7 @@ use crate::{connection_tables, to_micros};
 use crate::{handle_db_error, AuthData};
 use create_pipeline_req::Config::Sql;
 
-const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(2);
+const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(10);
 
 async fn compile_sql<'e, E>(
     query: String,

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -55,7 +55,7 @@ use crate::{connection_tables, to_micros};
 use crate::{handle_db_error, AuthData};
 use create_pipeline_req::Config::Sql;
 
-const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(10);
+const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(2);
 
 async fn compile_sql<'e, E>(
     query: String,

--- a/arroyo-datastream/src/logical.rs
+++ b/arroyo-datastream/src/logical.rs
@@ -20,6 +20,7 @@ pub enum OperatorName {
     ArrowValue,
     ArrowKey,
     ArrowAggregate,
+    TumblingWindowAggregate,
     ConnectorSource,
     ConnectorSink,
 }

--- a/arroyo-datastream/src/logical.rs
+++ b/arroyo-datastream/src/logical.rs
@@ -22,6 +22,7 @@ pub enum OperatorName {
     ArrowAggregate,
     TumblingWindowAggregate,
     SlidingWindowAggregate,
+    SessionWindowAggregate,
     ConnectorSource,
     ConnectorSink,
 }

--- a/arroyo-datastream/src/logical.rs
+++ b/arroyo-datastream/src/logical.rs
@@ -21,6 +21,7 @@ pub enum OperatorName {
     ArrowKey,
     ArrowAggregate,
     TumblingWindowAggregate,
+    SlidingWindowAggregate,
     ConnectorSource,
     ConnectorSink,
 }

--- a/arroyo-df/src/lib.rs
+++ b/arroyo-df/src/lib.rs
@@ -43,7 +43,6 @@ use schemas::{
 
 use tables::{Insert, Table};
 
-use crate::plan_graph::get_arrow_program;
 use arroyo_rpc::api_types::connections::ConnectionProfile;
 use datafusion_common::{DFSchema, DFSchemaRef, DataFusionError};
 use prettyplease::unparse;

--- a/arroyo-df/src/lib.rs
+++ b/arroyo-df/src/lib.rs
@@ -35,6 +35,7 @@ use datafusion_expr::{AggregateUDF, TableSource};
 use logical::LogicalBatchInput;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::IntoNodeReferences;
+use plan_graph::Planner;
 use schemas::{
     add_timestamp_field, add_timestamp_field_if_missing_arrow, has_timestamp_field,
     window_arrow_struct,
@@ -1147,7 +1148,8 @@ pub async fn parse_and_get_arrow_program(
             rewriter.local_logical_plan_graph.add_edge(a, b, weight);
         }
     }
-    get_arrow_program(rewriter, schema_provider).await
+    let planner = Planner::new(schema_provider);
+    planner.get_arrow_program(rewriter).await
 }
 
 #[derive(Clone)]

--- a/arroyo-df/src/plan_graph.rs
+++ b/arroyo-df/src/plan_graph.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use arrow_array::types::IntervalMonthDayNanoType;
 use arrow_schema::Schema;
@@ -11,301 +11,484 @@ use datafusion::{
     },
     physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner},
 };
+use datafusion_execution::runtime_env::RuntimeConfig;
 use petgraph::{graph::DiGraph, visit::Topo};
 
-use tracing::{info, warn};
+use tracing::info;
 
-use crate::{physical::ArroyoPhysicalExtensionCodec, DataFusionEdge, QueryToGraphVisitor};
+use crate::{
+    physical::{ArroyoMemExec, ArroyoPhysicalExtensionCodec, DecodingContext, EmptyRegistry},
+    schemas::add_timestamp_field_arrow,
+    DataFusionEdge, QueryToGraphVisitor,
+};
 use crate::{tables::Table, ArroyoSchemaProvider, CompiledSql};
 use anyhow::{anyhow, bail, Context, Result};
 use arroyo_datastream::logical::{
     LogicalEdge, LogicalEdgeType, LogicalGraph, LogicalNode, LogicalProgram, OperatorName,
 };
-use arroyo_rpc::grpc::api::{self};
 use arroyo_rpc::grpc::api::{KeyPlanOperator, ValuePlanOperator, Window, WindowAggregateOperator};
-use datafusion_common::ScalarValue;
+use arroyo_rpc::{
+    grpc::api::{self, TumblingWindowAggregateOperator},
+    ArroyoSchema,
+};
+use datafusion_common::{DFSchemaRef, ScalarValue};
 use datafusion_expr::{expr::ScalarFunction, BuiltinScalarFunction, Expr, LogicalPlan};
 use datafusion_proto::{
     physical_plan::AsExecutionPlan,
-    protobuf::{PhysicalExprNode, PhysicalPlanNode},
+    protobuf::{
+        physical_plan_node::PhysicalPlanType, AggregateMode, PhysicalExprNode, PhysicalPlanNode,
+    },
 };
 use petgraph::prelude::EdgeRef;
 use petgraph::Direction;
 use prost::Message;
 
-pub(crate) async fn get_arrow_program(
-    rewriter: QueryToGraphVisitor,
+pub(crate) struct Planner {
     schema_provider: ArroyoSchemaProvider,
-) -> Result<CompiledSql> {
-    warn!(
-        "graph is {:?}",
-        petgraph::dot::Dot::with_config(&rewriter.local_logical_plan_graph, &[])
-    );
-    let mut topo = Topo::new(&rewriter.local_logical_plan_graph);
-    let mut program_graph: LogicalGraph = DiGraph::new();
+    planner: DefaultPhysicalPlanner,
+    session_state: SessionState,
+}
 
-    let planner = DefaultPhysicalPlanner::default();
-    let mut config = SessionConfig::new();
-    config
-        .options_mut()
-        .optimizer
-        .enable_round_robin_repartition = false;
-    config.options_mut().optimizer.repartition_aggregations = false;
-    let session_state = SessionState::new_with_config_rt(config, Arc::new(RuntimeEnv::default()))
-        .with_physical_optimizer_rules(vec![]);
+impl Planner {
+    pub fn new(schema_provider: ArroyoSchemaProvider) -> Self {
+        let planner = DefaultPhysicalPlanner::default();
+        let mut config = SessionConfig::new();
+        config
+            .options_mut()
+            .optimizer
+            .enable_round_robin_repartition = false;
+        config.options_mut().optimizer.repartition_aggregations = false;
+        let session_state =
+            SessionState::new_with_config_rt(config, Arc::new(RuntimeEnv::default()))
+                .with_physical_optimizer_rules(vec![]);
 
-    let mut node_mapping = HashMap::new();
-    while let Some(node_index) = topo.next(&rewriter.local_logical_plan_graph) {
-        let logical_extension = rewriter
-            .local_logical_plan_graph
-            .node_weight(node_index)
-            .unwrap();
-
-        let new_node = match logical_extension {
-            crate::LogicalPlanExtension::TableScan(logical_plan) => {
-                let LogicalPlan::TableScan(table_scan) = logical_plan else {
-                    panic!("expected table scan")
-                };
-
-                let table_name = table_scan.table_name.to_string();
-                let source = schema_provider
-                    .get_table(&table_name)
-                    .ok_or_else(|| anyhow!("table {} not found", table_scan.table_name))?;
-
-                let Table::ConnectorTable(cn) = source else {
-                    panic!("expect connector table")
-                };
-
-                let sql_source = cn.as_sql_source()?;
-                let source_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("source_{}", program_graph.node_count()),
-                    description: sql_source.source.config.description.clone(),
-                    operator_name: OperatorName::ConnectorSource,
-                    operator_config: api::ConnectorOp::from(sql_source.source.config)
-                        .encode_to_vec(),
-                    parallelism: 1,
-                });
-
-                let watermark_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("watermark_{}", program_graph.node_count()),
-                    description: "watermark".to_string(),
-                    operator_name: OperatorName::Watermark,
-                    parallelism: 1,
-                    operator_config: api::PeriodicWatermark {
-                        period_micros: 1_000_000,
-                        max_lateness_micros: 0,
-                        idle_time_micros: None,
-                    }
-                    .encode_to_vec(),
-                });
-
-                let mut edge: LogicalEdge = (&DataFusionEdge::new(
-                    table_scan.projected_schema.clone(),
-                    LogicalEdgeType::Forward,
-                    vec![],
-                )
-                .unwrap())
-                    .into();
-
-                edge.projection = table_scan.projection.clone();
-
-                program_graph.add_edge(source_index, watermark_index, edge);
-
-                node_mapping.insert(node_index, watermark_index);
-                watermark_index
-            }
-            crate::LogicalPlanExtension::ValueCalculation(logical_plan) => {
-                let _inputs = logical_plan.inputs();
-                let physical_plan = planner
-                    .create_physical_plan(logical_plan, &session_state)
-                    .await;
-
-                let physical_plan =
-                    physical_plan.context("creating physical plan for value calculation")?;
-
-                let physical_plan_node: PhysicalPlanNode =
-                    PhysicalPlanNode::try_from_physical_plan(
-                        physical_plan,
-                        &ArroyoPhysicalExtensionCodec::default(),
-                    )?;
-
-                let config = ValuePlanOperator {
-                    name: "tmp".into(),
-                    physical_plan: physical_plan_node.encode_to_vec(),
-                };
-
-                let new_node_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("value_{}", program_graph.node_count()),
-                    description: format!("arrow_value<{}>", config.name),
-                    operator_name: OperatorName::ArrowValue,
-                    operator_config: config.encode_to_vec(),
-                    parallelism: 1,
-                });
-
-                node_mapping.insert(node_index, new_node_index);
-
-                new_node_index
-            }
-            crate::LogicalPlanExtension::KeyCalculation {
-                projection: logical_plan,
-                key_columns,
-            } => {
-                info!("logical plan for key calculation:\n{:?}", logical_plan);
-                info!("input schema: {:?}", logical_plan.schema());
-                let physical_plan = planner
-                    .create_physical_plan(logical_plan, &session_state)
-                    .await;
-
-                let physical_plan = physical_plan.context("creating physical plan")?;
-
-                println!("physical plan {:#?}", physical_plan);
-                let physical_plan_node: PhysicalPlanNode =
-                    PhysicalPlanNode::try_from_physical_plan(
-                        physical_plan,
-                        &ArroyoPhysicalExtensionCodec::default(),
-                    )?;
-                let config = KeyPlanOperator {
-                    name: "tmp".into(),
-                    physical_plan: physical_plan_node.encode_to_vec(),
-                    key_fields: key_columns.iter().map(|column| (*column) as u64).collect(),
-                };
-
-                let new_node_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("key_{}", program_graph.node_count()),
-                    operator_name: OperatorName::ArrowKey,
-                    operator_config: config.encode_to_vec(),
-                    description: format!("ArrowKey<{}>", config.name),
-                    parallelism: 1,
-                });
-
-                node_mapping.insert(node_index, new_node_index);
-
-                new_node_index
-            }
-            crate::LogicalPlanExtension::AggregateCalculation(aggregate) => {
-                let my_aggregate = aggregate.aggregate.clone();
-                let logical_plan = LogicalPlan::Aggregate(my_aggregate);
-
-                let LogicalPlan::TableScan(_table_scan) = aggregate.aggregate.input.as_ref() else {
-                    bail!("expected logical plan")
-                };
-
-                let physical_plan = planner
-                    .create_physical_plan(&logical_plan, &session_state)
-                    .await
-                    .context("couldn't create physical plan for aggregate")?;
-
-                let physical_plan_node: PhysicalPlanNode =
-                    PhysicalPlanNode::try_from_physical_plan(
-                        physical_plan,
-                        &ArroyoPhysicalExtensionCodec::default(),
-                    )?;
-                let slide = match &aggregate.window {
-                    WindowType::Tumbling { width } => Some(width),
-                    WindowType::Sliding { width:_, slide } => Some(slide),
-                    WindowType::Instant => bail!("instant window not yet implemented"),
-                    WindowType::Session { gap:_ } => None,
-                };
-
-                let date_bin = slide.map(|slide| {
-                    Expr::ScalarFunction(ScalarFunction {
-                        func_def: datafusion_expr::ScalarFunctionDefinition::BuiltIn(
-                            BuiltinScalarFunction::DateBin,
-                        ),
-                        args: vec![
-                            Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(
-                                IntervalMonthDayNanoType::make_value(0, 0, slide.as_nanos() as i64),
-                            ))),
-                            Expr::Column(datafusion_common::Column {
-                                relation: None,
-                                name: "_timestamp".into(),
-                            }),
-                        ],
-                    })
-                });
-                let binning_function = date_bin
-                    .map(|date_bin| {
-                        planner.create_physical_expr(
-                            &date_bin,
-                            &aggregate.aggregate.input.schema().as_ref(),
-                            &aggregate.aggregate.input.schema().as_ref().into(),
-                            &session_state,
-                        )
-                    })
-                    .transpose()?;
-
-                let binning_function_proto = binning_function
-                    .map(|binning_function| PhysicalExprNode::try_from(binning_function))
-                    .transpose()?
-                    .unwrap_or_default();
-                let input_schema: Schema = aggregate.aggregate.input.schema().as_ref().into();
-
-                let config = WindowAggregateOperator {
-                    name: format!("windo_aggregate<{:?}>", aggregate.window),
-                    physical_plan: physical_plan_node.encode_to_vec(),
-                    binning_function: binning_function_proto.encode_to_vec(),
-                    // unused now
-                    binning_schema: vec![],
-                    input_schema: serde_json::to_vec(&input_schema)?,
-                    window: Some(Window {
-                        window: Some(aggregate.window.clone().into()),
-                    }),
-                    window_field_name: aggregate.window_field.name().to_string(),
-                    window_index: aggregate.window_index as u64,
-                    key_fields: aggregate
-                        .key_fields
-                        .iter()
-                        .map(|field| (*field) as u64)
-                        .collect(),
-                };
-
-                let new_node_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("aggregate_{}", program_graph.node_count()),
-                    operator_name: OperatorName::ArrowAggregate,
-                    operator_config: config.encode_to_vec(),
-                    parallelism: 1,
-                    description: config.name.clone(),
-                });
-
-                node_mapping.insert(node_index, new_node_index);
-                new_node_index
-            }
-            crate::LogicalPlanExtension::Sink {
-                name: _,
-                connector_op,
-            } => {
-                let connector_op: api::ConnectorOp = connector_op.clone().into();
-                let sink_index = program_graph.add_node(LogicalNode {
-                    operator_id: format!("sink_{}", program_graph.node_count()),
-                    operator_name: OperatorName::ConnectorSink,
-                    operator_config: connector_op.encode_to_vec(),
-                    parallelism: 1,
-                    description: connector_op.description.clone(),
-                });
-                node_mapping.insert(node_index, sink_index);
-                sink_index
-            }
-        };
-
-        for edge in rewriter
-            .local_logical_plan_graph
-            .edges_directed(node_index, Direction::Incoming)
-        {
-            program_graph.add_edge(
-                *node_mapping.get(&edge.source()).unwrap(),
-                new_node,
-                edge.weight().try_into().unwrap(),
-            );
+        Self {
+            schema_provider,
+            planner,
+            session_state,
         }
     }
 
-    let program = LogicalProgram {
-        graph: program_graph,
-    };
+    pub(crate) async fn get_arrow_program(
+        &self,
+        rewriter: QueryToGraphVisitor,
+    ) -> Result<CompiledSql> {
+        let mut topo = Topo::new(&rewriter.local_logical_plan_graph);
+        let mut program_graph: LogicalGraph = DiGraph::new();
 
-    Ok(CompiledSql {
-        program,
-        connection_ids: vec![],
-        schemas: HashMap::new(),
-    })
+        let mut node_mapping = HashMap::new();
+        while let Some(node_index) = topo.next(&rewriter.local_logical_plan_graph) {
+            let logical_extension = rewriter
+                .local_logical_plan_graph
+                .node_weight(node_index)
+                .unwrap();
+
+            let new_node = match logical_extension {
+                crate::LogicalPlanExtension::TableScan(logical_plan) => {
+                    let LogicalPlan::TableScan(table_scan) = logical_plan else {
+                        panic!("expected table scan")
+                    };
+
+                    let table_name = table_scan.table_name.to_string();
+                    let source = self
+                        .schema_provider
+                        .get_table(&table_name)
+                        .ok_or_else(|| anyhow!("table {} not found", table_scan.table_name))?;
+
+                    let Table::ConnectorTable(cn) = source else {
+                        panic!("expect connector table")
+                    };
+
+                    let sql_source = cn.as_sql_source()?;
+                    let source_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("source_{}", program_graph.node_count()),
+                        description: sql_source.source.config.description.clone(),
+                        operator_name: OperatorName::ConnectorSource,
+                        operator_config: api::ConnectorOp::from(sql_source.source.config)
+                            .encode_to_vec(),
+                        parallelism: 1,
+                    });
+
+                    let watermark_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("watermark_{}", program_graph.node_count()),
+                        description: "watermark".to_string(),
+                        operator_name: OperatorName::Watermark,
+                        parallelism: 1,
+                        operator_config: api::PeriodicWatermark {
+                            period_micros: 1_000_000,
+                            max_lateness_micros: 0,
+                            idle_time_micros: None,
+                        }
+                        .encode_to_vec(),
+                    });
+
+                    let mut edge: LogicalEdge = (&DataFusionEdge::new(
+                        table_scan.projected_schema.clone(),
+                        LogicalEdgeType::Forward,
+                        vec![],
+                    )
+                    .unwrap())
+                        .into();
+
+                    edge.projection = table_scan.projection.clone();
+
+                    program_graph.add_edge(source_index, watermark_index, edge);
+
+                    node_mapping.insert(node_index, watermark_index);
+                    watermark_index
+                }
+                crate::LogicalPlanExtension::ValueCalculation(logical_plan) => {
+                    let _inputs = logical_plan.inputs();
+                    let physical_plan = self
+                        .planner
+                        .create_physical_plan(logical_plan, &self.session_state)
+                        .await;
+
+                    let physical_plan =
+                        physical_plan.context("creating physical plan for value calculation")?;
+
+                    let physical_plan_node: PhysicalPlanNode =
+                        PhysicalPlanNode::try_from_physical_plan(
+                            physical_plan,
+                            &ArroyoPhysicalExtensionCodec::default(),
+                        )?;
+
+                    let config = ValuePlanOperator {
+                        name: "tmp".into(),
+                        physical_plan: physical_plan_node.encode_to_vec(),
+                    };
+
+                    let new_node_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("value_{}", program_graph.node_count()),
+                        description: format!("arrow_value<{}>", config.name),
+                        operator_name: OperatorName::ArrowValue,
+                        operator_config: config.encode_to_vec(),
+                        parallelism: 1,
+                    });
+
+                    node_mapping.insert(node_index, new_node_index);
+
+                    new_node_index
+                }
+                crate::LogicalPlanExtension::KeyCalculation {
+                    projection: logical_plan,
+                    key_columns,
+                } => {
+                    info!("logical plan for key calculation:\n{:?}", logical_plan);
+                    info!("input schema: {:?}", logical_plan.schema());
+                    let physical_plan = self
+                        .planner
+                        .create_physical_plan(logical_plan, &self.session_state)
+                        .await;
+
+                    let physical_plan = physical_plan.context("creating physical plan")?;
+
+                    println!("physical plan {:#?}", physical_plan);
+                    let physical_plan_node: PhysicalPlanNode =
+                        PhysicalPlanNode::try_from_physical_plan(
+                            physical_plan,
+                            &ArroyoPhysicalExtensionCodec::default(),
+                        )?;
+                    let config = KeyPlanOperator {
+                        name: "tmp".into(),
+                        physical_plan: physical_plan_node.encode_to_vec(),
+                        key_fields: key_columns.iter().map(|column| (*column) as u64).collect(),
+                    };
+
+                    let new_node_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("key_{}", program_graph.node_count()),
+                        operator_name: OperatorName::ArrowKey,
+                        operator_config: config.encode_to_vec(),
+                        description: format!("ArrowKey<{}>", config.name),
+                        parallelism: 1,
+                    });
+
+                    node_mapping.insert(node_index, new_node_index);
+
+                    new_node_index
+                }
+                crate::LogicalPlanExtension::AggregateCalculation(aggregate) => {
+                    let my_aggregate = aggregate.aggregate.clone();
+                    let logical_plan = LogicalPlan::Aggregate(my_aggregate);
+
+                    let LogicalPlan::TableScan(_table_scan) = aggregate.aggregate.input.as_ref()
+                    else {
+                        bail!("expected logical plan")
+                    };
+                    let logical_node = match &aggregate.window {
+                        WindowType::Tumbling { width } => {
+                            let mut logical_node = self.tumbling_window_config(aggregate).await?;
+                            logical_node.operator_id = format!(
+                                "{}_{}",
+                                logical_node.operator_id,
+                                program_graph.node_count()
+                            );
+                            Some(logical_node)
+                        }
+                        WindowType::Sliding { width: _, slide } => None,
+                        WindowType::Instant => None,
+                        WindowType::Session { gap: _ } => None,
+                    }
+                    .expect("only support tumbling windows for now");
+
+                    let new_node_index = program_graph.add_node(logical_node);
+                    node_mapping.insert(node_index, new_node_index);
+                    new_node_index
+                    /*
+
+                    let physical_plan = self.planner
+                        .create_physical_plan(&logical_plan, &self.session_state)
+                        .await
+                        .context("couldn't create physical plan for aggregate")?;
+
+                    let physical_plan_node: PhysicalPlanNode =
+                        PhysicalPlanNode::try_from_physical_plan(
+                            physical_plan,
+                            &ArroyoPhysicalExtensionCodec::default(),
+                        )?;
+
+                    let slide = match &aggregate.window {
+                        WindowType::Tumbling { width } => Some(width),
+                        WindowType::Sliding { width: _, slide } => Some(slide),
+                        WindowType::Instant => bail!("instant window not yet implemented"),
+                        WindowType::Session { gap: _ } => None,
+                    };
+
+                    let date_bin = slide.map(|slide| {
+                        Expr::ScalarFunction(ScalarFunction {
+                            func_def: datafusion_expr::ScalarFunctionDefinition::BuiltIn(
+                                BuiltinScalarFunction::DateBin,
+                            ),
+                            args: vec![
+                                Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(
+                                    IntervalMonthDayNanoType::make_value(
+                                        0,
+                                        0,
+                                        slide.as_nanos() as i64,
+                                    ),
+                                ))),
+                                Expr::Column(datafusion_common::Column {
+                                    relation: None,
+                                    name: "_timestamp".into(),
+                                }),
+                            ],
+                        })
+                    });
+                    let binning_function = date_bin
+                        .map(|date_bin| {
+                            self.planner.create_physical_expr(
+                                &date_bin,
+                                &aggregate.aggregate.input.schema().as_ref(),
+                                &aggregate.aggregate.input.schema().as_ref().into(),
+                                &self.session_state,
+                            )
+                        })
+                        .transpose()?;
+
+                    let binning_function_proto = binning_function
+                        .map(|binning_function| PhysicalExprNode::try_from(binning_function))
+                        .transpose()?
+                        .unwrap_or_default();
+                    let input_schema: Schema = aggregate.aggregate.input.schema().as_ref().into();
+
+                    let config = WindowAggregateOperator {
+                        name: format!("windo_aggregate<{:?}>", aggregate.window),
+                        physical_plan: physical_plan_node.encode_to_vec(),
+                        binning_function: binning_function_proto.encode_to_vec(),
+                        // unused now
+                        binning_schema: vec![],
+                        input_schema: serde_json::to_vec(&input_schema)?,
+                        window: Some(Window {
+                            window: Some(aggregate.window.clone().into()),
+                        }),
+                        window_field_name: aggregate.window_field.name().to_string(),
+                        window_index: aggregate.window_index as u64,
+                        key_fields: aggregate
+                            .key_fields
+                            .iter()
+                            .map(|field| (*field) as u64)
+                            .collect(),
+                    };
+
+                    let new_node_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("aggregate_{}", program_graph.node_count()),
+                        operator_name: OperatorName::ArrowAggregate,
+                        operator_config: config.encode_to_vec(),
+                        parallelism: 1,
+                        description: config.name.clone(),
+                    });
+
+                    node_mapping.insert(node_index, new_node_index);
+                    new_node_index*/
+                }
+                crate::LogicalPlanExtension::Sink {
+                    name: _,
+                    connector_op,
+                } => {
+                    let connector_op: api::ConnectorOp = connector_op.clone().into();
+                    let sink_index = program_graph.add_node(LogicalNode {
+                        operator_id: format!("sink_{}", program_graph.node_count()),
+                        operator_name: OperatorName::ConnectorSink,
+                        operator_config: connector_op.encode_to_vec(),
+                        parallelism: 1,
+                        description: connector_op.description.clone(),
+                    });
+                    node_mapping.insert(node_index, sink_index);
+                    sink_index
+                }
+            };
+
+            for edge in rewriter
+                .local_logical_plan_graph
+                .edges_directed(node_index, Direction::Incoming)
+            {
+                program_graph.add_edge(
+                    *node_mapping.get(&edge.source()).unwrap(),
+                    new_node,
+                    edge.weight().try_into().unwrap(),
+                );
+            }
+        }
+
+        let program = LogicalProgram {
+            graph: program_graph,
+        };
+
+        Ok(CompiledSql {
+            program,
+            connection_ids: vec![],
+            schemas: HashMap::new(),
+        })
+    }
+
+    async fn tumbling_window_config(
+        &self,
+        aggregate: &crate::AggregateCalculation,
+    ) -> Result<LogicalNode> {
+        let WindowType::Tumbling { width } = aggregate.window else {
+            bail!("expected tumbling window")
+        };
+        let binning_function_proto =
+            self.binning_function_proto(width, aggregate.aggregate.input.schema().clone())?;
+        let input_schema: Schema = aggregate.aggregate.input.schema().as_ref().into();
+
+        let input_schema = ArroyoSchema {
+            schema: Arc::new(input_schema),
+            timestamp_index: aggregate.aggregate.input.schema().fields().len() - 1,
+            key_indices: aggregate.key_fields.clone(),
+        };
+
+        let my_aggregate = aggregate.aggregate.clone();
+        let logical_plan = LogicalPlan::Aggregate(my_aggregate);
+
+        let LogicalPlan::TableScan(_table_scan) = aggregate.aggregate.input.as_ref() else {
+            bail!("expected logical plan");
+        };
+
+        let physical_plan = self
+            .planner
+            .create_physical_plan(&logical_plan, &self.session_state)
+            .await
+            .context("couldn't create physical plan for aggregate")?;
+
+        let codec = ArroyoPhysicalExtensionCodec {
+            context: DecodingContext::Planning,
+        };
+
+        let mut physical_plan_node: PhysicalPlanNode =
+            PhysicalPlanNode::try_from_physical_plan(physical_plan.clone(), &codec)?;
+
+        let PhysicalPlanType::Aggregate(mut final_aggregate_proto) = physical_plan_node
+            .physical_plan_type
+            .take()
+            .ok_or_else(|| anyhow!("missing physical plan"))?
+        else {
+            bail!("expected aggregate physical plan, not {:?}", physical_plan);
+        };
+
+        let AggregateMode::Final = final_aggregate_proto.mode() else {
+            bail!("expect AggregateMode to be Final so we can decompose it for checkpointing.")
+        };
+
+        // pull the input out to be computed separately for each bin.
+        let partial_aggregation_plan = final_aggregate_proto
+            .input
+            .take()
+            .expect("should have input");
+
+        // need to convert to ExecutionPlan to get the partial schema.
+        let partial_aggregation_exec_plan = partial_aggregation_plan.try_into_physical_plan(
+            &EmptyRegistry {},
+            &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
+            &codec,
+        )?;
+        let partial_schema = partial_aggregation_exec_plan.schema();
+
+        let final_input_table_provider = ArroyoMemExec {
+            table_name: "partial".into(),
+            schema: partial_schema.clone(),
+        };
+
+        final_aggregate_proto.input = Some(Box::new(PhysicalPlanNode::try_from_physical_plan(
+            Arc::new(final_input_table_provider),
+            &codec,
+        )?));
+
+        let finish_plan = PhysicalPlanNode {
+            physical_plan_type: Some(PhysicalPlanType::Aggregate(final_aggregate_proto)),
+        };
+
+        let partial_schema = ArroyoSchema::new(
+            add_timestamp_field_arrow(partial_schema.clone()),
+            partial_schema.fields().len(),
+            aggregate.key_fields.clone(),
+        );
+        let config = TumblingWindowAggregateOperator {
+            name: format!("TumblingWindow<{:?}>", width),
+            width_micros: width.as_micros() as u64,
+            binning_function: binning_function_proto.encode_to_vec(),
+            window_field_name: aggregate.window_field.name().to_string(),
+            window_index: aggregate.window_index as u64,
+            input_schema: Some(input_schema.try_into()?),
+            partial_schema: Some(partial_schema.try_into()?),
+            partial_aggregation_plan: partial_aggregation_plan.encode_to_vec(),
+            final_aggregation_plan: finish_plan.encode_to_vec(),
+        };
+        Ok(LogicalNode {
+            operator_id: config.name.clone(),
+            description: "tumbling window".to_string(),
+            operator_name: OperatorName::TumblingWindowAggregate,
+            operator_config: config.encode_to_vec(),
+            parallelism: 1,
+        })
+    }
+
+    fn binning_function_proto(
+        &self,
+        duration: Duration,
+        input_schema: DFSchemaRef,
+    ) -> Result<PhysicalExprNode> {
+        let date_bin = Expr::ScalarFunction(ScalarFunction {
+            func_def: datafusion_expr::ScalarFunctionDefinition::BuiltIn(
+                BuiltinScalarFunction::DateBin,
+            ),
+            args: vec![
+                Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(
+                    IntervalMonthDayNanoType::make_value(0, 0, duration.as_nanos() as i64),
+                ))),
+                Expr::Column(datafusion_common::Column {
+                    relation: None,
+                    name: "_timestamp".into(),
+                }),
+            ],
+        });
+
+        let binning_function = self.planner.create_physical_expr(
+            &date_bin,
+            &input_schema,
+            &input_schema.as_ref().into(),
+            &self.session_state,
+        )?;
+        Ok(PhysicalExprNode::try_from(binning_function)?)
+    }
 }

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -156,6 +156,16 @@ message SlidingWindowAggregateOperator {
   bytes final_aggregation_plan = 10;
 }
 
+message SessionWindowAggregateOperator {
+  string name = 1;
+  uint64 gap_micros = 2;
+  string window_field_name = 3;
+  uint64 window_index = 4;
+  ArroyoSchema input_schema = 5;
+  ArroyoSchema unkeyed_aggregate_schema = 6;
+  bytes partial_aggregation_plan = 7;
+  bytes final_aggregation_plan = 8;
+}
 
 enum OperatorName {
   STRUCT_TO_RECORD_BATCH = 0;

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -131,6 +131,18 @@ message WindowAggregateOperator {
   bytes input_schema = 9;
 }
 
+message TumblingWindowAggregateOperator {
+  string name = 1;
+  uint64 width_micros = 2;
+  bytes binning_function = 3;
+  string window_field_name = 4;
+  uint64 window_index = 5;
+  ArroyoSchema input_schema = 6;
+  ArroyoSchema partial_schema = 7;
+  bytes partial_aggregation_plan = 8;
+  bytes final_aggregation_plan = 9;
+}
+
 
 enum OperatorName {
   STRUCT_TO_RECORD_BATCH = 0;

--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -143,6 +143,19 @@ message TumblingWindowAggregateOperator {
   bytes final_aggregation_plan = 9;
 }
 
+message SlidingWindowAggregateOperator {
+  string name = 1;
+  uint64 width_micros = 2;
+  uint64 slide_micros = 3;
+  bytes binning_function = 4;
+  string window_field_name = 5;
+  uint64 window_index = 6;
+  ArroyoSchema input_schema = 7;
+  ArroyoSchema partial_schema = 8;
+  bytes partial_aggregation_plan = 9;
+  bytes final_aggregation_plan = 10;
+}
+
 
 enum OperatorName {
   STRUCT_TO_RECORD_BATCH = 0;

--- a/arroyo-rpc/src/lib.rs
+++ b/arroyo-rpc/src/lib.rs
@@ -197,6 +197,8 @@ pub fn error_chain(e: anyhow::Error) -> String {
 
 pub const TIMESTAMP_FIELD: &str = "_timestamp";
 
+pub type ArroyoSchemaRef = Arc<ArroyoSchema>;
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ArroyoSchema {
     pub schema: Arc<Schema>,

--- a/arroyo-state/src/tables/expiring_time_key_map.rs
+++ b/arroyo-state/src/tables/expiring_time_key_map.rs
@@ -132,18 +132,7 @@ impl ExpiringTimeKeyTable {
                 };
                 for (timestamp, batch) in batches {
                     if cutoff <= timestamp {
-                        info!(
-                            "inserting batch {:?} with timestamp {:?}",
-                            batch,
-                            print_time(timestamp)
-                        );
                         data.entry(timestamp).or_default().push(batch)
-                    } else {
-                        info!(
-                            "filtered batch {:?} with timestamp {:?}",
-                            batch,
-                            print_time(timestamp)
-                        );
                     }
                 }
             }

--- a/arroyo-state/src/tables/table_manager.rs
+++ b/arroyo-state/src/tables/table_manager.rs
@@ -365,11 +365,11 @@ impl TableManager {
                 .tables
                 .get(table_name)
                 .ok_or_else(|| anyhow!("no registered table {}", table_name))?;
-            let global_keyed_table = table_implementation
+            let expiring_time_key_table = table_implementation
                 .as_any()
                 .downcast_ref::<ExpiringTimeKeyTable>()
                 .ok_or_else(|| anyhow!("wrong table type for table {}", table_name))?;
-            let saved_data = global_keyed_table
+            let saved_data = expiring_time_key_table
                 .get_view(self.writer.sender.clone(), watermark)
                 .await?;
             let cache: Box<dyn Any + Send> = Box::new(saved_data);

--- a/arroyo-worker/src/arrow/mod.rs
+++ b/arroyo-worker/src/arrow/mod.rs
@@ -6,6 +6,7 @@ use arrow_array::TimestampNanosecondArray;
 use arrow_json::writer::record_batches_to_json_rows;
 use arroyo_df::physical::ArroyoPhysicalExtensionCodec;
 use arroyo_df::physical::DecodingContext;
+use arroyo_df::physical::EmptyRegistry;
 use arroyo_rpc::grpc::api::ConnectorOp;
 use arroyo_rpc::grpc::controller_grpc_client::ControllerGrpcClient;
 use arroyo_rpc::grpc::{api, SinkDataReq};
@@ -19,16 +20,11 @@ use datafusion_common::DataFusionError;
 use datafusion_common::Result as DFResult;
 use datafusion_execution::runtime_env::RuntimeConfig;
 use datafusion_execution::runtime_env::RuntimeEnv;
-use datafusion_execution::FunctionRegistry;
 use datafusion_execution::TaskContext;
-use datafusion_expr::AggregateUDF;
-use datafusion_expr::ScalarUDF;
-use datafusion_expr::WindowUDF;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use futures::StreamExt;
 use prost::Message as ProstMessage;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::SystemTime;
@@ -40,34 +36,6 @@ pub mod session_aggregating_window;
 pub mod sliding_aggregating_window;
 pub(crate) mod sync;
 pub mod tumbling_aggregating_window;
-pub struct EmptyRegistry {}
-
-impl FunctionRegistry for EmptyRegistry {
-    fn udfs(&self) -> HashSet<String> {
-        HashSet::new()
-    }
-
-    fn udf(&self, name: &str) -> datafusion_common::Result<Arc<ScalarUDF>> {
-        DFResult::Err(DataFusionError::NotImplemented(format!(
-            "udf {} not implemented",
-            name
-        )))
-    }
-
-    fn udaf(&self, name: &str) -> datafusion_common::Result<Arc<AggregateUDF>> {
-        DFResult::Err(DataFusionError::NotImplemented(format!(
-            "udaf {} not implemented",
-            name
-        )))
-    }
-
-    fn udwf(&self, name: &str) -> datafusion_common::Result<Arc<WindowUDF>> {
-        DFResult::Err(DataFusionError::NotImplemented(format!(
-            "udwf {} not implemented",
-            name
-        )))
-    }
-}
 
 pub struct ValueExecutionOperator {
     name: String,

--- a/arroyo-worker/src/arrow/mod.rs
+++ b/arroyo-worker/src/arrow/mod.rs
@@ -36,6 +36,7 @@ use tonic::transport::Channel;
 
 use crate::operator::{ArrowOperator, ArrowOperatorConstructor, OperatorNode};
 
+pub mod session_aggregating_window;
 pub mod sliding_aggregating_window;
 pub(crate) mod sync;
 pub mod tumbling_aggregating_window;

--- a/arroyo-worker/src/arrow/session_aggregating_window.rs
+++ b/arroyo-worker/src/arrow/session_aggregating_window.rs
@@ -1,0 +1,944 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::{Arc, RwLock},
+    time::SystemTime,
+};
+
+use anyhow::{anyhow, bail, Context as AnyhowContext, Result};
+use arrow::{
+    compute::{
+        concat_batches, filter_record_batch, kernels::cmp::gt_eq, lexsort_to_indices, partition,
+        take, SortColumn,
+    },
+    row::{OwnedRow, RowConverter, SortField},
+};
+use arrow_array::{
+    types::TimestampNanosecondType, Array, PrimitiveArray, RecordBatch, StructArray,
+    TimestampNanosecondArray,
+};
+use arrow_schema::{DataType, Field, FieldRef, Schema};
+use arroyo_df::{physical::ArroyoMemExec, schemas::window_arrow_struct};
+use arroyo_rpc::{
+    grpc::{api, api::window::Window, TableConfig},
+    ArroyoSchema, ArroyoSchemaRef, TIMESTAMP_FIELD,
+};
+use arroyo_state::{
+    global_table_config, tables::global_keyed_map::GlobalKeyedView, timestamp_table_config,
+};
+use arroyo_types::{
+    from_nanos, print_time, to_nanos, ArrowMessage, CheckpointBarrier, SignalMessage, Watermark,
+};
+use datafusion::{execution::context::SessionContext, physical_plan::ExecutionPlan};
+
+use crate::operator::{ArrowOperator, ArrowOperatorConstructor};
+use crate::{engine::ArrowContext, operator::OperatorNode};
+use arroyo_df::physical::{ArroyoPhysicalExtensionCodec, DecodingContext};
+use datafusion_execution::{
+    runtime_env::{RuntimeConfig, RuntimeEnv},
+    SendableRecordBatchStream,
+};
+use datafusion_proto::{
+    physical_plan::AsExecutionPlan,
+    protobuf::{physical_plan_node::PhysicalPlanType, AggregateMode, PhysicalPlanNode},
+};
+use prost::Message;
+use std::time::Duration;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio_stream::StreamExt;
+use tracing::{debug, info, warn};
+
+use super::EmptyRegistry;
+
+// TODO: advance futures outside of method calls.
+
+pub struct SessionAggregatingWindowFunc {
+    config: Arc<SessionWindowConfig>,
+    keys_by_next_watermark_action: BTreeMap<SystemTime, HashSet<OwnedRow>>,
+    key_computations: HashMap<OwnedRow, KeyComputingHolder>,
+    keys_by_start_time: BTreeMap<SystemTime, HashSet<OwnedRow>>,
+    row_converter: RowConverter,
+}
+
+impl SessionAggregatingWindowFunc {
+    fn should_advance(&self, watermark: SystemTime) -> bool {
+        let result = self
+            .keys_by_next_watermark_action
+            .first_key_value()
+            .map(|(next_watermark_action, _)| *next_watermark_action <= watermark)
+            .unwrap_or(false);
+        if result {
+            debug!("should advance at watermark {:?}", watermark);
+        } else {
+            debug!("should not advance at watermark {:?}", watermark);
+        }
+        result
+    }
+
+    async fn advance(&mut self, ctx: &mut ArrowContext) -> Result<()> {
+        let Some(watermark) = ctx.last_present_watermark() else {
+            debug!("no watermark, not advancing");
+            return Ok(());
+        };
+        let results = self.results_at_watermark(watermark).await?;
+        if !results.is_empty() {
+            let result_batch = self.to_record_batch(results, ctx)?;
+            debug!("emitting session batch of size {}", result_batch.num_rows());
+            ctx.collect(result_batch).await;
+        }
+
+        Ok(())
+    }
+
+    async fn results_at_watermark(
+        &mut self,
+        watermark: SystemTime,
+    ) -> Result<Vec<(OwnedRow, Vec<SessionWindowResult>)>> {
+        let mut results = vec![];
+        while self.should_advance(watermark) {
+            let (_next_watermark_action, keys) = self
+                .keys_by_next_watermark_action
+                .pop_first()
+                .ok_or_else(|| anyhow!("should have a key to advance"))?;
+            for key in keys {
+                let key_computation = self
+                    .key_computations
+                    .get_mut(&key)
+                    .ok_or_else(|| anyhow!("should have key {:?}", key))?;
+                let initial_start_time = key_computation.earliest_data().unwrap();
+                let flushed_batches = key_computation.watermark_update(watermark).await?;
+                if !flushed_batches.is_empty() {
+                    results.push((key.clone(), flushed_batches));
+                }
+                if key_computation.is_empty() {
+                    self.key_computations.remove(&key);
+                    self.keys_by_start_time
+                        .get_mut(&initial_start_time)
+                        .unwrap()
+                        .remove(&key);
+                } else {
+                    let new_start_time = key_computation.earliest_data().unwrap();
+                    if new_start_time != initial_start_time {
+                        self.keys_by_start_time
+                            .get_mut(&initial_start_time)
+                            .unwrap()
+                            .remove(&key);
+                        self.keys_by_start_time
+                            .entry(new_start_time)
+                            .or_default()
+                            .insert(key.clone());
+                    }
+
+                    let next_watermark_action = key_computation.next_watermark_action().unwrap();
+                    if next_watermark_action == _next_watermark_action {
+                        bail!(" processed a watermark at {} and next watermark action stayed at {}. batches by start time {:?}, active_session date_end():{:?} ",
+                         print_time(watermark), print_time(next_watermark_action), key_computation.batches_by_start_time, key_computation.active_session.as_ref().map(|session| print_time(session.data_end)));
+                    }
+                    self.keys_by_next_watermark_action
+                        .entry(next_watermark_action)
+                        .or_default()
+                        .insert(key);
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    fn earliest_batch_time(&self) -> Option<SystemTime> {
+        self.keys_by_start_time
+            .first_key_value()
+            .map(|(start_time, _keys)| *start_time)
+    }
+
+    async fn add_at_watermark(
+        &mut self,
+        sorted_batch: RecordBatch,
+        watermark: Option<SystemTime>,
+    ) -> Result<()> {
+        let partition = partition(
+            sorted_batch
+                .columns()
+                .into_iter()
+                .take(self.config.input_schema_ref.key_indices.len())
+                .map(|column| column.clone())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .unwrap();
+
+        for range in partition.ranges() {
+            let key_batch = sorted_batch.slice(range.start, range.end - range.start);
+            let first_row = self
+                .row_converter
+                .convert_columns(
+                    &key_batch.slice(0, 1).columns()
+                        [0..(self.config.input_schema_ref.key_indices.len())],
+                )
+                .unwrap();
+            let row = first_row.row(0);
+            let key_computation =
+                self.key_computations
+                    .entry(row.owned())
+                    .or_insert_with(|| KeyComputingHolder {
+                        session_window_config: self.config.clone(),
+                        active_session: None,
+                        batches_by_start_time: BTreeMap::new(),
+                    });
+            let initial_next_watermark_action = key_computation.next_watermark_action();
+            let initial_data_start = key_computation.earliest_data();
+            key_computation
+                .add_batch(key_batch, watermark)
+                .await
+                .unwrap();
+            let new_next_watermark_action = key_computation
+                .next_watermark_action()
+                .expect("should have next watermark action");
+            let new_initial_data_start = key_computation
+                .earliest_data()
+                .expect("should have earliest data");
+            match initial_next_watermark_action {
+                Some(initial_next_watermark_action) => {
+                    if initial_next_watermark_action != new_next_watermark_action {
+                        let owned_row = row.owned();
+                        self.keys_by_next_watermark_action
+                            .get_mut(&initial_next_watermark_action)
+                            .expect("should have key")
+                            .remove(&owned_row);
+                        self.keys_by_next_watermark_action
+                            .entry(new_next_watermark_action)
+                            .or_default()
+                            .insert(owned_row);
+                    }
+                    let initial_data_start =
+                        initial_data_start.expect("should have initial data start");
+                    if initial_data_start != new_initial_data_start {
+                        let owned_row = row.owned();
+                        self.keys_by_start_time
+                            .get_mut(&initial_data_start)
+                            .expect("should have key")
+                            .remove(&owned_row);
+                        self.keys_by_start_time
+                            .entry(new_initial_data_start)
+                            .or_default()
+                            .insert(owned_row);
+                    }
+                }
+                None => {
+                    let owned_row = row.owned();
+                    self.keys_by_next_watermark_action
+                        .entry(new_next_watermark_action)
+                        .or_default()
+                        .insert(owned_row.clone());
+
+                    self.keys_by_start_time
+                        .entry(new_initial_data_start)
+                        .or_default()
+                        .insert(owned_row);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn sort_columns(&self, batch: &RecordBatch) -> Vec<SortColumn> {
+        let mut columns: Vec<_> = self
+            .config
+            .input_schema_ref
+            .key_indices
+            .iter()
+            .map(|index| SortColumn {
+                values: batch.column(*index).clone(),
+                options: None,
+            })
+            .collect();
+        columns.push(SortColumn {
+            values: batch
+                .column(self.config.input_schema_ref.timestamp_index)
+                .clone(),
+            options: None,
+        });
+        columns
+    }
+
+    fn filter_batch_by_time(
+        &self,
+        batch: RecordBatch,
+        watermark: Option<SystemTime>,
+    ) -> Result<RecordBatch> {
+        let Some(watermark) = watermark else {
+            // no watermark, so we just return the same batch.
+            return Ok(batch);
+        };
+        // filter out late data
+        let timestamp_column = batch
+            .column(self.config.input_schema_ref.timestamp_index)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap();
+        let watermark_scalar = TimestampNanosecondArray::new_scalar(to_nanos(watermark) as i64);
+        let on_time = gt_eq(timestamp_column, &watermark_scalar).unwrap();
+        Ok(filter_record_batch(&batch, &on_time)?)
+    }
+
+    fn sort_batch(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        let sort_columns = self.sort_columns(batch);
+        let sort_indices = lexsort_to_indices(&sort_columns, None).expect("should be able to sort");
+        let columns = batch
+            .columns()
+            .iter()
+            .map(|c| take(c, &sort_indices, None).unwrap())
+            .collect();
+        Ok(RecordBatch::try_new(batch.schema(), columns)?)
+    }
+
+    fn to_record_batch(
+        &self,
+        results: Vec<(OwnedRow, Vec<SessionWindowResult>)>,
+        ctx: &mut ArrowContext,
+    ) -> Result<RecordBatch> {
+        debug!("first result is {:#?}", results[0]);
+        let (rows, results): (Vec<_>, Vec<_>) = results
+            .iter()
+            .flat_map(|(owned_row, session_results)| {
+                let row = owned_row.row();
+                session_results
+                    .into_iter()
+                    .map(move |session_result| (row, session_result))
+            })
+            .unzip();
+        let key_columns = self.row_converter.convert_rows(rows)?;
+
+        let window_start_array = PrimitiveArray::<TimestampNanosecondType>::from(
+            results
+                .iter()
+                .map(|result| result.window_start)
+                .map(|start| to_nanos(start) as i64)
+                .collect::<Vec<_>>(),
+        );
+        let window_end_array = PrimitiveArray::<TimestampNanosecondType>::from(
+            results
+                .iter()
+                .map(|result| result.window_end)
+                .map(|end| to_nanos(end) as i64)
+                .collect::<Vec<_>>(),
+        );
+        let timestamp_array = PrimitiveArray::<TimestampNanosecondType>::from(
+            results
+                .iter()
+                .map(|result| result.window_end)
+                .map(|end| to_nanos(end) as i64 - 1)
+                .collect::<Vec<_>>(),
+        );
+        let merged_batch = concat_batches(
+            &results[0].batch.schema(),
+            results.iter().map(|result| &result.batch),
+        )?;
+        let DataType::Struct(window_fields) = self.config.window_field.data_type() else {
+            bail!("expected window field to be a struct");
+        };
+        let window_struct_array = StructArray::try_new(
+            window_fields.clone(),
+            vec![Arc::new(window_start_array), Arc::new(window_end_array)],
+            None,
+        )?;
+        let mut columns = key_columns;
+        columns.insert(self.config.window_index, Arc::new(window_struct_array));
+        columns.extend_from_slice(merged_batch.columns());
+        columns.push(Arc::new(timestamp_array));
+        Ok(RecordBatch::try_new(
+            ctx.out_schema.as_ref().unwrap().schema.clone(),
+            columns,
+        )?)
+    }
+}
+
+struct SessionWindowConfig {
+    gap: Duration,
+    input_schema_ref: ArroyoSchemaRef,
+    unkeyed_aggregate_schema_ref: ArroyoSchemaRef,
+    window_field: FieldRef,
+    window_index: usize,
+    //TODO: perform partial aggregations and checkpoint those.
+    //partial_physical_exec: Arc<dyn ExecutionPlan>,
+    final_physical_exec: Arc<dyn ExecutionPlan>,
+    receiver: Arc<RwLock<Option<UnboundedReceiver<RecordBatch>>>>,
+}
+
+struct ActiveSession {
+    // the data start time for this session
+    data_start: SystemTime,
+    data_end: SystemTime,
+    sender: Option<UnboundedSender<RecordBatch>>,
+    // the next batch's execution plan
+    result_stream: SendableRecordBatchStream,
+}
+
+impl ActiveSession {
+    async fn new(
+        aggregation_plan: Arc<dyn ExecutionPlan>,
+        initial_timestamp: SystemTime,
+        sender: UnboundedSender<RecordBatch>,
+    ) -> Result<Self> {
+        let result_exec = aggregation_plan.execute(0, SessionContext::new().task_ctx())?;
+        Ok(Self {
+            data_start: initial_timestamp,
+            data_end: initial_timestamp,
+            sender: Some(sender),
+            result_stream: result_exec,
+        })
+    }
+    // Add all data in the batch that is within gap of the current session interval,
+    // updating gap as more data is added.
+    // The batch is sorted and it will never be the case that the start of batch is less than data_start - gap.
+    // return the remaining data.
+    fn add_batch(
+        &mut self,
+        batch: RecordBatch,
+        gap: Duration,
+        timestamp_index: usize,
+    ) -> Result<Option<(SystemTime, RecordBatch)>> {
+        let timestamp_column = batch
+            .column(timestamp_index)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap();
+        let start = timestamp_column.value(0);
+        let end = timestamp_column.value(batch.num_rows() - 1);
+
+        if end < to_nanos(self.data_end + gap) as i64 {
+            // all data in the batch is within the current session interval
+            // add it to the current session and update the gap
+            self.data_end = self.data_end.max(from_nanos(end as u128));
+            self.data_start = self.data_start.min(from_nanos(start as u128));
+            self.sender.as_ref().unwrap().send(batch)?;
+            return Ok(None);
+        }
+
+        if (to_nanos(self.data_end + gap) as i64) < start {
+            // all data in the batch is after the current session interval
+            // return the batch
+            warn!("got batch that is entirely after the current session interval");
+            return Ok(Some((from_nanos(start as u128), batch)));
+        }
+
+        if start < to_nanos(self.data_start - gap) as i64 {
+            bail!("received a batch that starts before the current data_start - gap, this should not have happened.");
+        }
+        if start < to_nanos(self.data_start) as i64 {
+            self.data_start = from_nanos(start as u128);
+        }
+        // TODO: test best way to compute this
+        let mut index = 1;
+        while index < batch.num_rows() {
+            let value = timestamp_column.value(index);
+            index += 1;
+            //
+            if value < to_nanos(self.data_end) as i64 {
+                continue;
+            }
+            if value < to_nanos(self.data_end + gap) as i64 {
+                // this value is within the current session interval
+                // add it to the current session and update the gap
+                self.data_end = from_nanos(value as u128);
+                continue;
+            }
+            break;
+        }
+        if index == batch.num_rows() {
+            // all data in the batch is within the current session interval
+            // we've already updated the gap, so we can just add it to the current session
+            self.sender.as_ref().unwrap().send(batch)?;
+            return Ok(None);
+        }
+        self.sender.as_ref().unwrap().send(batch.slice(0, index))?;
+
+        let batch = batch.slice(index, batch.num_rows() - index);
+        let start_time = from_nanos(timestamp_column.value(index) as u128);
+
+        Ok(Some((start_time, batch)))
+    }
+
+    async fn finish(mut self, gap: Duration) -> Result<SessionWindowResult> {
+        {
+            // drop the active session sender
+            self.sender.take();
+        }
+        let result_batches: Vec<_> = self
+            .result_stream
+            .map(|batch| Ok(batch?))
+            .collect::<Result<_>>()
+            .await?;
+        if result_batches.len() != 1 {
+            bail!(
+                "expect active session result to be excactly one batch, not {:?}",
+                result_batches
+            );
+        }
+        let batch = result_batches.into_iter().next().unwrap();
+        if batch.num_rows() != 1 {
+            bail!(
+                "expect active session result to be excactly one row, not {:?}",
+                batch
+            );
+        }
+        Ok(SessionWindowResult {
+            window_start: self.data_start,
+            window_end: self.data_end + gap,
+            batch,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SessionWindowResult {
+    window_start: SystemTime,
+    window_end: SystemTime,
+    batch: RecordBatch,
+}
+
+struct KeyComputingHolder {
+    session_window_config: Arc<SessionWindowConfig>,
+    // this is computing the currently active batch.
+    active_session: Option<ActiveSession>,
+    // buffered batches that may not be in the current session.
+    // For now checkpointing happens on incoming batches, but in the future we can checkpoint partial aggregates.
+    batches_by_start_time: BTreeMap<SystemTime, Vec<RecordBatch>>,
+}
+
+impl KeyComputingHolder {
+    fn next_watermark_action(&self) -> Option<SystemTime> {
+        match self.active_session {
+            Some(ref active_session) => {
+                Some(active_session.data_end + self.session_window_config.gap)
+            }
+            None => self
+                .batches_by_start_time
+                .first_key_value()
+                .map(|(start_time, _batches)| *start_time - self.session_window_config.gap),
+        }
+    }
+    /* This method is for advancing the state machine when the watermark is incremented.
+      The operator code is responsible for making sure it is called on all appropriate KeyComputingHolders.
+      It assumes the invariant is already enforced that all buffered batches start after the current active session plus the gap.
+    */
+    async fn watermark_update(
+        &mut self,
+        watermark: SystemTime,
+    ) -> Result<Vec<SessionWindowResult>> {
+        // Check if the current session is complete. This will happen if max_active_timestamp + gap is less than the watermark.
+        // If it is, we need to finish the current session and start a new one.
+        let mut results = vec![];
+        loop {
+            if self.active_session.is_some() {
+                let active_session = self.active_session.as_mut().unwrap();
+                if active_session.data_end + self.session_window_config.gap < watermark {
+                    let result = self
+                        .active_session
+                        .take()
+                        .unwrap()
+                        .finish(self.session_window_config.gap)
+                        .await?;
+                    results.push(result);
+                } else {
+                    // the active session is not finished, so we can stop.
+                    break;
+                }
+            } else {
+                let Some((initial_timestamp, _value)) =
+                    self.batches_by_start_time.first_key_value()
+                else {
+                    break;
+                };
+                if watermark + self.session_window_config.gap < *initial_timestamp {
+                    // the next batch is after the watermark + gap, so there could be a session before it.
+                    break;
+                }
+
+                let (sender, unbounded_receiver) = unbounded_channel();
+                {
+                    let mut internal_receiver =
+                        self.session_window_config.receiver.write().unwrap();
+                    *internal_receiver = Some(unbounded_receiver);
+                }
+
+                self.active_session = Some(
+                    ActiveSession::new(
+                        self.session_window_config.final_physical_exec.clone(),
+                        *initial_timestamp,
+                        sender,
+                    )
+                    .await?,
+                );
+                self.fill_active_session()?;
+            }
+        }
+        Ok(results)
+    }
+
+    /* This enforces the invariant that all buffered batches start after the current active session plus the gap.
+      This is called when the watermark is advanced, and when data is added.
+      There are some pathological cases, e.g. if the gap is 1.5s and one batch has evens and the others odds,
+      which would strip off one row at a time, but this should be rare.
+    */
+    fn fill_active_session(&mut self) -> Result<()> {
+        let Some(active_session) = self.active_session.as_mut() else {
+            bail!("fill_active_session() should not be called when there is no active session");
+        };
+        loop {
+            let Some((first_key, _batches)) = self.batches_by_start_time.first_key_value() else {
+                break;
+            };
+            if active_session.data_end + self.session_window_config.gap < *first_key {
+                // the next batch is after the current session + gap, so we can stop.
+                break;
+            }
+            let (_start_time, batches) = self
+                .batches_by_start_time
+                .pop_first()
+                .expect("will have already exited");
+
+            for batch in batches {
+                if let Some((start_time, batch)) = active_session.add_batch(
+                    batch,
+                    self.session_window_config.gap,
+                    self.session_window_config
+                        .unkeyed_aggregate_schema_ref
+                        .timestamp_index,
+                )? {
+                    self.batches_by_start_time
+                        .entry(start_time)
+                        .or_default()
+                        .push(batch);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn add_batch(&mut self, batch: RecordBatch, watermark: Option<SystemTime>) -> Result<()> {
+        if batch.num_rows() == 0 {
+            warn!("was asked to add an empty batch, should be impossible");
+            return Ok(());
+        }
+        let start_time = start_time_for_sorted_batch(
+            &batch,
+            &self.session_window_config.unkeyed_aggregate_schema_ref,
+        );
+        let Some(watermark) = watermark else {
+            // no watermark, so we can't start an active session yet, just put it in the buffer.
+            self.batches_by_start_time
+                .entry(start_time)
+                .or_default()
+                .push(batch);
+            return Ok(());
+        };
+        self.batches_by_start_time
+            .entry(start_time)
+            .or_default()
+            .push(batch);
+
+        if self.active_session.is_some() {
+            // the invariant may be broken, so we should fix fill in the active session.
+            // this is a little inefficient as we know only the new batch could be added,
+            // but it's just a couple of map adds.
+            self.fill_active_session()?;
+        }
+        let flushed_batches = self.watermark_update(watermark).await?;
+        if !flushed_batches.is_empty() {
+            bail!("should not have flushed batches when adding a batch");
+        }
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.active_session.is_none() && self.batches_by_start_time.is_empty()
+    }
+
+    fn earliest_data(&self) -> Option<SystemTime> {
+        match self.active_session {
+            Some(ref active_session) => Some(active_session.data_start),
+            None => self
+                .batches_by_start_time
+                .first_key_value()
+                .map(|(start_time, _batches)| *start_time),
+        }
+    }
+}
+
+fn start_time_for_sorted_batch(batch: &RecordBatch, schema: &ArroyoSchema) -> SystemTime {
+    let timestamp_array = batch.column(schema.timestamp_index);
+    let timestamp_array = timestamp_array
+        .as_any()
+        .downcast_ref::<PrimitiveArray<TimestampNanosecondType>>()
+        .unwrap();
+    let min_timestamp = timestamp_array.value(0);
+    from_nanos(min_timestamp as u128)
+}
+
+impl ArrowOperatorConstructor<api::WindowAggregateOperator> for SessionAggregatingWindowFunc {
+    fn from_config(proto_config: api::WindowAggregateOperator) -> Result<OperatorNode> {
+        let input_schema: Schema = serde_json::from_slice(proto_config.input_schema.as_slice())
+            .context(format!(
+                "failed to deserialize schema of length {}",
+                proto_config.input_schema.len()
+            ))?;
+
+        let mut physical_plan =
+            PhysicalPlanNode::decode(&mut proto_config.physical_plan.as_slice()).unwrap();
+
+        let Some(arroyo_rpc::grpc::api::Window {
+            window: Some(Window::SessionWindow(window)),
+        }) = proto_config.window
+        else {
+            bail!("expected Session window")
+        };
+        let window_field = Arc::new(Field::new(
+            proto_config.window_field_name,
+            window_arrow_struct(),
+            true,
+        ));
+
+        // Calculate the partial schema so that it can be saved to state.
+        let key_indices: Vec<_> = proto_config
+            .key_fields
+            .into_iter()
+            .map(|x| x as usize)
+            .collect();
+
+        let receiver = Arc::new(RwLock::new(None));
+        let PhysicalPlanType::Aggregate(mut aggregate) = physical_plan
+            .physical_plan_type
+            .take()
+            .ok_or_else(|| anyhow!("missing physical plan"))?
+        else {
+            bail!("expected aggregate physical plan, not {:?}", physical_plan);
+        };
+
+        let AggregateMode::Final = aggregate.mode() else {
+            bail!("expect AggregateMode to start as Final in session window. Currently is switched to Single")
+        };
+
+        if aggregate.group_expr.len() != key_indices.len() {
+            bail!(
+                "expected {} group expressions, got {}",
+                key_indices.len(),
+                aggregate.group_expr.len()
+            );
+        }
+        // Remove the key fields from the group expression, as we decompose incoming data into key-specific aggregates.
+        // TODO: move into planning?
+        aggregate.group_expr.clear();
+        aggregate.group_expr_name.clear();
+        aggregate.groups.clear();
+        aggregate.mode = AggregateMode::Single.into();
+
+        let table_provider = ArroyoMemExec {
+            table_name: "input".into(),
+            schema: Arc::new(input_schema.clone()),
+        };
+
+        // swap in an ArroyoMemExec as the source.
+        // This is a flexible table source that can be decoded in various ways depending on what is needed.
+        aggregate.input = Some(Box::new(PhysicalPlanNode::try_from_physical_plan(
+            Arc::new(table_provider),
+            &ArroyoPhysicalExtensionCodec::default(),
+        )?));
+
+        let codec = ArroyoPhysicalExtensionCodec {
+            context: DecodingContext::UnboundedBatchStream(receiver.clone()),
+        };
+
+        let final_plan = PhysicalPlanNode {
+            physical_plan_type: Some(PhysicalPlanType::Aggregate(aggregate)),
+        };
+
+        debug!("physical plan: {:#?}", final_plan);
+
+        // deserialize the finish plan to read directly from a Vec<RecordBatch> behind a RWLock.
+        let final_execution_plan = final_plan.try_into_physical_plan(
+            &EmptyRegistry {},
+            &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
+            &codec,
+        )?;
+        let Some((timestamp_field_index, _)) = input_schema.column_with_name(TIMESTAMP_FIELD)
+        else {
+            bail!("input schema does not have a timestamp field")
+        };
+        let row_converter = RowConverter::new(
+            input_schema
+                .fields()
+                .into_iter()
+                .take(key_indices.len())
+                .map(|field| SortField::new(field.data_type().clone()))
+                .collect(),
+        )?;
+        debug!(
+            "output aggregate schema is {:#?}",
+            final_execution_plan.schema()
+        );
+        let input_schema_ref = Arc::new(ArroyoSchema::new(
+            Arc::new(input_schema),
+            timestamp_field_index,
+            key_indices.clone(),
+        ));
+        let unkeyed_aggregate_schema_ref = input_schema_ref.clone();
+        let config = SessionWindowConfig {
+            gap: Duration::from_micros(window.gap_micros),
+            window_field,
+            window_index: proto_config.window_index as usize,
+            input_schema_ref,
+            unkeyed_aggregate_schema_ref,
+            final_physical_exec: final_execution_plan,
+            receiver,
+        };
+
+        Ok(OperatorNode::from_operator(Box::new(Self {
+            config: Arc::new(config),
+            keys_by_next_watermark_action: BTreeMap::new(),
+            keys_by_start_time: BTreeMap::new(),
+            key_computations: HashMap::new(),
+            row_converter,
+        })))
+    }
+}
+
+#[async_trait::async_trait]
+
+impl ArrowOperator for SessionAggregatingWindowFunc {
+    fn name(&self) -> String {
+        "session_window".to_string()
+    }
+
+    async fn on_start(&mut self, ctx: &mut ArrowContext) {
+        let start_times_map: &mut GlobalKeyedView<usize, Option<SystemTime>> =
+            ctx.table_manager.get_global_keyed_state("e").await.unwrap();
+        let start_time = start_times_map
+            .get_all()
+            .values()
+            .filter_map(|earliest| earliest.clone())
+            .min();
+        if start_time.is_none() {
+            // each subtask only writes None if it has no data at all, e.g. key_computations is empty.
+            return;
+        };
+        info!("restoring from state at {:?}", start_time);
+
+        let table = ctx
+            .table_manager
+            // TODO: this will subtract the retention from start time, so hold more than it should,
+            // but we plan to overhaul it all anyway.
+            .get_expiring_time_key_table("s", start_time)
+            .await
+            .expect("should be able to load table");
+        let all_batches = table.all_batches_for_watermark(start_time);
+        for (_max_timestamp, batches) in all_batches {
+            for batch in batches {
+                let batch = self
+                    .filter_batch_by_time(batch.clone(), start_time)
+                    .expect("should be able to filter");
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+                let sorted = self
+                    .sort_batch(&batch)
+                    .expect("should be able to sort batch");
+
+                self.add_at_watermark(sorted, start_time)
+                    .await
+                    .expect("should be able to add batch");
+            }
+        }
+        let evicted_results = self
+            .results_at_watermark(SystemTime::now())
+            .await
+            .expect("should be able to get results");
+        if evicted_results.len() > 0 {
+            warn!(
+                "evicted {} results when restoring from state.",
+                evicted_results.len()
+            );
+        }
+    }
+
+    // TODO: filter out late data
+    async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut ArrowContext) {
+        debug!("received batch {:?}", batch);
+        let current_watermark = ctx.last_present_watermark();
+        let batch = if let Some(watermark) = current_watermark {
+            // filter out late data
+            let timestamp_column = batch
+                .column(self.config.input_schema_ref.timestamp_index)
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .unwrap();
+            let watermark_scalar = TimestampNanosecondArray::new_scalar(to_nanos(watermark) as i64);
+            let on_time = gt_eq(timestamp_column, &watermark_scalar).unwrap();
+            filter_record_batch(&batch, &on_time).unwrap()
+        } else {
+            batch
+        };
+        if batch.num_rows() == 0 {
+            warn!("fully filtered out a batch");
+            return;
+        }
+        let sorted = self
+            .sort_batch(&batch)
+            .expect("should be able to sort batch");
+
+        // send to state backend.
+        // TODO: pre-aggregate data before sending to state backend.
+        let table = ctx
+            .table_manager
+            .get_expiring_time_key_table("s", current_watermark)
+            .await
+            .expect("should get table");
+
+        let max_timestamp = sorted
+            .column(self.config.input_schema_ref.timestamp_index)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap()
+            .value(sorted.num_rows() - 1);
+        table.insert(from_nanos(max_timestamp as u128), sorted.clone());
+
+        self.add_at_watermark(sorted, current_watermark)
+            .await
+            .expect("should be able to add batch");
+    }
+
+    async fn handle_watermark(&mut self, watermark: Watermark, ctx: &mut ArrowContext) {
+        self.advance(ctx).await.unwrap();
+
+        ctx.broadcast(ArrowMessage::Signal(SignalMessage::Watermark(watermark)))
+            .await;
+    }
+
+    async fn handle_checkpoint(&mut self, _b: CheckpointBarrier, ctx: &mut ArrowContext) {
+        let watermark = ctx.last_present_watermark();
+        let table = ctx
+            .table_manager
+            .get_expiring_time_key_table("s", watermark)
+            .await
+            .expect("should get table");
+        table.flush(watermark).await.unwrap();
+        ctx.table_manager
+            .get_global_keyed_state("e")
+            .await
+            .unwrap()
+            .insert(ctx.task_info.task_index, self.earliest_batch_time()).await;
+    }
+
+    fn tables(&self) -> HashMap<String, TableConfig> {
+        let mut tables = global_table_config("e", "earliest start time of all active batches.");
+        tables.insert(
+            "s".to_string(),
+            timestamp_table_config(
+                "s",
+                "session",
+                // TODO: something better
+                self.config.gap * 100,
+                self.config.input_schema_ref.as_ref().clone(),
+            ),
+        );
+        tables
+    }
+}

--- a/arroyo-worker/src/arrow/session_aggregating_window.rs
+++ b/arroyo-worker/src/arrow/session_aggregating_window.rs
@@ -924,7 +924,8 @@ impl ArrowOperator for SessionAggregatingWindowFunc {
             .get_global_keyed_state("e")
             .await
             .unwrap()
-            .insert(ctx.task_info.task_index, self.earliest_batch_time()).await;
+            .insert(ctx.task_info.task_index, self.earliest_batch_time())
+            .await;
     }
 
     fn tables(&self) -> HashMap<String, TableConfig> {

--- a/arroyo-worker/src/arrow/tumbling_aggregating_window.rs
+++ b/arroyo-worker/src/arrow/tumbling_aggregating_window.rs
@@ -99,75 +99,28 @@ type PolledFutureT = <NextBatchFuture<SystemTime> as Future>::Output;
 
 impl TumblingAggregatingWindowFunc<SystemTime> {}
 
-impl ArrowOperatorConstructor<api::WindowAggregateOperator>
+impl ArrowOperatorConstructor<api::TumblingWindowAggregateOperator>
     for TumblingAggregatingWindowFunc<SystemTime>
 {
-    fn from_config(proto_config: api::WindowAggregateOperator) -> Result<OperatorNode> {
-        let Some(arroyo_rpc::grpc::api::Window {
-            window: Some(window),
-        }) = &proto_config.window
-        else {
-            bail!("expected a window")
-        };
-        info!("window is {:?}", window);
-        match window {
-            Window::SlidingWindow(_) => {
-                return SlidingAggregatingWindowFunc::from_config(proto_config)
-            }
-            Window::TumblingWindow(_) => {}
-            Window::InstantWindow(_) => bail!("instant window unsupported"),
-            Window::SessionWindow(_) => {
-                info!("session window");
-                return SessionAggregatingWindowFunc::from_config(proto_config)
-            }
-        }
+    fn from_config(config: api::TumblingWindowAggregateOperator) -> anyhow::Result<OperatorNode> {
+        let width = Duration::from_micros(config.width_micros);
+        let input_schema: ArroyoSchema = config
+            .input_schema
+            .ok_or_else(|| anyhow!("requires input schema"))?
+            .try_into()?;
+        let binning_function = PhysicalExprNode::decode(&mut config.binning_function.as_slice())?;
         let binning_function =
-            PhysicalExprNode::decode(&mut proto_config.binning_function.as_slice()).unwrap();
-        let input_schema: Schema = serde_json::from_slice(proto_config.input_schema.as_slice())
-            .context(format!(
-                "failed to deserialize schema of length {}",
-                proto_config.input_schema.len()
-            ))?;
-
-        let binning_function =
-            parse_physical_expr(&binning_function, &EmptyRegistry {}, &input_schema)?;
-
-        let mut physical_plan =
-            PhysicalPlanNode::decode(&mut proto_config.physical_plan.as_slice()).unwrap();
-
-        let Some(arroyo_rpc::grpc::api::Window {
-            window: Some(Window::TumblingWindow(window)),
-        }) = proto_config.window
-        else {
-            bail!("expected tumbling window")
-        };
-        let window_field = Arc::new(Field::new(
-            proto_config.window_field_name,
-            window_arrow_struct(),
-            true,
-        ));
+            parse_physical_expr(&binning_function, &EmptyRegistry {}, &input_schema.schema)?;
 
         let receiver = Arc::new(RwLock::new(None));
         let final_batches_passer = Arc::new(RwLock::new(Vec::new()));
 
-        let PhysicalPlanType::Aggregate(mut aggregate) = physical_plan
-            .physical_plan_type
-            .take()
-            .ok_or_else(|| anyhow!("missing physical plan"))?
-        else {
-            bail!("expected aggregate physical plan, not {:?}", physical_plan);
-        };
-
-        let AggregateMode::Final = aggregate.mode() else {
-            bail!("expect AggregateMode to be Final so we can decompose it for checkpointing.")
-        };
-
-        // pull the input out to be computed separately for each bin.
-        let partial_aggregation_plan = aggregate.input.as_ref().unwrap();
-
         let codec = ArroyoPhysicalExtensionCodec {
             context: DecodingContext::UnboundedBatchStream(receiver.clone()),
         };
+
+        let partial_aggregation_plan =
+            PhysicalPlanNode::decode(&mut config.partial_aggregation_plan.as_slice())?;
 
         // deserialize partial aggregation into execution plan with an UnboundedBatchStream source.
         // this is behind a RwLock and will have a new channel swapped in before computation is initialized
@@ -178,22 +131,12 @@ impl ArrowOperatorConstructor<api::WindowAggregateOperator>
             &codec,
         )?;
 
-        let partial_schema = partial_aggregation_plan.schema();
-        let table_provider = ArroyoMemExec {
-            table_name: "partial".into(),
-            schema: partial_schema,
-        };
+        let partial_schema = config
+            .partial_schema
+            .ok_or_else(|| anyhow!("requires partial schema"))?
+            .try_into()?;
 
-        // swap in an ArroyoMemExec as the source.
-        // This is a flexible table source that can be decoded in various ways depending on what is needed.
-        aggregate.input = Some(Box::new(PhysicalPlanNode::try_from_physical_plan(
-            Arc::new(table_provider),
-            &ArroyoPhysicalExtensionCodec::default(),
-        )?));
-
-        let finish_plan = PhysicalPlanNode {
-            physical_plan_type: Some(PhysicalPlanType::Aggregate(aggregate)),
-        };
+        let finish_plan = PhysicalPlanNode::decode(&mut config.final_aggregation_plan.as_slice())?;
 
         let final_codec = ArroyoPhysicalExtensionCodec {
             context: DecodingContext::LockedBatchVec(final_batches_passer.clone()),
@@ -205,26 +148,14 @@ impl ArrowOperatorConstructor<api::WindowAggregateOperator>
             &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
             &final_codec,
         )?;
-
-        // Calculate the partial schema so that it can be saved to state.
-        let key_indices: Vec<_> = proto_config
-            .key_fields
-            .into_iter()
-            .map(|x| x as usize)
-            .collect();
-
-        let schema_ref = partial_aggregation_plan.schema();
-        // timestamp is stored in the bin, will be appended prior to writing to state.
-        let partial_schema = add_timestamp_field_arrow(schema_ref);
-        let timestamp_index = partial_schema.fields().len() - 1;
-        let partial_schema = ArroyoSchema {
-            schema: partial_schema,
-            timestamp_index,
-            key_indices,
-        };
+        let window_field = Arc::new(Field::new(
+            config.window_field_name,
+            window_arrow_struct(),
+            true,
+        ));
 
         Ok(OperatorNode::from_operator(Box::new(Self {
-            width: Duration::from_micros(window.size_micros),
+            width,
             binning_function,
             partial_aggregation_plan,
             partial_schema,
@@ -234,7 +165,7 @@ impl ArrowOperatorConstructor<api::WindowAggregateOperator>
             futures: Arc::new(Mutex::new(FuturesUnordered::new())),
             execs: BTreeMap::new(),
             window_field,
-            window_index: proto_config.window_index as usize,
+            window_index: config.window_index as usize,
         })))
     }
 }
@@ -286,7 +217,6 @@ impl ArrowOperator for TumblingAggregatingWindowFunc<SystemTime> {
         for range in partition.ranges() {
             // the binning function already rounded down to the bin start.
             let bin_start = from_nanos(typed_bin.value(range.start) as u128);
-
             let watermark = ctx.last_present_watermark();
 
             if watermark.is_some() && bin_start < self.bin_start(watermark.unwrap()) {
@@ -353,9 +283,10 @@ impl ArrowOperator for TumblingAggregatingWindowFunc<SystemTime> {
                         .unwrap();
                     while let Some(batch) = final_exec.next().await {
                         let batch = batch.expect("should be able to compute batch");
-                        let bin_start = to_nanos(bin) as i64;
-                        let bin_end = to_nanos(bin + self.width) as i64;
+                        let bin_start = to_nanos(popped_bin) as i64;
+                        let bin_end = to_nanos(popped_bin + self.width) as i64;
                         let timestamp = bin_end - 1;
+
                         let timestamp_array =
                             ScalarValue::TimestampNanosecond(Some(timestamp), None)
                                 .to_array_of_size(batch.num_rows())

--- a/arroyo-worker/src/connectors/filesystem/source/mod.rs
+++ b/arroyo-worker/src/connectors/filesystem/source/mod.rs
@@ -218,7 +218,7 @@ impl FileSystemSourceFunc {
                             format!("path:{}, err:{}", path, err),
                         )
                     })?
-                    .with_batch_size(1024);
+                    .with_batch_size(8192);
                 let stream = reader_builder.build().map_err(|err| {
                     UserError::new(
                         "could not build parquet record batch stream",

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -1427,6 +1427,7 @@ pub fn construct_operator(operator: OperatorName, config: Vec<u8>) -> OperatorNo
             KeyExecutionOperator::from_config(prost::Message::decode(&mut buf).unwrap())
         }
         OperatorName::ArrowAggregate => {
+            // TODO: this should not be in a specific window.
             TumblingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
         }
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -20,6 +20,7 @@ use datafusion_common::hash_utils;
 
 use tracing::{debug, info, warn};
 
+use crate::arrow::sliding_aggregating_window::SlidingAggregatingWindowFunc;
 use crate::arrow::tumbling_aggregating_window::TumblingAggregatingWindowFunc;
 use crate::arrow::{GrpcRecordBatchSink, KeyExecutionOperator, ValueExecutionOperator};
 use crate::connectors::filesystem::single_file::sink::FileSink;
@@ -1432,6 +1433,9 @@ pub fn construct_operator(operator: OperatorName, config: Vec<u8>) -> OperatorNo
         }
         OperatorName::TumblingWindowAggregate => {
             TumblingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
+        }
+        OperatorName::SlidingWindowAggregate => {
+            SlidingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
         }
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
             let op: api::ConnectorOp = prost::Message::decode(&mut buf).unwrap();

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -20,6 +20,7 @@ use datafusion_common::hash_utils;
 
 use tracing::{debug, info, warn};
 
+use crate::arrow::session_aggregating_window::SessionAggregatingWindowFunc;
 use crate::arrow::sliding_aggregating_window::SlidingAggregatingWindowFunc;
 use crate::arrow::tumbling_aggregating_window::TumblingAggregatingWindowFunc;
 use crate::arrow::{GrpcRecordBatchSink, KeyExecutionOperator, ValueExecutionOperator};
@@ -1436,6 +1437,9 @@ pub fn construct_operator(operator: OperatorName, config: Vec<u8>) -> OperatorNo
         }
         OperatorName::SlidingWindowAggregate => {
             SlidingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
+        }
+        OperatorName::SessionWindowAggregate => {
+            SessionAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
         }
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
             let op: api::ConnectorOp = prost::Message::decode(&mut buf).unwrap();

--- a/arroyo-worker/src/engine.rs
+++ b/arroyo-worker/src/engine.rs
@@ -1430,6 +1430,9 @@ pub fn construct_operator(operator: OperatorName, config: Vec<u8>) -> OperatorNo
             // TODO: this should not be in a specific window.
             TumblingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
         }
+        OperatorName::TumblingWindowAggregate => {
+            TumblingAggregatingWindowFunc::from_config(prost::Message::decode(&mut buf).unwrap())
+        }
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
             let op: api::ConnectorOp = prost::Message::decode(&mut buf).unwrap();
             match op.operator.as_str() {


### PR DESCRIPTION
This implements Session Windows in the record batch ecosystem. The algorithm works as follows:


Each group by key is tracked separately in a KeyComputingHolder. This contains the configuration, potentially an ActiveSession, and a sorted map from minimum time to a Vec of RecordBatches. RecordBatches are always sorted by time order, and there is an invariant that if the active session is non-empty the data_end + gap is less than the first batches_by_start_time. This allows us to immediately flush the active session when the watermark advances.

### Adding a Batch
All batches are first added to the buffered batches, and then fill_active_session() is called to enforce the invariant. fill_active_session() compares the end of the active session with the fist batch in the buffer, and if they are within gap, adds as much of the batch as is definitely in the session. This is done in a loop until the invariant is reached.

### Advancing the watermark
When the watermark is advanced, two things may happen: The active session may be finished and a new active session may begin. These are done in a loop, first checking if there have been no events in the active session since `watermark - gap`. Then, if the first buffered event is within `gap` of the watermark, it will definitely be present in the next active session. As such, it is used to start a new session. When a new session is initialized, we call `fill_active_session()` to enforce the invariant.



This change also refactors the production of these windowed aggregates, so more of the SQL manipulation happens in planning, rather in the from_config() method of the operators.
