### PR TITLE
drop old checkpoint rows from database.

### DIFF
--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -45,6 +45,10 @@ UPDATE checkpoints
     set state = 'compacted'
 WHERE job_id = :job_id AND epoch < :epoch;
 
+--! drop_old_checkpoint_rows
+DELETE FROM checkpoints
+WHERE job_id = :job_id AND epoch < :epoch;
+
 --! create_checkpoint
 INSERT INTO checkpoints
 (pub_id, organization_id, job_id, state_backend, epoch, min_epoch, start_time)


### PR DESCRIPTION
This addresses #562 by dropping epochs more than a hundred before the min_epoch.