### PR TITLE
Use hash of UDF definition for saving libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
  "arrow 50.0.0",
  "arrow-array 50.0.0",
  "async-trait",
+ "base64 0.21.7",
  "bincode 2.0.0-rc.3",
  "chrono",
  "serde",

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -21,7 +21,7 @@ use arroyo_rpc::grpc::{
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_types::{
-    dylib_name, from_micros, grpc_port, ports, service_port, NodeId, WorkerId, COMPILER_ADDR_ENV,
+    from_micros, grpc_port, ports, service_port, NodeId, WorkerId, COMPILER_ADDR_ENV,
     COMPILER_PORT_ENV,
 };
 use deadpool_postgres::Pool;
@@ -478,7 +478,8 @@ impl ControllerGrpc for ControllerServer {
                         Err(e) => return Ok(udf_error_resp(e)),
                     },
                 }),
-                dylib_path: format!("udfs/{}", dylib_name(&function_name)),
+                save: req.save,
+                dylib_path: req.dylib_path,
             })
             .await?
             .into_inner();

--- a/crates/arroyo-df/src/lib.rs
+++ b/crates/arroyo-df/src/lib.rs
@@ -68,8 +68,7 @@ use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalProgram};
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::TIMESTAMP_FIELD;
-use arroyo_types::{dylib_name, NullableType, ARTIFACT_URL_DEFAULT, ARTIFACT_URL_ENV};
-use std::path::Path;
+use arroyo_types::{dylib_path, NullableType};
 use std::time::{Duration, SystemTime};
 use std::{collections::HashMap, sync::Arc};
 use syn::{parse_file, FnArg, Item, ReturnType, Visibility};
@@ -320,20 +319,10 @@ impl ArroyoSchemaProvider {
                 Err(e) => bail!("Error converting arg types: {}", e),
             };
 
-            let artifact_url =
-                std::env::var(ARTIFACT_URL_ENV).unwrap_or(ARTIFACT_URL_DEFAULT.to_string());
-
-            let dylib_path = Path::new(&artifact_url)
-                .join("udfs")
-                .join(dylib_name(&function.sig.ident.to_string()))
-                .to_str()
-                .expect("Could not convert dylib path to string")
-                .to_string();
-
             self.dylib_udfs.insert(
                 function.sig.ident.to_string(),
                 DylibUdfConfig {
-                    dylib_path,
+                    dylib_path: dylib_path(&body),
                     arg_types,
                     return_type: data_type_to_arrow_type(&ret.data_type)?,
                 },

--- a/crates/arroyo-df/src/physical.rs
+++ b/crates/arroyo-df/src/physical.rs
@@ -30,7 +30,6 @@ use arrow::array;
 use arroyo_rpc::grpc::api::arroyo_exec_node::Node;
 use arroyo_rpc::grpc::api::{arroyo_exec_node, ArroyoExecNode, MemExecNode, UnnestExecNode};
 use arroyo_storage::StorageProvider;
-use arroyo_types::dylib_name;
 use datafusion::physical_plan::unnest::UnnestExec;
 use datafusion_execution::FunctionRegistry;
 use datafusion_expr::{
@@ -202,7 +201,11 @@ impl UdfDylib {
         // write the dylib to a local file
         let local_udfs_dir = "/tmp/arroyo/local_udfs";
         std::fs::create_dir_all(local_udfs_dir).expect("unable to create local udfs dir");
-        let local_dylib_path = Path::new(local_udfs_dir).join(dylib_name(name));
+
+        let dylib_file_name = Path::new(&config.dylib_path)
+            .file_name()
+            .expect("Invalid dylib path");
+        let local_dylib_path = Path::new(local_udfs_dir).join(dylib_file_name);
 
         std::fs::write(&local_dylib_path, udf).expect("unable to write dylib to file");
 

--- a/crates/arroyo-df/src/rewriters.rs
+++ b/crates/arroyo-df/src/rewriters.rs
@@ -18,7 +18,6 @@ use datafusion_expr::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::info;
 
 #[derive(Default)]
 pub struct TimestampRewriter {}

--- a/crates/arroyo-df/src/watermark_node.rs
+++ b/crates/arroyo-df/src/watermark_node.rs
@@ -1,7 +1,7 @@
 use crate::schemas::add_timestamp_field;
 use anyhow::{anyhow, Result};
 use arroyo_rpc::df::ArroyoSchema;
-use datafusion_common::{DFSchemaRef, OwnedTableReference, TableReference};
+use datafusion_common::{DFSchemaRef, OwnedTableReference};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use std::{fmt::Formatter, sync::Arc};
 

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -168,6 +168,8 @@ message WorkerErrorRes {
 
 message BuildUdfReq {
   string definition = 1;
+  bool save = 2;
+  string dylib_path = 3;
 }
 
 message BuildUdfResp {
@@ -469,6 +471,7 @@ message UdfCrate {
 message BuildUdfCompilerReq {
   UdfCrate udf_crate = 1;
   string dylib_path = 2;
+  bool save = 3;
 }
 
 message BuildUdfCompilerResp {

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -547,6 +547,16 @@ impl StorageProvider {
         }
     }
 
+    pub async fn exists<P: Into<String>>(&self, path: P) -> Result<bool, StorageError> {
+        let path: String = path.into();
+        let exists = self
+            .object_store
+            .head(&self.qualify_path(&path.into()))
+            .await;
+
+        Ok(exists.is_ok())
+    }
+
     pub async fn get_as_stream<P: Into<String>>(
         &self,
         path: P,

--- a/crates/arroyo-types/Cargo.toml
+++ b/crates/arroyo-types/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0", features = ["derive"] }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 async-trait = "0.1.74"
+base64 = "0.21.7"


### PR DESCRIPTION
Compute a hash of the UDF definition and use it as the file name of the library. Check if the library exists to avoid building libraries multiple times.

Also make the compiler service only run 'cargo build' when needed, otherwise running 'cargo check'.
