### PR TITLE
Gracefully handle panics in UDFs

### DIFF
--- a/crates/arroyo-df/src/physical.rs
+++ b/crates/arroyo-df/src/physical.rs
@@ -157,7 +157,7 @@ pub fn window_scalar_function() -> ScalarUDF {
 
 #[derive(WrapperApi)]
 struct UdfDylibInterface {
-    run: unsafe extern "C" fn(
+    run: unsafe extern "C-unwind" fn(
         args_ptr: *mut FfiArraySchemaPair,
         args_len: usize,
         args_capacity: usize,

--- a/crates/arroyo-df/src/udfs.rs
+++ b/crates/arroyo-df/src/udfs.rs
@@ -150,7 +150,7 @@ pub fn lib_rs(definition: &str) -> anyhow::Result<String> {
         pub struct FfiArraySchemaPair(FFI_ArrowArray, FFI_ArrowSchema);
 
         #[no_mangle]
-        pub extern "C" fn run(args_ptr: *mut FfiArraySchemaPair, args_len: usize, args_capacity: usize) -> FfiArraySchemaPair {
+        pub extern "C-unwind" fn run(args_ptr: *mut FfiArraySchemaPair, args_len: usize, args_capacity: usize) -> FfiArraySchemaPair {
             let args = unsafe {
                 Vec::from_raw_parts(args_ptr, args_len, args_capacity)
             };


### PR DESCRIPTION
If a UDF panics (across the current C FFI boundary) it causes the parent to abort. Currently, this leads to a double free and segfault, because both the UDF wrapper and the calling code attempt to free the input arrays. (In normal operation this doesn't happen because we were leaking the arrays from the parent; but the mem::forget call was after the invocation of the UDF and thus wasn't being called if that invocation panicked).

This PR fixes that issue by leaking the memory before we call the UDF. However, that still leads to an unwanted abort of the process; ideally we'd have our queue-driven clean shutdown like we have if a UDF panics in 0.9.

To get back to that, we now catch panics in the UDF wrapper code and return a bool indicating whether or not the UDF panicked. If so, we re-emit the panic in the parent.