### PR TITLE
Add support for custom schema registry subjects

### DIFF
--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -627,14 +627,18 @@ async fn get_schema(
         ));
     };
 
-    let resolver =
-        ConfluentSchemaRegistry::new(&endpoint, &table.subject(), api_key.clone(), api_secret.clone())
-            .map_err(|e| {
-                bad_request(format!(
-                    "failed to fetch schemas from schema repository: {}",
-                    e
-                ))
-            })?;
+    let resolver = ConfluentSchemaRegistry::new(
+        &endpoint,
+        &table.subject(),
+        api_key.clone(),
+        api_secret.clone(),
+    )
+    .map_err(|e| {
+        bad_request(format!(
+            "failed to fetch schemas from schema repository: {}",
+            e
+        ))
+    })?;
 
     resolver.get_schema_for_version(None).await.map_err(|e| {
         bad_request(format!(

--- a/arroyo-api/src/connection_tables.rs
+++ b/arroyo-api/src/connection_tables.rs
@@ -628,7 +628,7 @@ async fn get_schema(
     };
 
     let resolver =
-        ConfluentSchemaRegistry::new(&endpoint, &table.topic, api_key.clone(), api_secret.clone())
+        ConfluentSchemaRegistry::new(&endpoint, &table.subject(), api_key.clone(), api_secret.clone())
             .map_err(|e| {
                 bad_request(format!(
                     "failed to fetch schemas from schema repository: {}",

--- a/arroyo-api/src/pipelines.rs
+++ b/arroyo-api/src/pipelines.rs
@@ -184,7 +184,7 @@ async fn try_register_confluent_schema(
     };
 
     let schema_registry =
-        ConfluentSchemaRegistry::new(&endpoint, &table.topic, api_key, api_secret)?;
+        ConfluentSchemaRegistry::new(&endpoint, &table.subject(), api_key, api_secret)?;
 
     match config.format.clone() {
         Some(Format::Avro(mut avro)) => {

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -44,7 +44,7 @@ import_types!(schema = "../connector-schemas/kafka/table.json");
 impl KafkaTable {
     pub fn subject(&self) -> Cow<str> {
         match &self.value_subject {
-            None => Cow::Owned(format!("{}_value", self.topic)),
+            None => Cow::Owned(format!("{}-value", self.topic)),
             Some(s) => Cow::Borrowed(s),
         }
     }

--- a/arroyo-connectors/src/kafka.rs
+++ b/arroyo-connectors/src/kafka.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use anyhow::{anyhow, bail};
 use arroyo_formats::avro::deserialize_slice_avro;
 use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema, TestSourceMessage};
@@ -14,6 +13,7 @@ use rdkafka::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;

--- a/arroyo-rpc/src/schema_resolver.rs
+++ b/arroyo-rpc/src/schema_resolver.rs
@@ -350,10 +350,10 @@ impl ConfluentSchemaRegistry {
             .join(&format!("/schemas/ids/{}", id))
             .unwrap();
 
-        self.client
-            .get_schema_for_url(url)
-            .await
-            .context(format!("failed to fetch schema for subject '{}'", self.subject))
+        self.client.get_schema_for_url(url).await.context(format!(
+            "failed to fetch schema for subject '{}'",
+            self.subject
+        ))
     }
 
     pub async fn get_schema_for_version(

--- a/arroyo-sql-macro/src/connectors.rs
+++ b/arroyo-sql-macro/src/connectors.rs
@@ -102,6 +102,7 @@ pub fn get_json_schema_source() -> Result<Connection> {
             read_mode: Some(ReadMode::ReadUncommitted),
         },
         client_configs: HashMap::new(),
+        value_subject: None,
     };
     KafkaConnector {}.from_config(
         Some(2),
@@ -209,6 +210,7 @@ pub fn get_avro_source() -> Result<Connection> {
             read_mode: Some(ReadMode::ReadUncommitted),
         },
         client_configs: HashMap::new(),
+        value_subject: None,
     };
     KafkaConnector {}.from_config(
         Some(3),

--- a/arroyo-sql/src/lib.rs
+++ b/arroyo-sql/src/lib.rs
@@ -770,6 +770,7 @@ pub fn get_test_expression(
                     group_id: "test-consumer-group".to_string().try_into().unwrap(),
                 },
                 client_configs: HashMap::new(),
+                value_subject: None,
             },
             Some(&schema),
         )

--- a/arroyo-worker/src/connectors/kafka/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use arroyo_rpc::var_str::VarStr;
@@ -15,6 +16,16 @@ import_types!(
     }
 );
 import_types!(schema = "../connector-schemas/kafka/table.json");
+
+impl KafkaTable {
+    pub fn subject(&self) -> Cow<str> {
+        match &self.value_subject {
+            None => Cow::Owned(format!("{}_value", self.topic)),
+            Some(s) => Cow::Borrowed(s),
+        }
+    }
+}
+
 
 impl SourceOffset {
     fn get_offset(&self) -> Offset {

--- a/arroyo-worker/src/connectors/kafka/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/mod.rs
@@ -26,7 +26,6 @@ impl KafkaTable {
     }
 }
 
-
 impl SourceOffset {
     fn get_offset(&self) -> Offset {
         match self {

--- a/arroyo-worker/src/connectors/kafka/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/mod.rs
@@ -20,7 +20,7 @@ import_types!(schema = "../connector-schemas/kafka/table.json");
 impl KafkaTable {
     pub fn subject(&self) -> Cow<str> {
         match &self.value_subject {
-            None => Cow::Owned(format!("{}_value", self.topic)),
+            None => Cow::Owned(format!("{}-value", self.topic)),
             Some(s) => Cow::Borrowed(s),
         }
     }

--- a/arroyo-worker/src/connectors/kafka/source/mod.rs
+++ b/arroyo-worker/src/connectors/kafka/source/mod.rs
@@ -120,7 +120,7 @@ where
                 Arc::new(
                     ConfluentSchemaRegistry::new(
                         &endpoint,
-                        &table.topic,
+                        &table.subject(),
                         api_key.clone(),
                         api_secret.clone(),
                     )

--- a/connector-schemas/kafka/table.json
+++ b/connector-schemas/kafka/table.json
@@ -72,6 +72,11 @@
             "additionalProperties": {
                 "type": "string"
             }
+        },
+        "value_subject": {
+            "type": "string",
+            "title": "Schema Registry value subject",
+            "description": "Set this to use a non-standard subject for this topic in Confluent Schema Registry (defaults to `{TOPIC}_value`)"
         }
     },
     "required": [


### PR DESCRIPTION
By default, kafa connect (and confluent cloud) will store the schema for a Kafka topic under the subject (the naming system for schema registry) "{topic}-value". However, in some cases there may be multiple subjects on a single topic with custom names. This PR adds the ability to override the default subject for a topic in the kafka table config.