### PR TITLE
Reset ExecutionPlans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,8 +2816,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b360b692bf6c6d6e6b6dbaf41a3be0020daeceac0f406aed54c75331e50dbb"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -2886,8 +2885,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f343ccc298f440e25aa38ff82678291a7acc24061c7370ba6c0ff5cc811412"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -2927,8 +2925,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9c93043081487e335399a21ebf8295626367a647ac5cb87d41d18afad7d0f7"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "chrono",
@@ -2964,8 +2961,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e204d89909e678846b6a95f156aafc1ee5b36cb6c9e37ec2e1449b078a38c818"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -2980,8 +2976,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f1c73f7801b2b8ba2297b3ad78ffcf6c1fc6b8171f502987eb9ad5cb244ee7"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -2995,8 +2990,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d16a0ddf2c991526f6ffe2f47a72c6da0b7354d6c32411dd20631fe2e38937"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "datafusion-common 36.0.0",
@@ -3027,8 +3021,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae27e07bf1f04d327be5c2a293470879801ab5535204dc3b16b062fda195496"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3079,8 +3072,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde620cd9ef76a3bca9c754fb68854bd2349c49f55baf97e08001f9e967f6d6b"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -3146,8 +3138,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4c75fba9ea99d64b2246cbd2fcae2e6fc973e6616b1015237a616036506dd4"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "ahash 0.8.7",
  "arrow",
@@ -3192,8 +3183,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2292251d5441d88d92a90d1511d5a8c88759a6562ff38ac1711b1587e6bf19c4"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "chrono",
@@ -3221,8 +3211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21474a95c3a62d113599d21b439fa15091b538bac06bd20be0bb2e7d22903c09"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=reset_execs_36#ac33c34268424edf3f7eafa694a14bd5ee4027ea"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3277,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "deltalake"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b9304c1b0a1dcc3fb4391e7039fa8dea0cebccf0cfe690a081c5fcf7c83c9e"
+checksum = "4e5fa38c2d00cc8a96789eaf3e7a2b27f0bd4c4c7a23e1e59bd5b7b4ceb796fe"
 dependencies = [
  "deltalake-aws",
  "deltalake-core",
@@ -3313,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "deltalake-core"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa36b3134e005ea27b129d44416830edf4954beeecfc7933b6fc6e2efa5cc92"
+checksum = "607be097d9bf5998bfbde3c5e6364f775e5adde0be55843130e5e50f2a2a4387"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -6151,7 +6140,6 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "50.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=50.0.0/parquet_bytes#8be0cb7860cb3053a976ac5ceac559b2beb2de8d"
 dependencies = [
  "ahash 0.8.7",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,10 @@ arrow-array = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0
 arrow-schema = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
 arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/json' }
 object_store = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '0.9.0/put_part_api'}
+datafusion = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-common = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-execution = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-physical-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-physical-plan = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
+datafusion-proto = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}

--- a/crates/arroyo-df/src/lib.rs
+++ b/crates/arroyo-df/src/lib.rs
@@ -10,6 +10,7 @@ use arrow_schema::{Field, Schema};
 use arroyo_datastream::WindowType;
 
 use datafusion::datasource::DefaultTableSource;
+#[allow(deprecated)]
 use datafusion::physical_plan::functions::make_scalar_function;
 use datafusion_common::{DFField, OwnedTableReference, ScalarValue};
 pub mod builder;
@@ -244,6 +245,7 @@ impl ArroyoSchemaProvider {
                 vec![DataType::Interval(datatypes::IntervalUnit::MonthDayNano)],
                 window_return_type,
                 Volatility::Volatile,
+                #[allow(deprecated)]
                 make_scalar_function(fn_impl),
             )),
         );

--- a/crates/arroyo-df/src/physical.rs
+++ b/crates/arroyo-df/src/physical.rs
@@ -550,6 +550,10 @@ impl ExecutionPlan for RwLockRecordBatchReader {
     fn statistics(&self) -> DFResult<datafusion_common::Statistics> {
         Ok(Statistics::new_unknown(&self.schema))
     }
+
+    fn reset(&self) -> DFResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -617,6 +621,10 @@ impl ExecutionPlan for UnboundedRecordBatchReader {
     fn statistics(&self) -> datafusion_common::Result<datafusion_common::Statistics> {
         Ok(datafusion_common::Statistics::new_unknown(&self.schema))
     }
+
+    fn reset(&self) -> DFResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -679,6 +687,10 @@ impl ExecutionPlan for RecordBatchVecReader {
     fn statistics(&self) -> datafusion_common::Result<datafusion_common::Statistics> {
         Ok(datafusion_common::Statistics::new_unknown(&self.schema))
     }
+
+    fn reset(&self) -> DFResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -734,5 +746,9 @@ impl ExecutionPlan for ArroyoMemExec {
 
     fn statistics(&self) -> DFResult<datafusion_common::Statistics> {
         Ok(datafusion_common::Statistics::new_unknown(&self.schema))
+    }
+
+    fn reset(&self) -> DFResult<()> {
+        Ok(())
     }
 }

--- a/crates/arroyo-worker/src/arrow/join_with_expiration.rs
+++ b/crates/arroyo-worker/src/arrow/join_with_expiration.rs
@@ -121,6 +121,7 @@ impl JoinWithExpiration {
             self.right_passer.write().unwrap().replace(right);
             self.left_passer.write().unwrap().replace(left);
         }
+        self.join_execution_plan.reset().unwrap();
         let mut records = self
             .join_execution_plan
             .execute(0, SessionContext::new().task_ctx())

--- a/crates/arroyo-worker/src/arrow/session_aggregating_window.rs
+++ b/crates/arroyo-worker/src/arrow/session_aggregating_window.rs
@@ -382,6 +382,7 @@ impl ActiveSession {
         initial_timestamp: SystemTime,
         sender: UnboundedSender<RecordBatch>,
     ) -> Result<Self> {
+        aggregation_plan.reset()?;
         let result_exec = aggregation_plan.execute(0, SessionContext::new().task_ctx())?;
         Ok(Self {
             data_start: initial_timestamp,
@@ -473,7 +474,7 @@ impl ActiveSession {
             .await?;
         if result_batches.len() != 1 {
             bail!(
-                "expect active session result to be excactly one batch, not {:?}",
+                "expect active session result to be exactly one batch, not {:?}",
                 result_batches
             );
         }

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -67,6 +67,8 @@ spec:
           value: {{ .Values.controller.service.adminPort | quote }}
         - name: HTTP_PORT
           value: {{ .Values.controller.service.httpPort | quote }}
+        - name: COMPILER_GRPC_PORT
+          value: {{ .Values.controller.service.compilerPort | quote }}
         - name: PROM_ENDPOINT
           value: "{{ include "arroyo.prometheusEndpoint" .}}"
         - name: API_METRICS_RATE

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -16,6 +16,7 @@ controller:
     tag: "dev"
   service:
     grpcPort: 9190
+    compilerPort: 9000
     adminPort: 8001
     httpPort: 80
 


### PR DESCRIPTION
This uses a fork of DataFusion that allows for cheaply reseting execution plans, and calls it directly before calling execute(). Worth taking look at the commit in the fork: https://github.com/ArroyoSystems/arrow-datafusion/commit/18e1c45d48ab723fa17d29d97a658f028e1ff1e8. The biggest change there was in rewriting how the execute() method for the various joins function. Unlike all other ExecutionPlans it tries to cache work using OnceAsync, which can contaminate future calls. Additionally, it would defer calling execute() on some inputs, which will cause issues given how Arroyo reuses plans. I removed the use of OnceAsync and ensured that execute() is called on both left and right before the join returns.