### PR TITLE
Remove build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,18 +73,6 @@ jobs:
             mv /tmp/refinery*-musl/refinery /tmp
           popd
           /tmp/refinery migrate -e DATABASE_URL -p arroyo-api/migrations
-      - name: Set up cache
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            target
-          key: ${{ runner.os }}-cargo-df-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-df
       - name: Install dependencies
         run: |
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin


### PR DESCRIPTION
Saving/restoring the build cache takes much longer than just recreating it.

With cache, CI times are in the 8-11 minute range (and occasionally much longer). Without, it is ~6 minutes.
