### PR TITLE
Improve kafka client_config setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,6 +6219,7 @@ dependencies = [
  "serde_json",
  "slab",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/arroyo-connectors/Cargo.toml
+++ b/arroyo-connectors/Cargo.toml
@@ -26,7 +26,7 @@ schemars = "0.8"
 tonic = {workspace = true}
 
 # connector dependencies
-rdkafka = { version = "0.33", features = ["cmake-build"] }
+rdkafka = { version = "0.33", features = ["cmake-build", "tracing"] }
 anyhow = "1.0.71"
 tracing = "0.1.37"
 regress = "0.6.0"

--- a/arroyo-connectors/src/lib.rs
+++ b/arroyo-connectors/src/lib.rs
@@ -399,7 +399,7 @@ fn construct_http_client(endpoint: &str, headers: Option<String>) -> anyhow::Res
     };
 
     let headers: anyhow::Result<HeaderMap> =
-        string_to_map(headers.as_ref().map(|t| t.as_str()).unwrap_or(""))
+        string_to_map(headers.as_ref().map(|t| t.as_str()).unwrap_or(""), ':')
             .expect("Invalid header map")
             .into_iter()
             .map(|(k, v)| {

--- a/arroyo-connectors/src/polling_http.rs
+++ b/arroyo-connectors/src/polling_http.rs
@@ -195,7 +195,7 @@ impl Connector for PollingHTTPConnector {
         let description = format!("PollingHTTPSource<{}>", table.endpoint);
 
         if let Some(headers) = &table.headers {
-            string_to_map(&headers.sub_env_vars()?).ok_or_else(|| {
+            string_to_map(&headers.sub_env_vars()?, ':').ok_or_else(|| {
                 anyhow!(
                     "Invalid format for headers; should be a \
                     comma-separated list of colon-separated key value pairs"

--- a/arroyo-connectors/src/sse.rs
+++ b/arroyo-connectors/src/sse.rs
@@ -79,7 +79,7 @@ impl Connector for SSEConnector {
         let description = format!("SSESource<{}>", table.endpoint);
 
         if let Some(headers) = &table.headers {
-            string_to_map(&headers.sub_env_vars()?).ok_or_else(|| {
+            string_to_map(&headers.sub_env_vars()?, ':').ok_or_else(|| {
                 anyhow!(
                     "Invalid format for headers; should be a \
                     comma-separated list of colon-separated key value pairs"
@@ -182,6 +182,7 @@ impl SseTester {
                 .map(|s| s.sub_env_vars())
                 .transpose()?
                 .unwrap_or("".to_string()),
+            ':',
         )
         .ok_or_else(|| anyhow!("Headers are invalid; should be comma-separated pairs"))?;
 

--- a/arroyo-connectors/src/websocket.rs
+++ b/arroyo-connectors/src/websocket.rs
@@ -88,7 +88,7 @@ impl Connector for WebsocketConnector {
                 }
             };
 
-            let headers = match string_to_map(&headers_str.unwrap_or("".to_string()))
+            let headers = match string_to_map(&headers_str.unwrap_or("".to_string()), ':')
                 .ok_or_else(|| anyhow!("Headers are invalid; should be comma-separated pairs"))
             {
                 Ok(headers) => headers,
@@ -223,7 +223,7 @@ impl Connector for WebsocketConnector {
         let description = format!("WebsocketSource<{}>", table.endpoint);
 
         if let Some(headers) = &table.headers {
-            string_to_map(&headers.sub_env_vars()?).ok_or_else(|| {
+            string_to_map(&headers.sub_env_vars()?, ':').ok_or_else(|| {
                 anyhow!(
                     "Invalid format for headers; should be a \
                     comma-separated list of colon-separated key value pairs"

--- a/arroyo-types/src/lib.rs
+++ b/arroyo-types/src/lib.rs
@@ -262,14 +262,14 @@ pub fn days_since_epoch(time: SystemTime) -> i32 {
         .div_euclid(86400) as i32
 }
 
-pub fn string_to_map(s: &str) -> Option<HashMap<String, String>> {
+pub fn string_to_map(s: &str, pair_delimeter: char) -> Option<HashMap<String, String>> {
     if s.trim().is_empty() {
         return Some(HashMap::new());
     }
 
     s.split(',')
         .map(|s| {
-            let mut kv = s.trim().split(':');
+            let mut kv = s.trim().split(pair_delimeter);
             Some((kv.next()?.trim().to_string(), kv.next()?.trim().to_string()))
         })
         .collect()

--- a/arroyo-worker/Cargo.toml
+++ b/arroyo-worker/Cargo.toml
@@ -61,7 +61,7 @@ governor = "0.6"
 tracing = "0.1"
 
 # connectors
-rdkafka = { version = "0.33", features = ["cmake-build"] }
+rdkafka = { version = "0.33", features = ["cmake-build", "tracing"] }
 rdkafka-sys = "4.5.0"
 eventsource-client = "0.11.0"
 regex = "1.8.1"

--- a/arroyo-worker/src/connectors/kafka/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/mod.rs
@@ -51,15 +51,15 @@ pub fn client_configs(connection: &KafkaConfig, table: &KafkaTable) -> HashMap<S
                     .sub_env_vars()
                     .expect("Missing env-vars for Kafka password"),
             );
-
-            client_configs.extend(
-                table
-                    .client_configs
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string())),
-            );
         }
     };
+
+    client_configs.extend(
+        table
+            .client_configs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string())),
+    );
 
     client_configs
 }

--- a/arroyo-worker/src/connectors/polling_http.rs
+++ b/arroyo-worker/src/connectors/polling_http.rs
@@ -77,6 +77,7 @@ where
                 .as_ref()
                 .map(|t| t.sub_env_vars().expect("Failed to substitute env vars"))
                 .unwrap_or("".to_string()),
+            ':',
         )
         .expect("Invalid header map")
         .into_iter()

--- a/arroyo-worker/src/connectors/sse.rs
+++ b/arroyo-worker/src/connectors/sse.rs
@@ -86,7 +86,7 @@ where
 
         Self {
             url: table.endpoint,
-            headers: string_to_map(&headers.unwrap_or("".to_string()))
+            headers: string_to_map(&headers.unwrap_or("".to_string()), ':')
                 .expect("Invalid header map")
                 .into_iter()
                 .collect(),

--- a/arroyo-worker/src/lib.rs
+++ b/arroyo-worker/src/lib.rs
@@ -631,6 +631,7 @@ pub fn header_map(headers: Option<VarStr>) -> HashMap<String, String> {
         &headers
             .map(|t| t.sub_env_vars().expect("Failed to substitute env vars"))
             .unwrap_or("".to_string()),
+        ':',
     )
     .expect("Invalid header map")
 }

--- a/k8s/arroyo/templates/api.yaml
+++ b/k8s/arroyo/templates/api.yaml
@@ -67,6 +67,10 @@ spec:
         {{- if .Values.api.resources }}
         resources: {{- toYaml .Values.api.resources | nindent 12 }}
         {{- end }}
+        volumeMounts:
+        {{- if .Values.volumeMounts }}
+        {{- include "tplvalues.render" (dict "value" .Values.volumeMounts "context" $) | nindent 10 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -79,6 +83,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      {{- if .Values.volumes }}
+      {{- include "tplvalues.render" (dict "value" .Values.volumes "context" $) | nindent 10 }}
+      {{- end }}
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR includes several fixes and improvements that make the kafka client more configurable, in service of supporting SSL authentication more naturally:
* The kafka tester in the UI now includes the client_options when constructing its client
* client_configs can now be set in SQL
* We will now always use client_configs in the kafka client, not just when SASL auth is enabled
* librdkafka is now compiled with the `tracing` option, which hooks it into our logging system giving better diagnostics
* In Helm, the api deployment now get volumes mounted, which allows it to access secrets needed for kafka testing

An example of SSL auth in SQL:


```sql
create table kafka_with_ssl (
    value TEXT,
) with (
    connector = 'kafka',
    bootstrap_servers = 'localhost:9092',
    format = 'raw_string',
    topic = 'test',
    type = 'source',
    client_configs = 'security.protocol=ssl,ssl.ca.location=/etc/secrets/ca.crt,ssl.certificate.location=/etc/secrets/client.certificate.pem,ssl.key.location=/etc/secrets/client.key,ssl.key.password=confluent'
);
```