### PR TITLE
rework SourceRewriter and TimestampRewriter to preserve table scan aliases.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.8",
  "tracing",
+ "tracing-subscriber",
  "unicase",
 ]
 

--- a/crates/arroyo-df/Cargo.toml
+++ b/crates/arroyo-df/Cargo.toml
@@ -39,6 +39,7 @@ async-trait = "0.1"
 proc-macro2 = "1"
 syn = {version = "2", features = ["full", "parsing", "extra-traits"]}
 tracing = "0.1.37"
+tracing-subscriber = "0.3"
 
 serde_json_path = "0.6.3"
 apache-avro = "0.16.0"

--- a/crates/arroyo-df/src/lib.rs
+++ b/crates/arroyo-df/src/lib.rs
@@ -568,10 +568,13 @@ impl LogicalPlanExtension {
                     fields.insert(*window_index, window_field.clone());
                 }
 
-                let output_schema = add_timestamp_field(Arc::new(
-                    DFSchema::new_with_metadata(fields, aggregate_schema.metadata().clone())
-                        .unwrap(),
-                ))
+                let output_schema = add_timestamp_field(
+                    Arc::new(
+                        DFSchema::new_with_metadata(fields, aggregate_schema.metadata().clone())
+                            .unwrap(),
+                    ),
+                    None,
+                )
                 .unwrap();
 
                 DataFusionEdge::new(output_schema, LogicalEdgeType::Forward, vec![]).unwrap()
@@ -1414,7 +1417,7 @@ pub async fn parse_and_get_arrow_program(
             .rewrite(&mut TimestampRewriter {})?
             .rewrite(&mut rewriter)?;
 
-        println!("Logical plan: {}", plan_rewrite.display_graphviz());
+        info!("Logical plan: {}", plan_rewrite.display_graphviz());
 
         for (original_name, index) in &rewriter.table_source_to_nodes {
             let node = rewriter

--- a/crates/arroyo-df/src/schemas.rs
+++ b/crates/arroyo-df/src/schemas.rs
@@ -1,6 +1,6 @@
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow_schema::{Field, Schema, SchemaRef};
-use datafusion_common::{DFField, DFSchema, DFSchemaRef, Result as DFResult};
+use datafusion_common::{DFField, DFSchema, DFSchemaRef, OwnedTableReference, Result as DFResult};
 use std::{collections::HashMap, sync::Arc};
 
 pub fn window_arrow_struct() -> DataType {
@@ -21,12 +21,16 @@ pub fn window_arrow_struct() -> DataType {
     )
 }
 
-pub(crate) fn add_timestamp_field(schema: DFSchemaRef) -> DFResult<DFSchemaRef> {
+pub(crate) fn add_timestamp_field(
+    schema: DFSchemaRef,
+    qualifier: Option<OwnedTableReference>,
+) -> DFResult<DFSchemaRef> {
     if has_timestamp_field(schema.clone()) {
         return Ok(schema);
     }
 
-    let timestamp_field = DFField::new_unqualified(
+    let timestamp_field = DFField::new(
+        qualifier,
         "_timestamp",
         DataType::Timestamp(TimeUnit::Nanosecond, None),
         false,

--- a/crates/arroyo-df/src/watermark_node.rs
+++ b/crates/arroyo-df/src/watermark_node.rs
@@ -1,13 +1,14 @@
 use crate::schemas::add_timestamp_field;
 use anyhow::{anyhow, Result};
 use arroyo_rpc::df::ArroyoSchema;
-use datafusion_common::DFSchemaRef;
+use datafusion_common::{DFSchemaRef, OwnedTableReference, TableReference};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use std::{fmt::Formatter, sync::Arc};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WatermarkNode {
     pub input: LogicalPlan,
+    pub qualifier: OwnedTableReference,
     pub watermark_expression: Option<Expr>,
     pub schema: DFSchemaRef,
     timestamp_index: usize,
@@ -35,35 +36,51 @@ impl UserDefinedLogicalNodeCore for WatermarkNode {
     }
 
     fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "WaterMarkNode")
+        write!(
+            f,
+            "WaterMarkNode({}): {}",
+            self.qualifier,
+            self.schema
+                .fields()
+                .iter()
+                .map(|f| f.qualified_name())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
     }
 
     fn from_template(&self, exprs: &[Expr], inputs: &[LogicalPlan]) -> Self {
         assert_eq!(inputs.len(), 1, "input size inconsistent");
         assert_eq!(exprs.len(), 1, "expression size inconsistent");
-        let schema = add_timestamp_field(self.input.schema().clone()).unwrap();
-        let timestamp_index = schema
-            .index_of_column_by_name(None, "_timestamp")
+        let timestamp_index = self
+            .schema
+            .index_of_column_by_name(Some(&self.qualifier), "_timestamp")
             .unwrap()
             .unwrap();
 
         Self {
             input: inputs[0].clone(),
+            qualifier: self.qualifier.clone(),
             watermark_expression: Some(exprs[0].clone()),
-            schema,
+            schema: self.schema.clone(),
             timestamp_index,
         }
     }
 }
 
 impl WatermarkNode {
-    pub(crate) fn new(input: LogicalPlan, watermark_expression: Option<Expr>) -> Result<Self> {
-        let schema = add_timestamp_field(input.schema().clone())?;
+    pub(crate) fn new(
+        input: LogicalPlan,
+        qualifier: OwnedTableReference,
+        watermark_expression: Option<Expr>,
+    ) -> Result<Self> {
+        let schema = add_timestamp_field(input.schema().clone(), Some(qualifier.clone()))?;
         let timestamp_index = schema
             .index_of_column_by_name(None, "_timestamp")?
             .ok_or_else(|| anyhow!("missing _timestamp column"))?;
         Ok(Self {
             input,
+            qualifier,
             watermark_expression,
             schema,
             timestamp_index,


### PR DESCRIPTION
TableScan's come in with qualifiers/aliases, and if one is used directly in a join then it assumes all fields are qualified. This wasn't happening for the _timestamp field we insert. This change fixes this by adding a qualifier to the add_timestamp_field() method, a qualfier to the WatermarkNode, and changing the from_template call on WatermarkNode.