### PR TITLE
Report correct metrics for record batches

### DIFF
--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -5,7 +5,10 @@ use arroyo_rpc::grpc::{
     api, HeartbeatNodeReq, RegisterNodeReq, StartWorkerData, StartWorkerHeader, StartWorkerReq,
     StopWorkerReq, StopWorkerStatus, WorkerFinishedReq,
 };
-use arroyo_types::{NodeId, WorkerId, ARROYO_PROGRAM_ENV, JOB_ID_ENV, NODE_ID_ENV, RUN_ID_ENV, TASK_SLOTS_ENV, WORKER_ID_ENV, SLOTS_PER_NODE};
+use arroyo_types::{
+    NodeId, WorkerId, ARROYO_PROGRAM_ENV, JOB_ID_ENV, NODE_ID_ENV, RUN_ID_ENV, SLOTS_PER_NODE,
+    TASK_SLOTS_ENV, WORKER_ID_ENV,
+};
 use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use prometheus::{register_gauge, Gauge};
@@ -106,7 +109,7 @@ impl Scheduler for ProcessScheduler {
         start_pipeline_req: StartPipelineReq,
     ) -> Result<(), SchedulerError> {
         let slots_per_node = arroyo_types::u32_config(SLOTS_PER_NODE, DEFAULT_SLOTS_PER_NODE);
-        
+
         let workers = (start_pipeline_req.slots as f32 / slots_per_node as f32).ceil() as usize;
 
         let mut slots_scheduled = 0;
@@ -120,7 +123,8 @@ impl Scheduler for ProcessScheduler {
         for _ in 0..workers {
             let path = base_path.clone();
 
-            let slots_here = (start_pipeline_req.slots - slots_scheduled).min(slots_per_node as usize);
+            let slots_here =
+                (start_pipeline_req.slots - slots_scheduled).min(slots_per_node as usize);
 
             let worker_id = self.worker_counter.fetch_add(1, Ordering::SeqCst);
 

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -89,7 +89,7 @@ impl ProcessScheduler {
     }
 }
 
-const SLOTS_PER_NODE: usize = 2;
+const SLOTS_PER_NODE: usize = 32;
 
 pub struct StartPipelineReq {
     pub name: String,

--- a/crates/arroyo-formats/src/json/schema.rs
+++ b/crates/arroyo-formats/src/json/schema.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, TimeUnit};
 use arroyo_types::ArroyoExtensionType;
 use schemars::schema::{Metadata, RootSchema, Schema};
 use std::sync::Arc;
@@ -98,7 +98,7 @@ fn to_arrow_datatype(
                 "i64" => Int64,
                 "f32" => Float32,
                 "f64" => Float64,
-                "chrono::DateTime<chrono::offset::Utc>" => todo!("JSON timestamps"),
+                "chrono::DateTime<chrono::offset::Utc>" => Timestamp(TimeUnit::Nanosecond, None),
                 _ => {
                     warn!("Unhandled primitive in json-schema: {}", t);
                     return (Utf8, false, Some(ArroyoExtensionType::JSON));

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -206,7 +206,6 @@ fn repartition<'a>(
             .collect();
         result.into_iter()
     } else {
-        //println!("record: {:?}", record);
         let range_size = record.num_rows() / qs + 1;
         let rotation = rand::thread_rng().gen_range(0..qs);
         let result: Vec<_> = (0..qs)
@@ -228,7 +227,9 @@ fn repartition<'a>(
 
 impl ArrowCollector {
     pub async fn collect(&mut self, record: RecordBatch) {
-        TaskCounters::MessagesSent.for_task(&self.task_info).inc_by(record.num_rows() as u64);
+        TaskCounters::MessagesSent
+            .for_task(&self.task_info, |c| c.inc_by(record.num_rows() as u64));
+        TaskCounters::BatchesSent.for_task(&self.task_info, |c| c.inc());
 
         let out_schema = self.out_schema.as_ref().unwrap();
 
@@ -588,9 +589,7 @@ impl ArrowContext {
                                     .unwrap();
                             })
                             .await;
-                        TaskCounters::DeserializationErrors
-                            .for_task(&self.task_info)
-                            .inc();
+                        TaskCounters::DeserializationErrors.for_task(&self.task_info, |c| c.inc())
                     }
                     BadData::Fail {} => {
                         return Err(UserError::new("Deserialization error", details));

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -228,7 +228,7 @@ fn repartition<'a>(
 
 impl ArrowCollector {
     pub async fn collect(&mut self, record: RecordBatch) {
-        TaskCounters::MessagesSent.for_task(&self.task_info).inc();
+        TaskCounters::MessagesSent.for_task(&self.task_info).inc_by(record.num_rows() as u64);
 
         let out_schema = self.out_schema.as_ref().unwrap();
 

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -204,7 +204,8 @@ async fn operator_run_behavior(
 
                         match message {
                             ArrowMessage::Data(record) => {
-                                TaskCounters::MessagesReceived.for_task(&ctx.task_info).inc_by(record.num_rows() as u64);
+                                TaskCounters::BatchesReceived.for_task(&ctx.task_info, |c| c.inc());
+                                TaskCounters::MessagesReceived.for_task(&ctx.task_info, |c| c.inc_by(record.num_rows() as u64));
                                 this.process_batch_index(idx, in_partitions, record, ctx)
                                     .instrument(tracing::trace_span!("handle_fn",
                                         name,
@@ -216,7 +217,7 @@ async fn operator_run_behavior(
                                 match this.handle_control_message(idx, &signal, &mut counter, &mut closed, in_partitions, ctx).await {
                                     ControlOutcome::Continue => {}
                                     ControlOutcome::Stop => {
-                                        // just stop; the stop will have already been broadcasted for example by
+                                        // just stop; the stop will have already been broadcast for example by
                                         // a final checkpoint
                                         break;
                                     }

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -204,7 +204,7 @@ async fn operator_run_behavior(
 
                         match message {
                             ArrowMessage::Data(record) => {
-                                TaskCounters::MessagesReceived.for_task(&ctx.task_info).inc();
+                                TaskCounters::MessagesReceived.for_task(&ctx.task_info).inc_by(record.num_rows() as u64);
                                 this.process_batch_index(idx, in_partitions, record, ctx)
                                     .instrument(tracing::trace_span!("handle_fn",
                                         name,

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -671,7 +671,7 @@ pub trait RecordBatchBuilder: Default + Debug + Sync + Send + 'static {
 /// A reference-counted reference to a [TaskInfo].
 pub type TaskInfoRef = Arc<TaskInfo>;
 
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Encode, Decode)]
 pub struct TaskInfo {
     pub job_id: String,
     pub operator_name: String,
@@ -735,6 +735,8 @@ pub static MESSAGES_RECV: &str = "arroyo_worker_messages_recv";
 pub static MESSAGES_SENT: &str = "arroyo_worker_messages_sent";
 pub static BYTES_RECV: &str = "arroyo_worker_bytes_recv";
 pub static BYTES_SENT: &str = "arroyo_worker_bytes_sent";
+pub static BATCHES_RECV: &str = "arroyo_worker_batches_recv";
+pub static BATCHES_SENT: &str = "arroyo_worker_batches_sent";
 pub static TX_QUEUE_SIZE: &str = "arroyo_worker_tx_queue_size";
 pub static TX_QUEUE_REM: &str = "arroyo_worker_tx_queue_rem";
 pub static DESERIALIZATION_ERRORS: &str = "arroyo_worker_deserialization_errors";

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -124,6 +124,9 @@ pub const COMPILER_FEATURES_ENV: &str = "COMPILER_FEATURES";
 pub const INSTALL_CLANG_ENV: &str = "INSTALL_CLANG";
 pub const INSTALL_RUSTC_ENV: &str = "INSTALL_RUSTC";
 
+// process scheduler
+pub const SLOTS_PER_NODE: &str = "SLOTS_PER_NODE";
+
 // kubernetes scheduler configuration
 pub const K8S_NAMESPACE_ENV: &str = "K8S_NAMESPACE";
 pub const K8S_WORKER_NAME_ENV: &str = "K8S_WORKER_NAME";


### PR DESCRIPTION
Includes a few other fixes discovered during benchmark work:
* fixed json schema regression where we were calling the wrong method
* added support for json schema timestamps
* reverted SLOTS_PER_NODE for the process scheduler back to 16 and made it configurable