### PR TITLE
Add support for configuring timestamp serialization format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "50.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=50.0.0/json#b6d76698f7c5b7c32906cd2c064ae4c149865cb9"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=timestamp_formats#6f9ca64cc65b23c5ca9350b57f37560a0b9863fa"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ arrow = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/par
 arrow-buffer = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
 arrow-array = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
 arrow-schema = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
-arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = 'timestamp_formats'}
+arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/json'}
 object_store = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '0.9.0/put_part_api'}
 datafusion = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
 datafusion-common = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ arrow = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/par
 arrow-buffer = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
 arrow-array = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
 arrow-schema = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/parquet_bytes'}
-arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '50.0.0/json'}
+arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = 'timestamp_formats'}
 object_store = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '0.9.0/put_part_api'}
 datafusion = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}
 datafusion-common = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = 'reset_execs_36'}

--- a/crates/arroyo-df/src/physical.rs
+++ b/crates/arroyo-df/src/physical.rs
@@ -267,7 +267,7 @@ impl ScalarUDFImpl for UdfDylib {
             .max()
             .unwrap();
 
-        let mut args = args
+        let args = args
             .iter()
             .map(|arg| {
                 let (array, schema) = match arg {

--- a/crates/arroyo-df/src/types.rs
+++ b/crates/arroyo-df/src/types.rs
@@ -178,7 +178,11 @@ fn convert_simple_data_type(
             3 => Ok(DataType::Timestamp(TimeUnit::Millisecond, None)),
             6 => Ok(DataType::Timestamp(TimeUnit::Microsecond, None)),
             9 => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
-            _ => bail!("unsupported precision {}", precision),
+            _ => bail!(
+                "unsupported precision {} -- supported precisions are 0 (seconds), \
+            3 (milliseconds), 6 (microseconds), and 9 (nanoseconds)",
+                precision
+            ),
         },
         SQLDataType::Date => Ok(DataType::Date32),
         SQLDataType::Time(None, tz_info) => {

--- a/crates/arroyo-sql-testing/golden_outputs/windowed_outer_join.json
+++ b/crates/arroyo-sql-testing/golden_outputs/windowed_outer_join.json
@@ -23,4 +23,4 @@
 {"hour":"2023-09-19T12:00:00","drivers":101,"pickups":100}
 {"hour":"2023-09-19T13:00:00","drivers":99,"pickups":100}
 {"hour":"2023-09-19T14:00:00","drivers":99,"pickups":62}
-{"hour":"2023-09-19T15:00:00","drivers":10}
+{"hour":"2023-09-19T15:00:00","drivers":10,"pickups":null}


### PR DESCRIPTION
This re-adds support for controlling how timestamps are serialized in JSON via the `json.timestamp_format` option on tables. The heavy-lifting is done by this change in our arrow-json fork: https://github.com/ArroyoSystems/arrow-rs/pull/3.

I've also exposed the ability to set explicit_nulls in the serializer and have enabled that, getting us back to the behavior in 0.9.

For JSON deserialization, the format of the data and the timestamp precision controls how timestamp fields are handled—e.g., a number in a TIMESTAMP(3) field will be interpreted as unix millis, while a string in any timestamp precision will be interpreted as a RFC3339 value.

I've also validated that alternate precisions are correctly supported when used as event_time fields.