### PR TITLE
Add NATS source and sink connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "arroyo-storage",
  "arroyo-types",
  "async-compression",
+ "async-nats",
  "async-trait",
  "aws-config",
  "aws-sdk-kinesis",
@@ -1295,6 +1296,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "rand",
+ "regex",
+ "ring 0.17.8",
+ "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2091,6 +2126,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -2766,6 +2804,33 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
 dependencies = [
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.52",
 ]
@@ -3670,6 +3735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "ed25519-compact"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,6 +3751,19 @@ checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
  "ct-codecs",
  "getrandom",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.10.8",
+ "signature 2.2.0",
+ "subtle",
 ]
 
 [[package]]
@@ -3884,6 +3971,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -5916,6 +6009,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom",
+ "log",
+ "rand",
+ "signatory",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5945,6 +6054,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -6582,6 +6700,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "platforms"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polling"
@@ -8115,6 +8239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae801b7733ca8d6a2b580debe99f67f36826a0f5b8a36055dc6bc40f8d6bc71"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8293,6 +8426,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8 0.10.2",
+ "rand_core",
+ "signature 2.2.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -85,5 +85,8 @@ rustls-pemfile = "1"
 tokio-rustls = "0.24"
 rustls = "0.21.11"
 
+# NATS
+async-nats = "0.33.0"
+
 [build-dependencies]
 glob = "0.3"

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -19,6 +19,7 @@ use arroyo_types::string_to_map;
 use blackhole::BlackholeConnector;
 use fluvio::FluvioConnector;
 use impulse::ImpulseConnector;
+use nats::NatsConnector;
 use nexmark::NexmarkConnector;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
@@ -40,6 +41,7 @@ pub mod impulse;
 pub mod kafka;
 pub mod kinesis;
 pub mod mqtt;
+pub mod nats;
 pub mod nexmark;
 pub mod polling_http;
 pub mod preview;
@@ -60,6 +62,7 @@ pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
         Box::new(KafkaConnector {}),
         Box::new(KinesisConnector {}),
         Box::new(MqttConnector {}),
+        Box::new(NatsConnector {}),
         Box::new(NexmarkConnector {}),
         Box::new(PollingHTTPConnector {}),
         Box::new(PreviewConnector {}),

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -268,7 +268,7 @@ impl Connector for NatsConnector {
                     connection: profile.clone(),
                     table: table.clone(),
                     framing: config.framing,
-                    format: config.format.unwrap(),
+                    format: config.format.expect("Format must be set for NATS source"),
                     bad_data: config.bad_data,
                     messages_per_second: NonZeroU32::new(
                         config
@@ -288,7 +288,9 @@ impl Connector for NatsConnector {
                     connection: profile.clone(),
                     table: table.clone(),
                     publisher: None,
-                    serializer: ArrowSerializer::new(config.format.unwrap()),
+                    serializer: ArrowSerializer::new(
+                        config.format.expect("Format must be set for NATS source"),
+                    ),
                 }))
             }
         })
@@ -299,7 +301,13 @@ async fn get_nats_client(connection: &NatsConfig) -> anyhow::Result<async_nats::
     let mut opts = async_nats::ConnectOptions::new();
 
     let servers_str = connection.servers.clone();
-    let servers_vec: Vec<ServerAddr> = servers_str.split(',').map(|s| s.parse().unwrap()).collect();
+    let servers_vec: Vec<ServerAddr> = servers_str
+        .split(',')
+        .map(|s| {
+            s.parse::<ServerAddr>()
+                .expect("Something went wrong while parsing servers string")
+        })
+        .collect();
 
     match &connection.authentication {
         NatsConfigAuthentication::None {} => {}

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -1,0 +1,295 @@
+use crate::nats::sink::NatsSinkFunc;
+use crate::nats::source::NatsSourceFunc;
+use crate::pull_opt;
+use anyhow::anyhow;
+use anyhow::bail;
+use arroyo_formats::ser::ArrowSerializer;
+use arroyo_operator::connector::{Connection, Connector};
+use arroyo_operator::operator::OperatorNode;
+use arroyo_rpc::api_types::connections::{
+    ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
+};
+use arroyo_rpc::var_str::VarStr;
+use arroyo_rpc::OperatorConfig;
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot::Receiver;
+use typify::import_types;
+
+pub mod sink;
+pub mod source;
+
+const CONFIG_SCHEMA: &str = include_str!("./profile.json");
+const TABLE_SCHEMA: &str = include_str!("./table.json");
+const ICON: &str = include_str!("./nats.svg");
+
+import_types!(
+    schema = "src/nats/profile.json",
+    convert = {
+        {type = "string", format = "var-str"} = VarStr
+    }
+);
+import_types!(schema = "src/nats//table.json");
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, PartialOrd)]
+pub struct NatsState {
+    stream_name: String,
+    stream_sequence_number: u64,
+}
+
+pub struct NatsConnector {}
+
+impl NatsConnector {
+    pub fn connection_from_options(
+        options: &mut HashMap<String, String>,
+    ) -> anyhow::Result<NatsConfig> {
+        let nats_servers = pull_opt("servers", options)?;
+        let nats_auth = options.remove("auth.type");
+        let nats_auth: NatsConfigAuthentication = match nats_auth.as_ref().map(|t| t.as_str()) {
+            Some("none") | None => NatsConfigAuthentication::None {},
+            Some("credentials") => NatsConfigAuthentication::Credentials {
+                username: VarStr::new(pull_opt("auth.username", options)?),
+                password: VarStr::new(pull_opt("auth.password", options)?),
+            },
+            Some(other) => bail!("Unknown auth type '{}'", other),
+        };
+
+        Ok(NatsConfig {
+            authentication: nats_auth,
+            servers: nats_servers,
+        })
+    }
+
+    pub fn table_from_options(options: &mut HashMap<String, String>) -> anyhow::Result<NatsTable> {
+        let mut client_config = HashMap::new();
+        for (k, v) in options.iter() {
+            client_config.insert(k.clone(), v.clone());
+        }
+        let conn_type = pull_opt("type", options)?;
+        let nats_table_type = match conn_type.as_str() {
+            "source" => ConnectorType::Source {
+                stream: Some(pull_opt("nats.stream", options)?),
+            },
+            "sink" => ConnectorType::Sink {
+                subject: Some(pull_opt("nats.subject", options)?),
+            },
+            _ => bail!("Type must be one of 'source' or 'sink'"),
+        };
+
+        Ok(NatsTable {
+            connector_type: nats_table_type,
+            client_configs: client_config,
+        })
+    }
+}
+
+impl Connector for NatsConnector {
+    type ProfileT = NatsConfig;
+    type TableT = NatsTable;
+
+    fn name(&self) -> &'static str {
+        "nats"
+    }
+
+    fn metadata(&self) -> arroyo_rpc::api_types::connections::Connector {
+        arroyo_rpc::api_types::connections::Connector {
+            id: "nats".to_string(),
+            name: "Nats".to_string(),
+            icon: ICON.to_string(),
+            description: "Read and write from a NATS cluster".to_string(),
+            enabled: true,
+            source: true,
+            sink: true,
+            testing: true,
+            hidden: false,
+            custom_schemas: true,
+            connection_config: Some(CONFIG_SCHEMA.to_string()),
+            table_config: TABLE_SCHEMA.to_owned(),
+        }
+    }
+
+    fn config_description(&self, config: Self::ProfileT) -> String {
+        (*config.servers).to_string()
+    }
+
+    fn table_type(&self, _: Self::ProfileT, table: Self::TableT) -> ConnectionType {
+        match &table.connector_type {
+            ConnectorType::Source { .. } => ConnectionType::Source,
+            ConnectorType::Sink { .. } => ConnectionType::Sink,
+        }
+    }
+
+    fn get_schema(
+        &self,
+        _: Self::ProfileT,
+        _: Self::TableT,
+        s: Option<&ConnectionSchema>,
+    ) -> Option<ConnectionSchema> {
+        s.cloned()
+    }
+
+    fn test(
+        &self,
+        _: &str,
+        _: Self::ProfileT,
+        _: Self::TableT,
+        _: Option<&ConnectionSchema>,
+        _tx: Sender<TestSourceMessage>,
+    ) {
+        // TODO: Actually test the connection by instantiating a NATS client
+        // and subscribing to the subject at the specified server.
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (_itx, _rx) = tokio::sync::mpsc::channel::<(
+                Sender<TestSourceMessage>,
+                Receiver<TestSourceMessage>,
+            )>(8);
+            let message = TestSourceMessage {
+                error: false,
+                done: true,
+                message: "Successfully validated connection".to_string(),
+            };
+            tx.send(message).unwrap();
+        });
+    }
+
+    fn from_config(
+        &self,
+        id: Option<i64>,
+        name: &str,
+        config: NatsConfig,
+        table: NatsTable,
+        schema: Option<&ConnectionSchema>,
+    ) -> anyhow::Result<Connection> {
+        let stream_or_subject = match &table.connector_type {
+            ConnectorType::Source { stream, .. } => stream.clone(),
+            ConnectorType::Sink { subject, .. } => subject.clone(),
+        };
+
+        let (connection_type, desc) = match table.connector_type {
+            ConnectorType::Source { .. } => (
+                ConnectionType::Source,
+                format!("NatsSource<{:?}>", stream_or_subject.clone()),
+            ),
+            ConnectorType::Sink { .. } => (
+                ConnectionType::Sink,
+                format!("NatsSink<{:?}>", stream_or_subject.clone()),
+            ),
+        };
+
+        let schema = schema
+            .map(|s| s.to_owned())
+            .ok_or_else(|| anyhow!("No schema defined for NATS connection"))?;
+
+        let format = schema
+            .format
+            .as_ref()
+            .map(|t| t.to_owned())
+            .ok_or_else(|| anyhow!("'format' must be set for NATS connection"))?;
+
+        let config = OperatorConfig {
+            connection: serde_json::to_value(config).unwrap(),
+            table: serde_json::to_value(table).unwrap(),
+            rate_limit: None,
+            format: Some(format),
+            bad_data: schema.bad_data.clone(),
+            framing: schema.framing.clone(),
+        };
+
+        Ok(Connection {
+            id,
+            connector: self.name(),
+            name: name.to_string(),
+            connection_type: connection_type,
+            schema,
+            config: serde_json::to_string(&config).unwrap(),
+            description: desc,
+        })
+    }
+
+    fn from_options(
+        &self,
+        name: &str,
+        options: &mut HashMap<String, String>,
+        schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
+        let connection = profile
+            .map(|p| {
+                serde_json::from_value(p.config.clone()).map_err(|e| {
+                    anyhow!("Invalid config for profile '{}' in database: {}", p.id, e)
+                })
+            })
+            .unwrap_or_else(|| Self::connection_from_options(options))?;
+
+        let table = Self::table_from_options(options)?;
+
+        Self::from_config(&self, None, name, connection, table, schema)
+    }
+
+    fn make_operator(
+        &self,
+        profile: Self::ProfileT,
+        table: Self::TableT,
+        config: OperatorConfig,
+    ) -> anyhow::Result<OperatorNode> {
+        Ok(match table.connector_type {
+            ConnectorType::Source { .. } => OperatorNode::from_source(Box::new(NatsSourceFunc {
+                stream: table.client_configs.get("nats.stream").cloned().unwrap(),
+                servers: profile.servers.clone(),
+                connection: profile.clone(),
+                table: table.clone(),
+                framing: config.framing,
+                format: config.format.unwrap(),
+                bad_data: config.bad_data,
+                consumer_config: get_client_config(&profile, &table),
+                messages_per_second: NonZeroU32::new(
+                    config
+                        .rate_limit
+                        .map(|l| l.messages_per_second)
+                        .unwrap_or(u32::MAX),
+                )
+                .unwrap(),
+            })),
+            ConnectorType::Sink { .. } => OperatorNode::from_operator(Box::new(NatsSinkFunc {
+                publisher: None,
+                servers: profile.servers.clone(),
+                subject: table.client_configs.get("nats.subject").cloned().unwrap(),
+                client_config: get_client_config(&profile, &table),
+                serializer: ArrowSerializer::new(config.format.unwrap()),
+            })),
+        })
+    }
+}
+
+fn get_client_config(connection: &NatsConfig, table: &NatsTable) -> HashMap<String, String> {
+    let mut consumer_configs: HashMap<String, String> = HashMap::new();
+
+    match &connection.authentication {
+        NatsConfigAuthentication::None {} => {}
+        NatsConfigAuthentication::Credentials { username, password } => {
+            consumer_configs.insert(
+                "nats.username".to_string(),
+                username
+                    .sub_env_vars()
+                    .expect("Missing env-vars for NATS username"),
+            );
+            consumer_configs.insert(
+                "nats.password".to_string(),
+                password
+                    .sub_env_vars()
+                    .expect("Missing env-vars for NATS password"),
+            );
+            consumer_configs.extend(
+                table
+                    .client_configs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string())),
+            );
+        }
+    };
+    consumer_configs
+}

--- a/crates/arroyo-connectors/src/nats/nats.svg
+++ b/crates/arroyo-connectors/src/nats/nats.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.0" id="katman_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 841.89 595.28" style="enable-background:new 0 0 841.89 595.28;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#32A574;}
+	.st1{fill:#2AAAE1;}
+	.st2{fill:#8EC044;}
+	.st3{fill:#385C93;}
+	.st4{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M420.95,68.98h220.39v178.67H420.95V68.98z"/>
+<path class="st1" d="M200.55,68.98h220.39v178.67H200.55V68.98z"/>
+<path class="st2" d="M420.95,247.81h220.39v178.67H420.95V247.81z"/>
+<path class="st3" d="M200.55,247.81h220.39v178.67H200.55V247.81z"/>
+<path class="st2" d="M388.55,425.5l107.82,99.81V425.5L388.55,425.5z"/>
+<path class="st3" d="M420.95,425.5l1.15,31.41l-34.52-32.23L420.95,425.5z"/>
+<path class="st4" d="M512.25,300.01V152.1h52.69v191.27h-79.85L323.92,192.84v150.69h-52.85V152.1h82.63L512.25,300.01z"/>
+</svg>

--- a/crates/arroyo-connectors/src/nats/nats.svg
+++ b/crates/arroyo-connectors/src/nats/nats.svg
@@ -1,19 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.0" id="katman_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 841.89 595.28" style="enable-background:new 0 0 841.89 595.28;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#32A574;}
-	.st1{fill:#2AAAE1;}
-	.st2{fill:#8EC044;}
-	.st3{fill:#385C93;}
-	.st4{fill:#FFFFFF;}
-</style>
-<path class="st0" d="M420.95,68.98h220.39v178.67H420.95V68.98z"/>
-<path class="st1" d="M200.55,68.98h220.39v178.67H200.55V68.98z"/>
-<path class="st2" d="M420.95,247.81h220.39v178.67H420.95V247.81z"/>
-<path class="st3" d="M200.55,247.81h220.39v178.67H200.55V247.81z"/>
-<path class="st2" d="M388.55,425.5l107.82,99.81V425.5L388.55,425.5z"/>
-<path class="st3" d="M420.95,425.5l1.15,31.41l-34.52-32.23L420.95,425.5z"/>
-<path class="st4" d="M512.25,300.01V152.1h52.69v191.27h-79.85L323.92,192.84v150.69h-52.85V152.1h82.63L512.25,300.01z"/>
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.15625 50H27.5303L42.6553 64V50H62.8423V0H1.15625V50ZM11.0933 11.688H22.6562L44.9062 32.438V11.688H52.2812V38.5H41.0943L18.4702 17.375V38.5H11.0953L11.0933 11.688Z" fill="#B5B5B5"/>
+<path d="M18.4697 17.3755L41.0938 38.5005H52.2797V11.6875H44.9057V32.4375L22.6558 11.6875H11.0938V38.5005H18.4688L18.4697 17.3755Z" fill="white"/>
+<path d="M1.15625 0H62.8433V50H1.15625V0Z" fill="#27AAE1"/>
+<path d="M32 0H62.844V25H32V0Z" fill="#929292"/>
+<path d="M32 25H62.844V50H32V25Z" fill="#B5B5B5"/>
+<path d="M1.15625 0H32.0002V25H1.15625V0Z" fill="#9F9F9F"/>
+<path d="M1.15625 25H32.0002V50H1.15625V25Z" fill="#5B5B5B"/>
+<path d="M32.0003 50L32.1543 54.303L27.5303 50H32.0003Z" fill="#5B5B5B"/>
+<path d="M16.3666 15.8296L43.1246 40.8136H56.3546V9.10156H47.6326V33.6416L21.3196 9.10156H7.64355V40.8116H16.3656L16.3666 15.8296Z" fill="white"/>
 </svg>

--- a/crates/arroyo-connectors/src/nats/profile.json
+++ b/crates/arroyo-connectors/src/nats/profile.json
@@ -5,6 +5,7 @@
         "servers": {
             "type": "string",
             "title": "NATS Servers",
+            "format": "var-str",
             "description": "Comma-separated list of NATS servers to connect to",
             "examples": [
                 "nats-1:4222,nats-2:4222"

--- a/crates/arroyo-connectors/src/nats/profile.json
+++ b/crates/arroyo-connectors/src/nats/profile.json
@@ -1,0 +1,55 @@
+{
+    "type": "object",
+    "title": "NatsConfig",
+    "properties": {
+        "servers": {
+            "type": "string",
+            "title": "NATS Servers",
+            "description": "Comma-separated list of NATS servers to connect to",
+            "examples": [
+                "nats-1:4222,nats-2:4222"
+            ]
+        },
+        "authentication": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "None",
+                    "properties": {
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "title": "Credentials",
+                    "required": [
+                        "username",
+                        "password"
+                    ],
+                    "sensitive": [
+                        "user",
+                        "password"
+                    ],
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "The username to use for authentication",
+                            "format": "var-str"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "The password to use for authentication",
+                            "format": "var-str"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        }
+    },
+    "required": [
+        "servers",
+        "authentication"
+    ]
+}

--- a/crates/arroyo-connectors/src/nats/sink/mod.rs
+++ b/crates/arroyo-connectors/src/nats/sink/mod.rs
@@ -34,7 +34,7 @@ impl ArrowOperator for NatsSinkFunc {
     }
 
     async fn on_start(&mut self, _ctx: &mut ArrowContext) {
-        match get_nats_client(&self.connection, &self.table).await {
+        match get_nats_client(&self.connection).await {
             Ok(client) => {
                 self.publisher = Some(client);
             }
@@ -53,18 +53,8 @@ impl ArrowOperator for NatsSinkFunc {
     }
 
     async fn handle_checkpoint(&mut self, _: CheckpointBarrier, _ctx: &mut ArrowContext) {
-        // TODO: Is it necessary to insert any kind of checklpoint in the state for NATS sink?
-        // let sequence_number = 1;
-        // ctx.table_manager
-        //     .get_global_keyed_state("n")
-        //     .await
-        //     .as_mut()
-        //     .unwrap()
-        //     .insert(ctx.task_info.task_index, sequence_number)
-        //     .await;
-
-        // TODO: Is flushing sufficient here to ensure messages are neither
-        // sent twice nor lost before being published successfully?
+        // TODO: Implement checkpointing of in-progress data to avoid depending on
+        // the downstream NATS availability to flush and checkpoint.
         self.publisher.as_mut().unwrap().flush().await.unwrap();
     }
 

--- a/crates/arroyo-connectors/src/nats/sink/mod.rs
+++ b/crates/arroyo-connectors/src/nats/sink/mod.rs
@@ -1,0 +1,145 @@
+use super::get_client_config;
+use super::ConnectorType;
+use super::NatsConfig;
+use super::NatsTable;
+use anyhow::Result;
+use arrow::array::RecordBatch;
+use arroyo_formats::ser::ArrowSerializer;
+use arroyo_operator::context::ArrowContext;
+use arroyo_operator::operator::ArrowOperator;
+use arroyo_rpc::grpc::TableConfig;
+use arroyo_rpc::ControlMessage;
+use arroyo_rpc::{ControlResp, OperatorConfig};
+use arroyo_types::*;
+use async_nats::ServerAddr;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tracing::info;
+use tracing::warn;
+
+pub struct NatsSinkFunc {
+    pub publisher: Option<async_nats::Client>,
+    pub servers: String,
+    pub subject: String,
+    pub client_config: HashMap<String, String>,
+    pub serializer: ArrowSerializer,
+}
+
+impl NatsSinkFunc {
+    async fn get_nats_client(&mut self) -> Result<async_nats::Client> {
+        info!("Creating NATS publisher for {:?}", self.subject);
+        let servers_vec: Vec<ServerAddr> = self
+            .servers
+            .split(',')
+            .map(|s| s.parse::<ServerAddr>().unwrap())
+            .collect();
+        let nats_client: async_nats::Client = async_nats::ConnectOptions::new()
+            .user_and_password(
+                self.client_config.get("nats.username").unwrap().to_string(),
+                self.client_config.get("nats.password").unwrap().to_string(),
+            )
+            .connect(servers_vec)
+            .await
+            .unwrap();
+        Ok(nats_client)
+    }
+
+    pub fn from_config(config: &str) -> Self {
+        let config: OperatorConfig =
+            serde_json::from_str(config).expect("Invalid config for NatSinkFunc");
+        let table: NatsTable =
+            serde_json::from_value(config.table).expect("Invalid table config for NatsSinkFunc");
+        let format = config
+            .format
+            .expect("NATS source must have a format configured");
+        let connection: NatsConfig = serde_json::from_value(config.connection)
+            .expect("Invalid connection config for NatsSinkFunc");
+        let subject = match &table.connector_type {
+            ConnectorType::Source { .. } => panic!("NATS sink cannot be created from a source"),
+            ConnectorType::Sink { subject, .. } => subject.clone(),
+        };
+        Self {
+            publisher: None,
+            servers: connection.servers.clone(),
+            subject: subject.unwrap().clone(),
+            client_config: get_client_config(&connection, &table),
+            serializer: ArrowSerializer::new(format),
+        }
+    }
+}
+
+#[async_trait]
+impl ArrowOperator for NatsSinkFunc {
+    fn name(&self) -> String {
+        format!("nats-publisher-{}", self.subject)
+    }
+
+    fn tables(&self) -> HashMap<String, TableConfig> {
+        HashMap::new()
+    }
+
+    async fn on_start(&mut self, _ctx: &mut ArrowContext) {
+        // TODO: Get the NATS state sequence_number, i.e. what's the last
+        // message that was succesfully published to the NATS server
+        match self.get_nats_client().await {
+            Ok(client) => {
+                self.publisher = Some(client);
+            }
+            Err(e) => {
+                panic!("Failed to construct NATS publisher: {:?}", e);
+            }
+        }
+    }
+
+    async fn on_close(&mut self, _: &Option<SignalMessage>, ctx: &mut ArrowContext) {
+        if let Some(ControlMessage::Commit { epoch, commit_data }) = ctx.control_rx.recv().await {
+            self.handle_commit(epoch, &commit_data, ctx).await;
+        } else {
+            warn!("No commit message received, not committing")
+        }
+    }
+
+    async fn handle_checkpoint(&mut self, _: CheckpointBarrier, _ctx: &mut ArrowContext) {
+        // TODO: In order to be generic, we shoudln't reuse the sequence number from the NATS source
+        // but rather a identifier specific to the pipeline. How to increment it?
+        // let sequence_number = 1;
+        // ctx.table_manager
+        //     .get_global_keyed_state("n")
+        //     .await
+        //     .as_mut()
+        //     .unwrap()
+        //     .insert(ctx.task_info.task_index, sequence_number)
+        //     .await;
+
+        // TODO: Is flushing sufficient here to ensure messages are neither 
+        // sent twice nor lost before being published successfully?
+        self.publisher.as_mut().unwrap().flush().await.unwrap();
+    }
+
+    async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut ArrowContext) {
+        let nats_subject = async_nats::Subject::from(self.subject.clone());
+        for msg in self.serializer.serialize(&batch) {
+            match self
+                .publisher
+                .as_mut()
+                .unwrap()
+                .publish(nats_subject.clone(), msg.into())
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => {
+                    ctx.control_tx
+                        .send(ControlResp::Error {
+                            operator_id: ctx.task_info.operator_id.clone(),
+                            task_index: ctx.task_info.task_index,
+                            message: e.to_string(),
+                            details: e.to_string(),
+                        })
+                        .await
+                        .unwrap();
+                    panic!("Panicked while processing element: {}", e.to_string());
+                }
+            }
+        }
+    }
+}

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -98,7 +98,12 @@ impl NatsSourceFunc {
             source_type: source
                 .clone()
                 .expect("Either a stream or a subject must be configured as NATS source"),
-            servers: connection.servers.clone(),
+            servers: connection
+                .servers
+                .sub_env_vars()
+                .map_err(|e| e.context("servers"))
+                .unwrap()
+                .clone(),
             connection,
             table,
             format,
@@ -209,9 +214,9 @@ impl NatsSourceFunc {
         let consumer_config = consumer::pull::Config {
             name: Some(consumer_name.clone()),
             replay_policy: consumer::ReplayPolicy::Instant,
-            inactive_threshold: Duration::from_secs(60),
+            inactive_threshold: Duration::from_secs(3600),
             ack_policy: consumer::AckPolicy::Explicit,
-            ack_wait: Duration::from_secs(60),
+            ack_wait: Duration::from_secs(120),
             num_replicas: 1,
             deliver_policy,
             ..Default::default()

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -71,7 +71,6 @@ impl SourceOperator for NatsSourceFunc {
                     })
                     .await
                     .unwrap();
-                // TODO: Fix panicking `NATS message error: missed idle heartbeat`
                 panic!("{}: {}", err.name, err.details);
             }
         }
@@ -241,11 +240,7 @@ impl NatsSourceFunc {
                 },
                 ack_wait: Duration::from_secs(ack_wait.clone() as u64),
                 description: description.clone(),
-                filter_subjects: filter_subjects
-                    .clone()
-                    .split(",")
-                    .map(|s| s.to_string())
-                    .collect(),
+                filter_subjects: filter_subjects.clone(),
                 rate_limit: rate_limit.clone() as u64,
                 sample_frequency: sample_frequency.clone() as u8,
                 num_replicas: num_replicas.clone() as usize,

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -109,9 +109,7 @@ impl NatsSourceFunc {
         &mut self,
         stream_name: String,
     ) -> async_nats::jetstream::stream::Stream {
-        let client = get_nats_client(&self.connection, &self.table)
-            .await
-            .unwrap();
+        let client = get_nats_client(&self.connection).await.unwrap();
         let jetstream = async_nats::jetstream::new(client);
         let mut stream = jetstream.get_stream(&stream_name).await.unwrap();
         let stream_info = stream.info().await.unwrap();

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -1,0 +1,404 @@
+use super::get_client_config;
+use super::ConnectorType;
+use super::NatsConfig;
+use super::NatsState;
+use super::NatsTable;
+use arroyo_operator::context::ArrowContext;
+use arroyo_operator::operator::SourceOperator;
+use arroyo_operator::SourceFinishType;
+use arroyo_rpc::formats::BadData;
+use arroyo_rpc::formats::{Format, Framing};
+use arroyo_rpc::grpc::StopMode;
+use arroyo_rpc::grpc::TableConfig;
+use arroyo_rpc::ControlMessage;
+use arroyo_rpc::ControlResp;
+use arroyo_rpc::OperatorConfig;
+use arroyo_types::UserError;
+use async_nats::jetstream::consumer;
+use async_nats::ServerAddr;
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::time::Duration;
+use tokio::select;
+use tracing::debug;
+use tracing::info;
+
+pub struct NatsSourceFunc {
+    pub stream: String,
+    pub servers: String,
+    pub connection: NatsConfig,
+    pub table: NatsTable,
+    pub format: Format,
+    pub framing: Option<Framing>,
+    pub bad_data: Option<BadData>,
+    pub consumer_config: HashMap<String, String>,
+    pub messages_per_second: NonZeroU32,
+}
+
+#[async_trait]
+impl SourceOperator for NatsSourceFunc {
+    fn name(&self) -> String {
+        format!("NATS-{}", self.stream)
+    }
+
+    fn tables(&self) -> HashMap<String, TableConfig> {
+        arroyo_state::global_table_config("n", "NATS source state")
+    }
+
+    async fn run(&mut self, ctx: &mut ArrowContext) -> SourceFinishType {
+        match self.run_int(ctx).await {
+            Ok(res) => res,
+            Err(err) => {
+                ctx.control_tx
+                    .send(ControlResp::Error {
+                        operator_id: ctx.task_info.operator_id.clone(),
+                        task_index: ctx.task_info.task_index,
+                        message: err.name.clone(),
+                        details: err.details.clone(),
+                    })
+                    .await
+                    .unwrap();
+                panic!("{}: {}", err.name, err.details);
+            }
+        }
+    }
+}
+
+impl NatsSourceFunc {
+    pub fn from_config(config: &str) -> Self {
+        let config: OperatorConfig =
+            serde_json::from_str(config).expect("Invalid config for NatSourceFunc");
+        let connection: NatsConfig = serde_json::from_value(config.connection)
+            .expect("Invalid connection config for NatsSourceFunc");
+        let table: NatsTable =
+            serde_json::from_value(config.table).expect("Invalid table config for NatsSourceFunc");
+        let format = config
+            .format
+            .expect("NATS source must have a format configured");
+        let framing = config.framing;
+
+        let stream = match &table.connector_type {
+            ConnectorType::Source { ref stream, .. } => stream,
+            _ => panic!("NATS source must have a stream configured"),
+        };
+
+        let consumer_default_config = get_client_config(&connection, &table);
+
+        Self {
+            stream: stream.clone().unwrap(),
+            servers: connection.servers.clone(),
+            connection,
+            table,
+            format,
+            framing,
+            bad_data: config.bad_data,
+            consumer_config: consumer_default_config,
+            messages_per_second: NonZeroU32::new(
+                config
+                    .rate_limit
+                    .map(|l| l.messages_per_second)
+                    .unwrap_or(u32::MAX),
+            )
+            .unwrap(),
+        }
+    }
+
+    async fn get_nats_stream(
+        &mut self,
+        stream_name: String,
+    ) -> async_nats::jetstream::stream::Stream {
+        let servers_str = &self.servers;
+        let servers_vec: Vec<ServerAddr> =
+            servers_str.split(',').map(|s| s.parse().unwrap()).collect();
+        let client = async_nats::ConnectOptions::new()
+            .user_and_password(
+                self.consumer_config
+                    .get("nats.username")
+                    .unwrap()
+                    .to_string(),
+                self.consumer_config
+                    .get("nats.password")
+                    .unwrap()
+                    .to_string(),
+            )
+            .connect(servers_vec)
+            .await
+            .unwrap();
+
+        let jetstream = async_nats::jetstream::new(client);
+        let mut stream = jetstream.get_stream(&stream_name).await.unwrap();
+        let stream_info = stream.info().await.unwrap();
+
+        info!("<---------------------------------------------->");
+        info!("Stream - timestamp of creation: {}", &stream_info.created);
+        info!(
+            "Stream - lowest sequence number still present: {}",
+            &stream_info.state.first_sequence
+        );
+        info!(
+            "Stream - last sequence number assigned to a message: {}",
+            &stream_info.state.last_sequence
+        );
+        info!(
+            "Stream - time that the last message was received: {}",
+            &stream_info.state.last_timestamp
+        );
+        info!(
+            "Stream - number of messages contained: {}",
+            &stream_info.state.messages
+        );
+        info!(
+            "Stream - number of bytes contained: {}",
+            &stream_info.state.bytes
+        );
+        info!(
+            "Stream - number of consumers: {}",
+            &stream_info.state.consumer_count
+        );
+
+        stream
+    }
+
+    async fn create_nats_consumer(
+        &mut self,
+        stream: &async_nats::jetstream::stream::Stream,
+        sequence_number: u64,
+        ctx: &mut ArrowContext,
+    ) -> consumer::Consumer<consumer::pull::Config> {
+        match sequence_number {
+            1 => info!(
+                ">> No state found for NATS, starting from sequence number #{}",
+                &sequence_number
+            ),
+            _ => info!(
+                ">> Found state for NATS, starting from sequence number #{}",
+                &sequence_number
+            ),
+        };
+
+        let deliver_policy = {
+            if sequence_number == 1 {
+                consumer::DeliverPolicy::All
+            } else {
+                consumer::DeliverPolicy::ByStartSequence {
+                    start_sequence: sequence_number,
+                }
+            }
+        };
+
+        let consumer_name = format!(
+            "{}-{}",
+            self.stream.clone(),
+            &ctx.task_info.operator_id.clone().replace("operator_", "")
+        );
+
+        // TODO: Replace by client_configs object built in module
+        let consumer_config = consumer::pull::Config {
+            name: Some(consumer_name.clone()),
+            replay_policy: consumer::ReplayPolicy::Instant,
+            inactive_threshold: Duration::from_secs(60),
+            ack_policy: consumer::AckPolicy::Explicit,
+            ack_wait: Duration::from_secs(60),
+            num_replicas: 1,
+            deliver_policy,
+            ..Default::default()
+        };
+
+        match stream.delete_consumer(&consumer_name).await {
+            Ok(_) => {
+                info!(">> Existing consumer deleted. Recreating consumer with new `start_sequence`.")
+            }
+            Err(_) => {
+                info!(">> No existing consumer found, proceeding with the creation of a new one.")
+            }
+        }
+
+        let mut consumer = stream
+            .create_consumer(consumer_config.clone())
+            .await
+            .unwrap();
+
+        let consumer_info = consumer.info().await.unwrap();
+        info!(
+            "Consumer - timestamp of creation: {}",
+            &consumer_info.created
+        );
+        info!(
+            "Consumer - last stream sequence of aknowledged messagee: {}",
+            &consumer_info.ack_floor.stream_sequence
+        );
+        info!(
+            "Consumer - last consumer sequence of aknowledged message: {}",
+            &consumer_info.ack_floor.consumer_sequence
+        );
+        info!(
+            "Consumer delivered messages: {}",
+            &consumer_info.num_ack_pending
+        );
+        info!(
+            "Consumer pending ack messages: {}",
+            &consumer_info.num_pending
+        );
+        info!(
+            "Consumer waiting delivery messages: {}",
+            &consumer_info.num_waiting
+        );
+        info!("<--------------------------------------------->");
+        consumer
+    }
+
+    async fn get_start_sequence_number(&self, ctx: &mut ArrowContext) -> u64 {
+        let state = ctx
+            .table_manager
+            .get_global_keyed_state::<String, NatsState>("n")
+            .await
+            .map_err(|err| UserError::new("failed to get global key value", err.to_string()))
+            .unwrap()
+            .get_all();
+
+        if !state.is_empty() {
+            let state_sequence_number = state
+                .get(&ctx.task_info.operator_id)
+                .map(|nats_state| nats_state.stream_sequence_number)
+                .unwrap();
+            state_sequence_number + 1
+        } else {
+            1
+        }
+    }
+
+    async fn run_int(&mut self, ctx: &mut ArrowContext) -> Result<SourceFinishType, UserError> {
+        let start_sequence = self.get_start_sequence_number(ctx).await;
+        let stream = self.get_nats_stream(self.stream.clone()).await;
+        let consumer = self
+            .create_nats_consumer(&stream, start_sequence, ctx)
+            .await;
+        let mut messages = consumer.messages().await.unwrap();
+        let mut sequence_numbers: HashMap<String, NatsState> = HashMap::new();
+
+        ctx.initialize_deserializer(
+            self.format.clone(),
+            self.framing.clone(),
+            self.bad_data.clone(),
+        );
+
+        loop {
+            select! {
+                message = messages.next() => {
+                    match message {
+                        Some(Ok(msg)) => {
+                            let payload = msg.payload.as_ref();
+                            let message_info = msg.info().unwrap();
+                            let timestamp = message_info.published.into() ;
+
+                            ctx.deserialize_slice(&payload, timestamp).await?;
+
+                            debug!("---------------------------------------------->");
+                            debug!(
+                                "Delivered stream sequence: {}",
+                                message_info.stream_sequence
+                            );
+                            debug!(
+                                "Delivered consumer sequence: {}",
+                                message_info.consumer_sequence
+                            );
+                            debug!(
+                                "Delivered message stream: {}",
+                                message_info.stream
+                            );
+                            debug!(
+                                "Delivered message consumer: {}",
+                                message_info.consumer
+                            );
+                            debug!(
+                                "Delivered message published: {}",
+                                message_info.published
+                            );
+                            debug!(
+                                "Delivered message pending: {}",
+                                message_info.pending
+                            );
+                            debug!(
+                                "Delivered message delivered: {}",
+                                message_info.delivered
+                            );
+
+                            if ctx.should_flush() {
+                                ctx.flush_buffer().await?;
+                            }
+
+                            sequence_numbers.insert(
+                                ctx.task_info.operator_id.clone(),
+                                NatsState {
+                                    stream_name: self.stream.clone(),
+                                    stream_sequence_number: message_info.stream_sequence.clone()
+                                }
+                            );
+
+                            // TODO: Has ACK to happens here at every message? Maybe it can be
+                            // done by ack only the last message before checkpointing
+                            msg.ack().await.unwrap();
+                        },
+                        Some(Err(msg)) => {
+                            return Err(UserError::new("NATS message error", msg.to_string()));
+                        },
+                        None => {
+                            break
+                            info!("Finished reading message from {}", self.stream);
+                        },
+                    }
+                }
+                control_message = ctx.control_rx.recv() => {
+                    match control_message {
+                        Some(ControlMessage::Checkpoint(c)) => {
+                            debug!("Starting checkpointing {}", ctx.task_info.task_index);
+                            let state = ctx.table_manager
+                                .get_global_keyed_state("n")
+                                .await
+                                .map_err(|err| UserError::new("failed to get global key value", err.to_string()))?;
+
+                            // TODO: Should this be parallelized?
+                            for (stream_name, sequence_number) in &sequence_numbers {
+                                state.insert(stream_name.clone(), sequence_number.clone()).await;
+                            }
+
+                            let state_sequence_number = state
+                                .get(&ctx.task_info.operator_id)
+                                .map(|nats_state| nats_state.stream_sequence_number)
+                                .unwrap();
+
+                            
+                            if self.start_checkpoint(c, ctx).await {
+                                return Ok(SourceFinishType::Immediate);
+                            }
+
+                            info!("Checkpoint done at sequence number #{}", state_sequence_number);
+                        }
+                        Some(ControlMessage::Stop { mode }) => {
+                            info!("Stopping NATS source: {:?}", mode);
+                            match mode {
+                                StopMode::Graceful => {
+                                    return Ok(SourceFinishType::Graceful);
+                                }
+                                StopMode::Immediate => {
+                                    return Ok(SourceFinishType::Immediate);
+                                }
+                            }
+                        }
+                        Some(ControlMessage::Commit { .. }) => {
+                            unreachable!("Sources shouldn't receive commit messages");
+                        }
+                        Some(ControlMessage::LoadCompacted {compacted}) => {
+                            ctx.load_compacted(compacted).await;
+                        }
+                        Some(ControlMessage::NoOp) => {}
+                        None => {}
+                    }
+                }
+            }
+        }
+        Ok(SourceFinishType::Graceful)
+    }
+}

--- a/crates/arroyo-connectors/src/nats/table.json
+++ b/crates/arroyo-connectors/src/nats/table.json
@@ -19,8 +19,107 @@
                                     "title": "NATS Jetstream",
                                     "properties": {
                                         "stream": {
+                                            "title": "Stream Name",
                                             "type": "string",
-                                            "description": "The NATS Jetstream stream to consume from"
+                                            "description": "The stream the consumer should consume from."
+                                        },
+                                        "ackPolicy": {
+                                            "title": "Acknowledgment Policy",
+                                            "type": "string",
+                                            "description": "How messages should be acknowledged.",
+                                            "enum": [
+                                                "Explicit",
+                                                "None",
+                                                "All"
+                                            ],
+                                            "default": "Explicit"
+                                        },
+                                        "replayPolicy": {
+                                            "title": "Replay policy",
+                                            "type": "string",
+                                            "description": "Whether messages are sent as quickly as possible or at the rate of receipt.",
+                                            "enum": [
+                                                "Original",
+                                                "Instant"
+                                            ],
+                                            "default": "Instant"
+                                        },
+                                        "ackWait": {
+                                            "title": "Acknowledgment wait",
+                                            "type": "integer",
+                                            "description": "The duration that the server will wait for an ack for any individual message once it has been delivered to a consumer.",
+                                            "default": 300
+                                        },
+                                        "description": {
+                                            "title": "Consumer description",
+                                            "type": "string",
+                                            "description": "A description of the consumer. This can be particularly useful for ephemeral consumers to indicate their purpose since the durable name cannot be provided."
+                                        },
+                                        "filterSubjects": {
+                                            "title": "Filter subjects",
+                                            "type": "string",
+                                            "description": "A list of subjects that the consumer should filter on. If the list is empty, then no filtering is done.",
+                                            "default": ""
+                                        },
+                                        "sampleFrequency": {
+                                            "title": "Sample frequency",
+                                            "type": "integer",
+                                            "description": "Sets the percentage of acknowledgements that should be sampled for observability, 0-100 This value is a string and for example allows both 30 and 30% as valid values.",
+                                            "default": 0
+                                        },
+                                        "numReplicas": {
+                                            "title": "Consumer number of replicas",
+                                            "type": "integer",
+                                            "description": "Sets the number of replicas for the consumer's state. By default, when the value is set to zero, consumers inherit the number of replicas from the stream.",
+                                            "default": 1
+                                        },
+                                        "inactiveThreshold": {
+                                            "title": "Inactive threshold duration",
+                                            "type": "integer",
+                                            "description": "Duration that instructs the server to cleanup consumers that are inactive for that long. Prior to 2.9, this only applied to ephemeral consumers.",
+                                            "default": 600
+                                        },
+                                        "rateLimit": {
+                                            "title": "Rate limit",
+                                            "type": "integer",
+                                            "description": "The maximum number of messages per second that will be delivered to consumers.",
+                                            "default": -1
+                                        },
+                                        "maxAckPending": {
+                                            "title": "Max messages pending for acknowledgement",
+                                            "type": "integer",
+                                            "description": "Defines the maximum number of messages without an acknowledgement that may be in-flight before pausing sending additional messages to the consumer. Once this limit is reached message delivery will be suspended.",
+                                            "default": -1
+                                        },
+                                        "maxDeliver": {
+                                            "title": "Max delivery attempts",
+                                            "type": "integer",
+                                            "description": "The maximum number of times a specific message delivery will be attempted. Applies to any message that is re-sent due to ack policy (i.e. due to a negative ack, or no ack sent by the client).",
+                                            "default": -1
+                                        },
+                                        "maxWaiting": {
+                                            "title": "Max waiting",
+                                            "type": "integer",
+                                            "description": "The maximum number of messages that can be waiting to be delivered to the consumer.",
+                                            "default": 1000000
+                                        },
+                                        "maxBatch": {
+                                            "title": "Max batch",
+                                            "type": "integer",
+                                            "description": "The maximum number of messages that will be delivered in a single batch.",
+                                            "default": 10000
+                                        },
+                                        "maxBytes": {
+                                            "title": "Max bytes",
+                                            "type": "integer",
+                                            "description": "The maximum number of bytes that will be delivered in a single batch.",
+                                            "default": 104857600
+                                        },
+                                        "maxExpires": {
+                                            "title": "Max expires",
+                                            "type": "integer",
+                                            "description": "The maximum number of messages that can be delivered to the consumer before they are considered expired.",
+                                            "default": 30000
                                         }
                                     },
                                     "required": [
@@ -72,14 +171,6 @@
                     "additionalProperties": false
                 }
             ]
-        },
-        "clientConfigs": {
-            "type": "object",
-            "title": "Client Configs",
-            "description": "Additional NATS configs to pass to the underlying NATS consumer or producer.",
-            "additionalProperties": {
-                "type": "string"
-            }
         }
     },
     "required": [

--- a/crates/arroyo-connectors/src/nats/table.json
+++ b/crates/arroyo-connectors/src/nats/table.json
@@ -10,9 +10,37 @@
                     "type": "object",
                     "title": "Source",
                     "properties": {
-                        "stream": {
-                            "type": "string",
-                            "description": "The NATS Jetstream stream to consume from"
+                        "sourceType": {
+                            "type": "object",
+                            "title": "Source Type",
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "title": "NATS Jetstream",
+                                    "properties": {
+                                        "stream": {
+                                            "type": "string",
+                                            "description": "The NATS Jetstream stream to consume from"
+                                        }
+                                    },
+                                    "required": [
+                                        "stream"
+                                    ]
+                                },
+                                {
+                                    "type": "object",
+                                    "title": "NATS Core",
+                                    "properties": {
+                                        "subject": {
+                                            "type": "string",
+                                            "description": "The NATS Core subject to consume from"
+                                        }
+                                    },
+                                    "required": [
+                                        "subject"
+                                    ]
+                                }
+                            ]
                         }
                     },
                     "additionalProperties": false
@@ -21,16 +49,31 @@
                     "type": "object",
                     "title": "Sink",
                     "properties": {
-                        "subject": {
-                            "type": "string",
-                            "description": "The NATS subject to publish to"
+                        "sinkType": {
+                            "type": "object",
+                            "title": "Sink Type",
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "title": "Nats Core",
+                                    "properties": {
+                                        "subject": {
+                                            "type": "string",
+                                            "description": "The NATS subject to publish to"
+                                        }
+                                    },
+                                    "required": [
+                                        "subject"
+                                    ]
+                                }
+                            ]
                         }
                     },
                     "additionalProperties": false
                 }
             ]
         },
-        "client_configs": {
+        "clientConfigs": {
             "type": "object",
             "title": "Client Configs",
             "description": "Additional NATS configs to pass to the underlying NATS consumer or producer.",

--- a/crates/arroyo-connectors/src/nats/table.json
+++ b/crates/arroyo-connectors/src/nats/table.json
@@ -57,9 +57,11 @@
                                         },
                                         "filterSubjects": {
                                             "title": "Filter subjects",
-                                            "type": "string",
+                                            "type": "array",
                                             "description": "A list of subjects that the consumer should filter on. If the list is empty, then no filtering is done.",
-                                            "default": ""
+                                            "uniqueItems": true,
+                                            "default": [],
+                                            "items": { "type": "string" }
                                         },
                                         "sampleFrequency": {
                                             "title": "Sample frequency",
@@ -119,7 +121,7 @@
                                             "title": "Max expires",
                                             "type": "integer",
                                             "description": "The maximum number of messages that can be delivered to the consumer before they are considered expired.",
-                                            "default": 30000
+                                            "default": 300000
                                         }
                                     },
                                     "required": [

--- a/crates/arroyo-connectors/src/nats/table.json
+++ b/crates/arroyo-connectors/src/nats/table.json
@@ -1,0 +1,45 @@
+{
+    "type": "object",
+    "title": "NatsTable",
+    "properties": {
+        "connectorType": {
+            "type": "object",
+            "title": "Connector Type",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "Source",
+                    "properties": {
+                        "stream": {
+                            "type": "string",
+                            "description": "The NATS Jetstream stream to consume from"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "title": "Sink",
+                    "properties": {
+                        "subject": {
+                            "type": "string",
+                            "description": "The NATS subject to publish to"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "client_configs": {
+            "type": "object",
+            "title": "Client Configs",
+            "description": "Additional NATS configs to pass to the underlying NATS consumer or producer.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "connectorType"
+    ]
+}


### PR DESCRIPTION
Opening the PR to get some feedbacks. This is a refactored version of https://github.com/gbto/arroyo/tree/feat/add-nats-source-connector which I've been using to run 6 pipelines in development for now one month on `arrow = { version = "0.9.0" }`. The source only support consuming from [NATS Streams](https://docs.nats.io/nats-concepts/jetstream/streams) and publishing to [NATS Subjects](https://docs.nats.io/nats-concepts/subjects). Both supports leverage connection profiles and tables configurations, with environment variable substitution for secrets. 

The tests are currently not implemented yet, neither are features that were note absolutely required to get it to work in our context of our architecture (e.g. autocomplete, schema validation and registry support, different semantics or deduplication..,). 

There still are a few flawed feature, in particular the way optional extra client configuration are parsed and the checkpointing in the sink connector. Comments on these 2 points would be really appreciated and implemented asap.

``` 
-- source configuration
create table demo_source (
    value text
    ) with (
    type = 'source',
    connector = 'nats',
    servers = 'nats-1:4222,nats-2:4222',
    'nats.stream' = 'demo-source,
    'auth.type' = 'credentials',
    'auth.username' = '{{ NATS_USER }}',
    'auth.password' = '{{ NATS_PASSWORD }}',
    format = 'json',
    'json.unstructured' = 'true'
);
```

```
-- sink configuration
create table demo_sink (
   value text
) with (
    type = 'sink',
    connector = 'nats',
    servers = 'nats-1:4222,nats-2:4222',
    'nats.subject' = 'demo.subject,
    'auth.type' = 'credentials',
    'auth.username' = '{{ NATS_USER }}',
    'auth.password' = '{{ NATS_PASSWORD }}',
    format = 'json',
    'json.unstructured' = 'true'
);
```