### PR TITLE
Add support for serializing avro lists

### DIFF
--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -127,6 +127,7 @@ pub(crate) fn source_field(name: &str, field_type: FieldType) -> SourceField {
             sql_name: match field_type.clone() {
                 FieldType::Primitive(p) => Some(primitive_to_sql(p).to_string()),
                 FieldType::Struct(_) => None,
+                FieldType::List(_) => None,
             },
             r#type: field_type,
         },

--- a/crates/arroyo-formats/src/avro/schema.rs
+++ b/crates/arroyo-formats/src/avro/schema.rs
@@ -91,7 +91,7 @@ fn arrow_to_avro(name: &str, dt: &DataType) -> serde_json::value::Value {
         DataType::List(t) | DataType::FixedSizeList(t, _) | DataType::LargeList(t) => {
             return json!({
                 "type": "array",
-                "items": arrow_to_avro(name, t.data_type())
+                "items": field_to_avro("item", &*t),
             });
         }
         DataType::Struct(fields) => {

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -104,6 +104,7 @@ pub struct StructType {
 pub enum FieldType {
     Primitive(PrimitiveType),
     Struct(StructType),
+    List(Box<SourceField>),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema, PartialEq, Eq)]
@@ -146,6 +147,7 @@ impl From<SourceField> for Field {
                     .map(|t| t.into())
                     .collect::<Vec<Field>>(),
             )),
+            FieldType::List(t) => DataType::List(Arc::new((*t).into())),
         };
 
         Field::new(f.field_name, t, f.nullable)
@@ -188,6 +190,7 @@ impl TryFrom<Field> for SourceField {
 
                 FieldType::Struct(st)
             }
+            DataType::List(item) => FieldType::List(Box::new((**item).clone().try_into()?)),
             dt => {
                 return Err(format!("Unsupported data type {:?}", dt));
             }

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -1,6 +1,5 @@
 use crate::ports::CONTROLLER_GRPC;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use arrow::util::pretty::pretty_format_batches;
 use arrow_array::RecordBatch;
 use bincode::{Decode, Encode};
 use serde::ser::SerializeStruct;
@@ -317,10 +316,6 @@ pub fn print_time(time: SystemTime) -> String {
     chrono::DateTime::<chrono::Utc>::from(time)
         .format("%Y-%m-%d %H:%M:%S%.3f")
         .to_string()
-}
-
-pub fn print_record_batch(batch: &RecordBatch) -> String {
-    format!("{}", pretty_format_batches(&[batch.clone()]).unwrap())
 }
 
 pub fn single_item_hash_map<I: Into<K>, K: Hash + Eq, V>(key: I, value: V) -> HashMap<K, V> {


### PR DESCRIPTION
This was left as a todo in #481.

I've also done the (small) amount of work necessary to let users define lists in DDL, so for example this now works:

```sql
create table my_sink (
  f INT[]
) with (
  connector = 'kafka',
  ...
);
```