### PR TITLE
Make key_indices optional to distinguish from an empty group by and no group by.

### DIFF
--- a/crates/arroyo-connectors/src/kafka/sink/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/mod.rs
@@ -171,8 +171,8 @@ impl ArrowOperator for KafkaSinkFunc {
     async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut ArrowContext) {
         let values = self.serializer.serialize(&batch);
 
-        if !ctx.in_schemas[0].key_indices.is_empty() {
-            let k = batch.project(&ctx.in_schemas[0].key_indices).unwrap();
+        if let Some(key_indices) = &ctx.in_schemas[0].key_indices {
+            let k = batch.project(key_indices).unwrap();
 
             // TODO: we can probably batch this for better performance
             for (k, v) in self.serializer.serialize(&k).zip(values) {

--- a/crates/arroyo-connectors/src/kafka/sink/test.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/test.rs
@@ -91,7 +91,7 @@ impl KafkaTopicTester {
             control_rx,
             command_tx,
             1,
-            vec![ArroyoSchema::new(schema(), 0, vec![])],
+            vec![ArroyoSchema::new_unkeyed(schema(), 0)],
             None,
             None,
             vec![vec![]],

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -109,7 +109,7 @@ impl KafkaTopicTester {
             command_tx,
             1,
             vec![],
-            Some(ArroyoSchema::new(
+            Some(ArroyoSchema::new_unkeyed(
                 Arc::new(Schema::new(vec![
                     Field::new(
                         "_timestamp",
@@ -119,7 +119,6 @@ impl KafkaTopicTester {
                     Field::new("value", DataType::Utf8, false),
                 ])),
                 0,
-                vec![],
             )),
             None,
             vec![vec![data_tx]],

--- a/crates/arroyo-datastream/src/logical.rs
+++ b/crates/arroyo-datastream/src/logical.rs
@@ -269,11 +269,7 @@ impl TryFrom<ArrowProgram> for LogicalProgram {
                 target,
                 LogicalEdge {
                     edge_type: edge.edge_type().into(),
-                    schema: ArroyoSchema {
-                        schema: serde_json::from_str(&schema.arrow_schema).unwrap(),
-                        timestamp_index: schema.timestamp_index as usize,
-                        key_indices: schema.key_indices.iter().map(|t| *t as usize).collect(),
-                    },
+                    schema: schema.clone().try_into()?,
                     projection: if edge.projection.is_empty() {
                         None
                     } else {
@@ -374,11 +370,7 @@ impl From<LogicalProgram> for ArrowProgram {
                 api::ArrowEdge {
                     source: source.index() as i32,
                     target: target.index() as i32,
-                    schema: Some(api::ArroyoSchema {
-                        arrow_schema: serde_json::to_string(&edge.schema.schema).unwrap(),
-                        timestamp_index: edge.schema.timestamp_index as u32,
-                        key_indices: edge.schema.key_indices.iter().map(|k| *k as u32).collect(),
-                    }),
+                    schema: Some(edge.schema.clone().try_into().unwrap()),
                     edge_type: edge_type as i32,
                     projection: edge
                         .projection

--- a/crates/arroyo-df/src/builder.rs
+++ b/crates/arroyo-df/src/builder.rs
@@ -155,7 +155,7 @@ impl Planner {
             physical_plan_type: Some(PhysicalPlanType::Aggregate(final_aggregate_proto)),
         };
 
-        let partial_schema = ArroyoSchema::new(
+        let partial_schema = ArroyoSchema::new_keyed(
             add_timestamp_field_arrow(partial_schema.clone()),
             partial_schema.fields().len(),
             key_indices,

--- a/crates/arroyo-df/src/extension/aggregate.rs
+++ b/crates/arroyo-df/src/extension/aggregate.rs
@@ -41,8 +41,6 @@ use super::{ArroyoExtension, NodeWithIncomingEdges};
 
 pub(crate) const AGGREGATE_EXTENSION_NAME: &'static str = "AggregateExtension";
 
-pub const DUMMY_KEY: &'static str = "_dummy_key";
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct AggregateExtension {
     pub(crate) window_behavior: WindowBehavior,

--- a/crates/arroyo-df/src/extension/watermark_node.rs
+++ b/crates/arroyo-df/src/extension/watermark_node.rs
@@ -129,10 +129,6 @@ impl WatermarkNode {
         })
     }
     pub(crate) fn arroyo_schema(&self) -> ArroyoSchema {
-        ArroyoSchema::new(
-            Arc::new(self.schema.as_ref().into()),
-            self.timestamp_index,
-            vec![],
-        )
+        ArroyoSchema::new_unkeyed(Arc::new(self.schema.as_ref().into()), self.timestamp_index)
     }
 }

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -258,6 +258,7 @@ message ArroyoSchema {
   string arrow_schema = 1;
   uint32 timestamp_index = 2;
   repeated uint32 key_indices = 3;
+  bool has_keys = 4;
 }
 
 message ArrowNode {

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -295,6 +295,7 @@ message ArroyoSchema {
   string arrow_schema = 1;
   uint32 timestamp_index = 2;
   repeated uint32 key_indices = 3;
+  bool has_keys = 4;
 }
 
 // Worker


### PR DESCRIPTION
This makes key_indices in ArroyoSchema an Option<Vec<usize>>, as when a query groups by only a time window we need to shuffle all data together. This approach won out over trying to mutate the SQL graph to insert a dummy key.