### PR TITLE
Implement UDAFs on datafusion

### DIFF
--- a/crates/arroyo-api/src/connection_tables.rs
+++ b/crates/arroyo-api/src/connection_tables.rs
@@ -13,7 +13,7 @@ use std::convert::Infallible;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
-use tracing::warn;
+use tracing::debug;
 
 use arroyo_connectors::confluent::ConfluentProfile;
 use arroyo_connectors::connector_for_type;
@@ -235,7 +235,7 @@ pub(crate) async fn get_all_connection_tables<C: GenericClient>(
         .map(|t| t.try_into())
         .map(|result| {
             if let Err(err) = &result {
-                warn!("Error building connection table: {}", err);
+                debug!("Error building connection table: {}", err);
             }
             result
         })
@@ -417,7 +417,7 @@ pub(crate) async fn get_connection_tables(
         .map(|t| t.try_into())
         .map(|result| {
             if let Err(err) = &result {
-                warn!("Error building connection table: {}", err);
+                debug!("Error building connection table: {}", err);
             }
             result
         })

--- a/crates/arroyo-df/src/builder.rs
+++ b/crates/arroyo-df/src/builder.rs
@@ -39,7 +39,6 @@ use datafusion_proto::{
 };
 
 pub(crate) struct PlanToGraphVisitor<'a> {
-    schema_provider: &'a ArroyoSchemaProvider,
     graph: DiGraph<LogicalNode, LogicalEdge>,
     output_schemas: HashMap<NodeIndex, ArroyoSchemaRef>,
     named_nodes: HashMap<NamedNode, NodeIndex>,
@@ -52,7 +51,6 @@ pub(crate) struct PlanToGraphVisitor<'a> {
 impl<'a> PlanToGraphVisitor<'a> {
     pub fn new(schema_provider: &'a ArroyoSchemaProvider) -> Self {
         Self {
-            schema_provider,
             graph: Default::default(),
             output_schemas: Default::default(),
             named_nodes: Default::default(),

--- a/crates/arroyo-df/src/lib.rs
+++ b/crates/arroyo-df/src/lib.rs
@@ -324,7 +324,10 @@ impl ArroyoSchemaProvider {
         let parsed = ParsedUdf::try_parse(body)?;
 
         if parsed.vec_arguments > 0 && parsed.vec_arguments != parsed.args.len() {
-            bail!("Function {} arguments must be vectors or none", parsed.name);
+            bail!(
+                "In function {}: for a UDAF, all arguments must be Vec<T>",
+                parsed.name
+            );
         }
         let fn_impl = |args: &[ArrayRef]| Ok(Arc::new(args[0].clone()) as ArrayRef);
 
@@ -449,15 +452,6 @@ impl ContextProvider for ArroyoSchemaProvider {
         None
     }
 }
-
-// pub fn new_registry() -> Registry {
-//     let mut registry = Registry::default();
-//     registry.add_udf(Arc::new(window_scalar_function()));
-//     for json_function in get_json_functions().values() {
-//         registry.add_udf(json_function.clone());
-//     }
-//     registry
-// }
 
 impl FunctionRegistry for ArroyoSchemaProvider {
     fn udfs(&self) -> HashSet<String> {

--- a/crates/arroyo-df/src/test/queries/prometheus.sql
+++ b/crates/arroyo-df/src/test/queries/prometheus.sql
@@ -12,7 +12,7 @@ create table metrics (
 
 
 select avg(idle) as idle from (
-  select irate(array_agg(value)) as idle,
+  select irate(value) as idle,
          cpu,
          hop(interval '5 seconds', interval '60 seconds') as window
   from (
@@ -28,7 +28,6 @@ select avg(idle) as idle from (
 
 
 
--- re-enable once we have support for views
 -- CREATE VIEW cpu_metrics AS
 -- SELECT
 --     extract_json_string(parsed, '$.labels.cpu') AS cpu,

--- a/crates/arroyo-df/src/udafs.rs
+++ b/crates/arroyo-df/src/udafs.rs
@@ -1,0 +1,140 @@
+use crate::physical::UdfDylib;
+use arrow::array::ArrayData;
+use arrow::buffer::OffsetBuffer;
+use arrow_array::cast::as_list_array;
+use arrow_array::{make_array, Array, ListArray};
+use arrow_schema::{DataType, FieldRef};
+use datafusion::arrow::array::ArrayRef;
+use datafusion::scalar::ScalarValue;
+use datafusion::{error::Result, physical_plan::Accumulator};
+use datafusion_common::DataFusionError;
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// An Arroyo UDAF is a scalar function that takes vector arguments. This Accumulator infra
+/// exists to wrap an Arroyo UDAF in a DF UDAF that first accumulates the array of data, then
+/// passes it to the vector-taking UDF.
+#[derive(Debug)]
+pub struct ArroyoUdaf {
+    values: Vec<ArrayRef>,
+    data_type: DataType,
+    inner: FieldRef,
+    udf: UdfDylib,
+}
+
+impl ArroyoUdaf {
+    pub fn new(data_type: DataType, udf: UdfDylib) -> Self {
+        println!("creating udaf with datatype {:?}", data_type);
+        let inner = match &data_type {
+            DataType::List(inner) => Arc::clone(inner),
+            _ => panic!("udaf {} type {:?} is not a list", udf.name(), data_type),
+        };
+
+        ArroyoUdaf {
+            data_type,
+            values: vec![],
+            udf,
+            inner,
+        }
+    }
+}
+
+impl ArroyoUdaf {
+    fn list_from_arr(&self, arr: ArrayRef) -> ListArray {
+        let offsets = OffsetBuffer::from_lengths([arr.len()]);
+
+        ListArray::new(self.inner.clone(), offsets, arr, None)
+    }
+    fn concatenate_array(&self) -> Result<ListArray> {
+        let element_arrays: Vec<&dyn Array> = self.values.iter().map(|a| a.as_ref()).collect();
+
+        let arr = arrow::compute::concat(&element_arrays)?;
+
+        Ok(self.list_from_arr(arr))
+    }
+}
+
+impl Accumulator for ArroyoUdaf {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        println!("update batch");
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        self.values.push(values[0].clone());
+
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        if self.values.is_empty() {
+            let data = Arc::new(make_array(ArrayData::new_empty(&self.data_type)));
+            return Ok(ScalarValue::List(Arc::new(self.list_from_arr(data))));
+        }
+
+        println!("in eval");
+
+        let ColumnarValue::Scalar(scalar) = self
+            .udf
+            .invoke(&[ColumnarValue::Scalar(ScalarValue::List(Arc::new(
+                self.concatenate_array()?,
+            )))])
+            .unwrap()
+        else {
+            return Err(DataFusionError::Execution(format!(
+                "UDAF {} returned an array result",
+                self.udf.name()
+            )));
+        };
+        println!("EVALUATED: {:?}", scalar);
+
+        Ok(scalar)
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        Ok(vec![ScalarValue::List(Arc::new(self.concatenate_array()?))])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        if states.is_empty() {
+            return Ok(());
+        }
+
+        let list_arr = as_list_array(&states[0]);
+        for arr in list_arr.iter().flatten() {
+            self.values.push(arr);
+        }
+
+        Ok(())
+    }
+}
+
+// Fake UDAF used just for plan-time
+#[derive(Debug)]
+pub struct EmptyUdaf {}
+impl Accumulator for EmptyUdaf {
+    fn update_batch(&mut self, _: &[ArrayRef]) -> Result<()> {
+        unreachable!()
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        unreachable!()
+    }
+
+    fn size(&self) -> usize {
+        unreachable!()
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        unreachable!()
+    }
+
+    fn merge_batch(&mut self, _: &[ArrayRef]) -> Result<()> {
+        unreachable!()
+    }
+}

--- a/crates/arroyo-df/src/udfs.rs
+++ b/crates/arroyo-df/src/udfs.rs
@@ -25,10 +25,10 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
     let udf_name = format_ident!("{}", parsed.name);
 
     let results_builder = if matches!(parsed.ret_type.data_type, DataType::Utf8) {
-        quote!(let mut results_builder = array::StringBuilder::with_capacity(args[0].len(), args[0].len() * 64);)
+        quote!(let mut results_builder = array::StringBuilder::with_capacity(batch_size, batch_size * 64);)
     } else {
         let return_type = data_type_to_arrow_type_token(parsed.ret_type.data_type.clone())?;
-        quote!(let mut results_builder = array::PrimitiveBuilder::<datatypes::#return_type>::with_capacity(args[0].len());)
+        quote!(let mut results_builder = array::PrimitiveBuilder::<datatypes::#return_type>::with_capacity(batch_size);)
     };
 
     let mut arrow_types = vec![];
@@ -50,7 +50,7 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
             let id = format_ident!("arg_{}", i);
             let def = match &arg_type.data_type {
                 DataType::Utf8 => {
-                    quote!(let #id = array::StringArray::from(args[#i].clone());)
+                    quote!(let #id = array::StringArray::from(args.next().unwrap());)
                 }
                 DataType::List(field) => {
                     let filter = if !field.is_nullable() {
@@ -60,11 +60,11 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
                     };
 
                     quote!(let #id = array::PrimitiveArray::<datatypes::#arrow_type>::from(
-                        args.into_iter().next().unwrap()
+                        args.next().unwrap()
                     ).iter()#filter.collect();)
                 }
                 _ => {
-                    quote!(let #id = array::PrimitiveArray::<datatypes::#arrow_type>::from(args[#i].clone());)
+                    quote!(let #id = array::PrimitiveArray::<datatypes::#arrow_type>::from(args.next().unwrap());)
                 }
             };
 
@@ -151,29 +151,24 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
 
         #[no_mangle]
         pub extern "C" fn run(args_ptr: *mut FfiArraySchemaPair, args_len: usize, args_capacity: usize) -> FfiArraySchemaPair {
-
             let args = unsafe {
                 Vec::from_raw_parts(args_ptr, args_len, args_capacity)
             };
 
-            let args = args
+            let batch_size = args[0].0.len();
+
+            let mut args = args
                 .into_iter()
                 .map(|pair| {
                     let FfiArraySchemaPair(array, schema) = pair;
                     unsafe { from_ffi(array, &schema).unwrap() }
-                })
-                .collect::<Vec<_>>();
+                });
 
-            println!("ARGS2={:?}", args);
             #results_builder
 
             #(#defs;)*
 
-            println!("AFTER DEFS");
-
             #call_loop
-
-            println!("AFTER CALL LOOP");
 
             let (array, schema) = to_ffi(&results_builder.finish().to_data()).unwrap();
             FfiArraySchemaPair(array, schema)

--- a/crates/arroyo-df/src/udfs.rs
+++ b/crates/arroyo-df/src/udfs.rs
@@ -60,7 +60,7 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
                     };
 
                     quote!(let #id = array::PrimitiveArray::<datatypes::#arrow_type>::from(
-                        args[0usize].clone().child_data()[0].clone()
+                        args.into_iter().next().unwrap()
                     ).iter()#filter.collect();)
                 }
                 _ => {
@@ -164,11 +164,16 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
                 })
                 .collect::<Vec<_>>();
 
+            println!("ARGS2={:?}", args);
             #results_builder
 
             #(#defs;)*
 
+            println!("AFTER DEFS");
+
             #call_loop
+
+            println!("AFTER CALL LOOP");
 
             let (array, schema) = to_ffi(&results_builder.finish().to_data()).unwrap();
             FfiArraySchemaPair(array, schema)

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -486,11 +486,16 @@ pub trait ArrowOperator: Send + 'static {
 #[derive(Default)]
 pub struct Registry {
     udfs: HashMap<String, Arc<ScalarUDF>>,
+    udafs: HashMap<String, Arc<AggregateUDF>>,
 }
 
 impl Registry {
     pub fn add_udf(&mut self, udf: Arc<ScalarUDF>) {
         self.udfs.insert(udf.name().to_string(), udf);
+    }
+
+    pub fn add_udaf(&mut self, udaf: Arc<AggregateUDF>) {
+        self.udafs.insert(udaf.name().to_string(), udaf);
     }
 }
 
@@ -503,14 +508,14 @@ impl FunctionRegistry for Registry {
         self.udfs
             .get(name)
             .cloned()
-            .ok_or_else(|| DataFusionError::Execution(format!("Udf {} not found", name)))
+            .ok_or_else(|| DataFusionError::Execution(format!("UDF {} not found", name)))
     }
 
     fn udaf(&self, name: &str) -> DFResult<Arc<AggregateUDF>> {
-        Err(DataFusionError::NotImplemented(format!(
-            "udaf {} not implemented",
-            name
-        )))
+        self.udafs
+            .get(name)
+            .cloned()
+            .ok_or_else(|| DataFusionError::Execution(format!("UDAF {name} not found")))
     }
 
     fn udwf(&self, name: &str) -> DFResult<Arc<WindowUDF>> {

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -235,6 +235,7 @@ message ArrowDylibUdfConfig {
   string dylib_path = 1;
   repeated bytes arg_types = 2;
   bytes return_type = 3;
+  bool aggregate = 4;
 }
 
 message ArrowProgramConfig {

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -189,8 +189,6 @@ impl Program {
         Self::from_logical(name, logical, &assignments, new_registry())
     }
 
-    pub async fn init_udfs() {}
-
     pub fn from_logical(
         name: String,
         logical: &LogicalGraph,

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -22,6 +22,7 @@ use arroyo_types::{
 use local_ip_address::local_ip;
 use rand::random;
 
+use arrow_schema::DataType;
 use base64::engine::general_purpose;
 use base64::Engine as Base64Engine;
 use datafusion_expr::{create_udaf, ScalarUDF, Volatility};
@@ -45,7 +46,7 @@ use prost::Message;
 use arroyo_datastream::logical::{LogicalGraph, LogicalProgram, ProgramConfig};
 use arroyo_df::inner_type;
 use arroyo_df::physical::{new_registry, UdfDylib};
-use arroyo_df::udafs::ArroyoUdaf;
+use arroyo_df::udafs::{ArroyoUdaf, UdafArg};
 use arroyo_server_common::shutdown::ShutdownGuard;
 
 pub mod arrow;
@@ -426,21 +427,40 @@ impl WorkerGrpc for WorkerServer {
 
         for (udf_name, dylib_config) in self.program_config.udf_dylibs.iter() {
             let dylib = UdfDylib::init(udf_name, dylib_config).await;
-            let data_type = dylib_config.arg_types[0].clone();
+
             if dylib_config.aggregate {
+                let output_type = Arc::new(dylib_config.return_type.clone());
+
+                let args: Vec<_> = dylib_config
+                    .arg_types
+                    .iter()
+                    .map(|arg| {
+                        UdafArg::new(match arg {
+                            DataType::List(f) => Arc::clone(f),
+                            _ => {
+                                panic!("arg type {:?} for UDAF {} is not a list", arg, udf_name)
+                            }
+                        })
+                    })
+                    .collect();
+
                 registry.add_udaf(Arc::new(create_udaf(
                     &udf_name,
                     dylib_config
                         .arg_types
                         .iter()
-                        .map(|t| inner_type(t).expect("udaf arg is not a vec"))
+                        .map(|t| inner_type(t).expect("UDAF arg is not a vec"))
                         .collect(),
                     Arc::new(dylib_config.return_type.clone()),
                     Volatility::Volatile,
                     Arc::new(move |_| {
-                        Ok(Box::new(ArroyoUdaf::new(data_type.clone(), dylib.clone())))
+                        Ok(Box::new(ArroyoUdaf::new(
+                            args.clone(),
+                            output_type.clone(),
+                            dylib.clone(),
+                        )))
                     }),
-                    Arc::new(vec![dylib_config.arg_types[0].clone()]),
+                    Arc::new(dylib_config.arg_types.clone()),
                 )));
             } else {
                 registry.add_udf(Arc::new(ScalarUDF::from(dylib)));


### PR DESCRIPTION
Adds proper support for UDAFs in datafusion by implementing an Accumulator which collects values for each UDAF argument, then on evaluate passes them into the UDAF dylib function. The state is the collectesd vector of records.