### PR TITLE
arroyo-df: nested aggregations

### DIFF
--- a/arroyo-rpc/proto/api.proto
+++ b/arroyo-rpc/proto/api.proto
@@ -135,12 +135,11 @@ message TumblingWindowAggregateOperator {
   string name = 1;
   uint64 width_micros = 2;
   bytes binning_function = 3;
-  string window_field_name = 4;
-  uint64 window_index = 5;
-  ArroyoSchema input_schema = 6;
-  ArroyoSchema partial_schema = 7;
-  bytes partial_aggregation_plan = 8;
-  bytes final_aggregation_plan = 9;
+  ArroyoSchema input_schema = 4;
+  ArroyoSchema partial_schema = 5;
+  bytes partial_aggregation_plan = 6;
+  bytes final_aggregation_plan = 7;
+  optional bytes final_projection = 8;
 }
 
 message SlidingWindowAggregateOperator {

--- a/arroyo-worker/src/arrow/join_with_expiration.rs
+++ b/arroyo-worker/src/arrow/join_with_expiration.rs
@@ -200,7 +200,7 @@ impl OperatorConstructor for JoinWithExpirationConstructor {
         };
         let join_physical_plan_node = PhysicalPlanNode::decode(&mut config.join_plan.as_slice())?;
         let join_execution_plan = join_physical_plan_node.try_into_physical_plan(
-            &EmptyRegistry {},
+            &EmptyRegistry::new(),
             &RuntimeEnv::new(RuntimeConfig::new())?,
             &codec,
         )?;

--- a/arroyo-worker/src/arrow/mod.rs
+++ b/arroyo-worker/src/arrow/mod.rs
@@ -40,7 +40,7 @@ impl OperatorConstructor for ValueExecutionConstructor {
     type ConfigT = api::ValuePlanOperator;
     fn with_config(&self, config: api::ValuePlanOperator) -> Result<OperatorNode> {
         let locked_batch = Arc::new(RwLock::default());
-        let registry = EmptyRegistry {};
+        let registry = EmptyRegistry::new();
 
         let plan = PhysicalPlanNode::decode(&mut config.physical_plan.as_slice()).unwrap();
         let codec = ArroyoPhysicalExtensionCodec {
@@ -165,7 +165,7 @@ impl OperatorConstructor for KeyExecutionConstructor {
 
     fn with_config(&self, config: api::KeyPlanOperator) -> Result<OperatorNode> {
         let locked_batch = Arc::new(RwLock::default());
-        let registry = EmptyRegistry {};
+        let registry = EmptyRegistry::new();
 
         let plan = PhysicalPlanNode::decode(&mut config.physical_plan.as_slice()).unwrap();
         let codec = ArroyoPhysicalExtensionCodec {

--- a/arroyo-worker/src/arrow/session_aggregating_window.rs
+++ b/arroyo-worker/src/arrow/session_aggregating_window.rs
@@ -693,7 +693,7 @@ impl OperatorConstructor for SessionAggregatingWindowConstructor {
         };
         let final_plan = PhysicalPlanNode::decode(&mut config.final_aggregation_plan.as_slice())?;
         let final_execution_plan = final_plan.try_into_physical_plan(
-            &EmptyRegistry {},
+            &EmptyRegistry::new(),
             &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
             &codec,
         )?;

--- a/arroyo-worker/src/arrow/sliding_aggregating_window.rs
+++ b/arroyo-worker/src/arrow/sliding_aggregating_window.rs
@@ -463,8 +463,11 @@ impl OperatorConstructor for SlidingAggregatingWindowConstructor {
             .ok_or_else(|| anyhow!("missing input schema"))?
             .try_into()?;
         let binning_function = PhysicalExprNode::decode(&mut config.binning_function.as_slice())?;
-        let binning_function =
-            parse_physical_expr(&binning_function, &EmptyRegistry {}, &input_schema.schema)?;
+        let binning_function = parse_physical_expr(
+            &binning_function,
+            &EmptyRegistry::new(),
+            &input_schema.schema,
+        )?;
 
         let receiver = Arc::new(RwLock::new(None));
         let final_batches_passer = Arc::new(RwLock::new(Vec::new()));
@@ -476,7 +479,7 @@ impl OperatorConstructor for SlidingAggregatingWindowConstructor {
             PhysicalPlanNode::decode(&mut config.partial_aggregation_plan.as_slice())?;
 
         let partial_aggregation_plan = partial_aggregation_plan.try_into_physical_plan(
-            &EmptyRegistry {},
+            &EmptyRegistry::new(),
             &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
             &codec,
         )?;
@@ -491,7 +494,7 @@ impl OperatorConstructor for SlidingAggregatingWindowConstructor {
             context: DecodingContext::LockedBatchVec(final_batches_passer.clone()),
         };
         let finish_execution_plan = finish_plan.try_into_physical_plan(
-            &EmptyRegistry {},
+            &EmptyRegistry::new(),
             &RuntimeEnv::new(RuntimeConfig::new()).unwrap(),
             &final_codec,
         )?;

--- a/arroyo-worker/src/operators/watermark_generator.rs
+++ b/arroyo-worker/src/operators/watermark_generator.rs
@@ -64,7 +64,8 @@ impl OperatorConstructor for WatermarkGeneratorConstructor {
     fn with_config(&self, config: ExpressionWatermarkConfig) -> anyhow::Result<OperatorNode> {
         let input_schema: ArroyoSchema = config.input_schema.unwrap().try_into()?;
         let expression = PhysicalExprNode::decode(&mut config.expression.as_slice())?;
-        let expression = parse_physical_expr(&expression, &EmptyRegistry {}, &input_schema.schema)?;
+        let expression =
+            parse_physical_expr(&expression, &EmptyRegistry::new(), &input_schema.schema)?;
 
         Ok(OperatorNode::from_operator(Box::new(
             WatermarkGenerator::expression(


### PR DESCRIPTION
This implements nested aggregations by detecting if the input has a window and if so using that. If it doesn't have a window, it looks to the input, using a visitor which includes a table scan map. 

Currently the checks around correct windowing are less robust than what is on master. We should discuss the exact semantics we'd like to support. 
A query like
```
create table impulse
 with (
    connector = 'impulse',
    event_rate = '10'
);
SELECT  window, subtask_index, sum(rows) as overall FROM (
SELECT tumble(interval '5 second') as window, CAST((counter/ 20) as BIGINT) as counter_mod, subtask_index, count(*) as rows FROM impulse GROUP BY 1,2,3) GROUP BY 1,2 
```
now behaves as expected.