### PR TITLE
make cargo clippy pass.

### DIFF
--- a/crates/arroyo-api/src/rest.rs
+++ b/crates/arroyo-api/src/rest.rs
@@ -84,7 +84,7 @@ pub fn create_rest_app(pool: Pool, controller_addr: &str) -> Router {
         Ok::<_, _>(res)
     });
 
-    let serve_dir = ServeDir::new(&asset_dir).not_found_service(fallback);
+    let serve_dir = ServeDir::new(asset_dir).not_found_service(fallback);
 
     // TODO: enable in development only!!!
     let cors = CorsLayer::new()

--- a/crates/arroyo-api/src/udfs.rs
+++ b/crates/arroyo-api/src/udfs.rs
@@ -29,17 +29,17 @@ const LOCAL_UDF_LIB_CRATE: &str = concat!(
     "/../arroyo-udf/arroyo-udf-plugin"
 );
 
-impl Into<GlobalUdf> for DbUdf {
-    fn into(self) -> GlobalUdf {
+impl From<DbUdf> for GlobalUdf {
+    fn from(val: DbUdf) -> Self {
         GlobalUdf {
-            id: self.pub_id,
-            prefix: self.prefix,
-            name: self.name,
-            created_at: to_micros(self.created_at),
-            definition: self.definition,
-            updated_at: to_micros(self.updated_at),
-            description: self.description,
-            dylib_url: self.dylib_url,
+            id: val.pub_id,
+            prefix: val.prefix,
+            name: val.name,
+            created_at: to_micros(val.created_at),
+            definition: val.definition,
+            updated_at: to_micros(val.updated_at),
+            description: val.description,
+            dylib_url: val.dylib_url,
         }
     }
 }
@@ -71,7 +71,7 @@ pub async fn create_udf(
     // build udf
     let build_udf_resp = build_udf(&mut compiler_service().await?, &req.definition, true).await?;
 
-    if build_udf_resp.errors.len() > 0 {
+    if !build_udf_resp.errors.is_empty() {
         return Err(bad_request("UDF is invalid"));
     }
 

--- a/crates/arroyo-bin/src/main.rs
+++ b/crates/arroyo-bin/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail};
-use arroyo_compiler_service;
+
 use arroyo_server_common::shutdown::Shutdown;
 use arroyo_server_common::{log_event, start_admin_server};
 use arroyo_types::{ports, DatabaseConfig};
@@ -119,13 +119,12 @@ async fn db_pool() -> Pool {
             exit(1);
         });
 
-    match pool
-        .get()
-        .await
-        .unwrap_or_else(|e| {
-            error!("Unable to create database connection for {} {}", config, e);
-            exit(1);
-        })
+    let object_manager = pool.get().await.unwrap_or_else(|e| {
+        error!("Unable to create database connection for {} {}", config, e);
+        exit(1);
+    });
+
+    match object_manager
         .query_one("select id from cluster_info", &[])
         .await
     {

--- a/crates/arroyo-compiler-service/src/lib.rs
+++ b/crates/arroyo-compiler-service/src/lib.rs
@@ -115,7 +115,7 @@ impl CompileService {
     }
 
     async fn check_cargo(&self) -> anyhow::Result<()> {
-        if binary_present(&*self.cargo_path.lock().await).await {
+        if binary_present(&self.cargo_path.lock().await).await {
             return Ok(());
         }
 
@@ -326,7 +326,7 @@ impl CompilerGrpc for CompileService {
         // parse output.stdout as json
         let mut errors = vec![];
         for line in lines {
-            let line_json: serde_json::Result<Value> = serde_json::from_str(&line.to_string());
+            let line_json: serde_json::Result<Value> = serde_json::from_str(line);
             if let Ok(line_json) = line_json {
                 if line_json["reason"] == "compiler-message"
                     && line_json["message"]["level"] == "error"

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -42,7 +42,7 @@ impl Connector for BlackholeConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Sink;
+        ConnectionType::Sink
     }
 
     fn get_schema(

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -67,7 +67,7 @@ impl Connector for DeltaLakeConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn from_config(
@@ -98,11 +98,8 @@ impl Connector for DeltaLakeConnector {
             bail!("commit_style must be DeltaLake");
         }
 
-        let backend_config = BackendConfig::parse_url(&write_path, true)?;
-        let is_local = match &backend_config {
-            BackendConfig::Local { .. } => true,
-            _ => false,
-        };
+        let backend_config = BackendConfig::parse_url(write_path, true)?;
+        let is_local = backend_config.is_local();
         let description = match (&format_settings, is_local) {
             (Some(FormatSettings::Parquet { .. }), true) => "LocalDeltaLake<Parquet>".to_string(),
             (Some(FormatSettings::Parquet { .. }), false) => "DeltaLake<Parquet>".to_string(),
@@ -177,11 +174,8 @@ impl Connector for DeltaLakeConnector {
             bail!("commit_style must be DeltaLake");
         }
 
-        let backend_config = BackendConfig::parse_url(&write_path, true)?;
-        let is_local = match &backend_config {
-            BackendConfig::Local { .. } => true,
-            _ => false,
-        };
+        let backend_config = BackendConfig::parse_url(write_path, true)?;
+        let is_local = backend_config.is_local();
         match (&format_settings, is_local) {
             (Some(FormatSettings::Parquet { .. }), true) => {
                 Ok(OperatorNode::from_operator(Box::new(

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -109,11 +109,8 @@ impl Connector for FileSystemConnector {
                     bail!("commit_style must be Direct");
                 };
 
-                let backend_config = BackendConfig::parse_url(&write_path, true)?;
-                let is_local = match &backend_config {
-                    BackendConfig::Local { .. } => true,
-                    _ => false,
-                };
+                let backend_config = BackendConfig::parse_url(write_path, true)?;
+                let is_local = backend_config.is_local();
                 let description = match (format_settings, is_local) {
                     (Some(FormatSettings::Parquet { .. }), true) => {
                         "LocalFileSystem<Parquet>".to_string()
@@ -226,12 +223,8 @@ impl Connector for FileSystemConnector {
                 storage_options: _,
                 write_path,
             } => {
-                let backend_config = BackendConfig::parse_url(&write_path, true)?;
-                let is_local = match &backend_config {
-                    BackendConfig::Local { .. } => true,
-                    _ => false,
-                };
-                match (format_settings, is_local) {
+                let backend_config = BackendConfig::parse_url(write_path, true)?;
+                match (format_settings, backend_config.is_local()) {
                     (Some(FormatSettings::Parquet { .. }), true) => {
                         Ok(OperatorNode::from_operator(Box::new(
                             LocalParquetFileSystemSink::new(write_path.to_string(), table, config),

--- a/crates/arroyo-connectors/src/filesystem/sink/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/delta.rs
@@ -141,8 +141,7 @@ fn create_add_action(file: &FinishedFile, relative_table_path: &Path) -> Result<
         .strip_prefix(&relative_table_path.to_string())
         .context(format!(
             "File {} is not in table {}",
-            file.filename,
-            relative_table_path.to_string()
+            file.filename, relative_table_path
         ))?;
     Ok(Action::Add(Add {
         path: subpath.to_string(),

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -62,8 +62,7 @@ impl BatchBufferingWriter for JsonWriter {
     }
 
     fn evict_current_buffer(&mut self) -> Vec<u8> {
-        let result = std::mem::take(&mut self.current_buffer);
-        result
+        std::mem::take(&mut self.current_buffer)
     }
 
     fn get_trailing_bytes_for_checkpoint(&mut self) -> Option<Vec<u8>> {

--- a/crates/arroyo-connectors/src/filesystem/sink/local.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/local.rs
@@ -70,7 +70,7 @@ impl<V: LocalWriter> LocalFileSystemWriter<V> {
             .clone()
             .unwrap()
             .file_naming
-            .unwrap_or_else(|| FileNaming {
+            .unwrap_or(FileNaming {
                 strategy: Some(FilenameStrategy::Serial),
                 prefix: None,
                 suffix: None,
@@ -142,8 +142,8 @@ impl<V: LocalWriter> LocalFileSystemWriter<V> {
             let filename = match partition {
                 Some(partition) => {
                     // make sure the partition directory exists in tmp and final
-                    create_dir_all(&format!("{}/{}", self.tmp_dir, partition)).unwrap();
-                    create_dir_all(&format!("{}/{}", self.final_dir, partition)).unwrap();
+                    create_dir_all(format!("{}/{}", self.tmp_dir, partition)).unwrap();
+                    create_dir_all(format!("{}/{}", self.final_dir, partition)).unwrap();
                     format!("{}/{}", partition, filename)
                 }
                 None => filename,
@@ -160,7 +160,7 @@ impl<V: LocalWriter> LocalFileSystemWriter<V> {
             );
             self.next_file_index += 1;
         }
-        self.writers.get_mut(&partition).unwrap()
+        self.writers.get_mut(partition).unwrap()
     }
 }
 
@@ -302,10 +302,8 @@ impl<V: LocalWriter + Send + 'static> TwoPhaseCommitter for LocalFileSystemWrite
             );
             tokio::fs::rename(tmp_file, destination).await?;
             finished_files.push(FinishedFile {
-                filename: object_store::path::Path::parse(
-                    destination.to_string_lossy().to_string(),
-                )?
-                .to_string(),
+                filename: object_store::path::Path::parse(&destination.to_string_lossy())?
+                    .to_string(),
                 partition: None,
                 size: destination.metadata()?.len() as usize,
             });

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -305,7 +305,7 @@ pub(crate) fn batches_by_partition(
             .map(|col| take(col, &sort_indices, None).unwrap())
             .collect(),
     )?;
-    let partition = arrow::compute::partition(&vec![sorted_partition.clone()])?;
+    let partition = arrow::compute::partition(&[sorted_partition.clone()])?;
     let typed_partition = sorted_partition
         .as_any()
         .downcast_ref::<StringArray>()

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -97,7 +97,7 @@ impl Connector for FluvioConnector {
             "source" => {
                 let offset = options.remove("source.offset");
                 TableType::Source {
-                    offset: match offset.as_ref().map(|f| f.as_str()) {
+                    offset: match offset.as_deref() {
                         Some("earliest") => SourceOffset::Earliest,
                         None | Some("latest") => SourceOffset::Latest,
                         Some(other) => bail!("invalid value for source.offset '{}'", other),
@@ -116,7 +116,7 @@ impl Connector for FluvioConnector {
             type_: table_type,
         };
 
-        Self::from_config(&self, None, name, EmptyConfig {}, table, schema)
+        Self::from_config(self, None, name, EmptyConfig {}, table, schema)
     }
 
     fn from_config(

--- a/crates/arroyo-connectors/src/fluvio/sink.rs
+++ b/crates/arroyo-connectors/src/fluvio/sink.rs
@@ -59,10 +59,7 @@ impl FluvioSinkFunc {
     async fn get_producer(&mut self) -> anyhow::Result<TopicProducer> {
         info!("Creating fluvio producer for {:?}", self.endpoint);
 
-        let config: Option<FluvioConfig> = self
-            .endpoint
-            .as_ref()
-            .map(|endpoint| FluvioConfig::new(endpoint));
+        let config: Option<FluvioConfig> = self.endpoint.as_ref().map(FluvioConfig::new);
 
         let client = if let Some(config) = &config {
             Fluvio::connect_with_config(config).await?
@@ -70,6 +67,6 @@ impl FluvioSinkFunc {
             Fluvio::connect().await?
         };
 
-        Ok(client.topic_producer(&self.topic).await?)
+        client.topic_producer(&self.topic).await
     }
 }

--- a/crates/arroyo-connectors/src/fluvio/source.rs
+++ b/crates/arroyo-connectors/src/fluvio/source.rs
@@ -73,10 +73,7 @@ impl FluvioSourceFunc {
     ) -> anyhow::Result<StreamMap<u32, impl Stream<Item = Result<ConsumerRecord, ErrorCode>>>> {
         info!("Creating Fluvio consumer for {:?}", self.endpoint);
 
-        let config: Option<FluvioConfig> = self
-            .endpoint
-            .as_ref()
-            .map(|endpoint| FluvioConfig::new(endpoint));
+        let config: Option<FluvioConfig> = self.endpoint.as_ref().map(FluvioConfig::new);
 
         let client = if let Some(config) = &config {
             Fluvio::connect_with_config(config).await?

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -65,7 +65,7 @@ impl Connector for ImpulseConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn get_schema(

--- a/crates/arroyo-connectors/src/kafka/sink/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/mod.rs
@@ -233,7 +233,7 @@ impl ArrowOperator for KafkaSinkFunc {
             operator_id: ctx.task_info.operator_id.clone(),
             subtask_index: ctx.task_info.task_index as u32,
             time: SystemTime::now(),
-            event_type: arroyo_rpc::grpc::TaskCheckpointEventType::FinishedCommit.into(),
+            event_type: arroyo_rpc::grpc::TaskCheckpointEventType::FinishedCommit,
         });
         ctx.control_tx
             .send(checkpoint_event)

--- a/crates/arroyo-connectors/src/kafka/sink/test.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/test.rs
@@ -146,7 +146,7 @@ async fn test_kafka_checkpoint_flushes() {
     let mut sink_with_writes = kafka_topic_tester.get_sink_with_writes().await;
     let mut consumer = kafka_topic_tester.get_consumer("0");
 
-    for chunk in &(1u32..200).into_iter().chunks(7) {
+    for chunk in &(1u32..200).chunks(7) {
         let array = UInt32Array::from_iter_values(chunk.into_iter());
         let batch = RecordBatch::try_new(schema(), vec![Arc::new(array)]).unwrap();
 

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -156,7 +156,7 @@ impl KafkaSourceFunc {
                                     .ok_or_else(|| UserError::new("Failed to read timestamp from Kafka record",
                                         "The message read from Kafka did not contain a message timestamp"))?;
 
-                                ctx.deserialize_slice(&v, from_millis(timestamp as u64)).await?;
+                                ctx.deserialize_slice(v, from_millis(timestamp as u64)).await?;
 
                                 if ctx.should_flush() {
                                     ctx.flush_buffer().await?;

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -70,10 +70,10 @@ impl Connector for KinesisConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, table: Self::TableT) -> ConnectionType {
-        return match table.type_ {
+        match table.type_ {
             TableType::Source { .. } => ConnectionType::Source,
             TableType::Sink { .. } => ConnectionType::Sink,
-        };
+        }
     }
 
     fn from_config(
@@ -118,7 +118,7 @@ impl Connector for KinesisConnector {
             connector: self.name(),
             name: name.to_string(),
             connection_type,
-            schema: schema,
+            schema,
             config: serde_json::to_string(&config).unwrap(),
             description,
         })
@@ -136,7 +136,7 @@ impl Connector for KinesisConnector {
             "source" => {
                 let offset: Option<String> = options.remove("source.offset");
                 TableType::Source {
-                    offset: match offset.as_ref().map(|f| f.as_str()) {
+                    offset: match offset.as_deref() {
                         Some("earliest") => SourceOffset::Earliest,
                         None | Some("latest") => SourceOffset::Latest,
                         Some(other) => bail!("invalid value for source.offset '{}'", other),
@@ -166,7 +166,7 @@ impl Connector for KinesisConnector {
             aws_region: options.remove("aws_region").map(|s| s.to_string()),
         };
 
-        Self::from_config(&self, None, name, EmptyConfig {}, table, schema)
+        Self::from_config(self, None, name, EmptyConfig {}, table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/kinesis/source.rs
+++ b/crates/arroyo-connectors/src/kinesis/source.rs
@@ -372,13 +372,10 @@ impl KinesisSourceFunc {
             select! {
                 result = futures.select_next_some() => {
                     let shard_id = result.name;
-                    match self.handle_async_result_split(shard_id,
+                    if let Some(future) = self.handle_async_result_split(shard_id,
                         result.result.map_err(|e| UserError::new("Fatal Kinesis error", e.to_string()))?, ctx).await? {
-                        Some(future) => {
                             futures.push(future);
-                        },
-                        None => {}
-                    }
+                        }
                 },
                 _ = shard_poll_interval.tick() => {
                     match self.sync_shards(ctx).await {

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -136,23 +136,22 @@ pub(crate) fn source_field(name: &str, field_type: FieldType) -> SourceField {
 }
 
 fn construct_http_client(endpoint: &str, headers: Option<String>) -> anyhow::Result<Client> {
-    if let Err(e) = reqwest::Url::parse(&endpoint) {
+    if let Err(e) = reqwest::Url::parse(endpoint) {
         bail!("invalid endpoint '{}': {:?}", endpoint, e)
     };
 
-    let headers: anyhow::Result<HeaderMap> =
-        string_to_map(headers.as_ref().map(|t| t.as_str()).unwrap_or(""), ':')
-            .expect("Invalid header map")
-            .into_iter()
-            .map(|(k, v)| {
-                Ok((
-                    TryInto::<HeaderName>::try_into(&k)
-                        .map_err(|_| anyhow!("invalid header name {}", k))?,
-                    TryInto::<HeaderValue>::try_into(&v)
-                        .map_err(|_| anyhow!("invalid header value {}", v))?,
-                ))
-            })
-            .collect();
+    let headers: anyhow::Result<HeaderMap> = string_to_map(headers.as_deref().unwrap_or(""), ':')
+        .expect("Invalid header map")
+        .into_iter()
+        .map(|(k, v)| {
+            Ok((
+                TryInto::<HeaderName>::try_into(&k)
+                    .map_err(|_| anyhow!("invalid header name {}", k))?,
+                TryInto::<HeaderValue>::try_into(&v)
+                    .map_err(|_| anyhow!("invalid header value {}", v))?,
+            ))
+        })
+        .collect();
 
     let client = reqwest::ClientBuilder::new()
         .default_headers(headers?)

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -122,7 +122,7 @@ impl Connector for NexmarkConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn get_schema(

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -117,7 +117,7 @@ impl Connector for PollingHTTPConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn test(
@@ -176,7 +176,7 @@ impl Connector for PollingHTTPConnector {
             EmptyConfig {},
             PollingHttpTable {
                 endpoint,
-                headers: headers.map(|s| VarStr::new(s)),
+                headers: headers.map(VarStr::new),
                 method,
                 body,
                 poll_interval_ms: interval,
@@ -254,9 +254,9 @@ impl Connector for PollingHTTPConnector {
         .map(|(k, v)| {
             (
                 (&k).try_into()
-                    .expect(&format!("invalid header name {}", k)),
+                    .unwrap_or_else(|_| panic!("invalid header name {}", k)),
                 (&v).try_into()
-                    .expect(&format!("invalid header value {}", v)),
+                    .unwrap_or_else(|_| panic!("invalid header value {}", v)),
             )
         })
         .collect();

--- a/crates/arroyo-connectors/src/polling_http/operator.rs
+++ b/crates/arroyo-connectors/src/polling_http/operator.rs
@@ -217,10 +217,8 @@ impl PollingHttpSourceFunc {
                     _ = timer.tick()  => {
                         match self.request().await {
                             Ok(buf) => {
-                                if self.emit_behavior == EmitBehavior::Changed {
-                                    if Some(&buf) == self.state.last_message.as_ref() {
-                                        continue;
-                                    }
+                                if self.emit_behavior == EmitBehavior::Changed && Some(&buf) == self.state.last_message.as_ref() {
+                                    continue;
                                 }
 
                                 ctx.deserialize_slice(&buf, SystemTime::now()).await?;

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -44,7 +44,7 @@ impl Connector for PreviewConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Sink;
+        ConnectionType::Sink
     }
 
     fn test(
@@ -115,8 +115,6 @@ impl Connector for PreviewConnector {
         _: Self::TableT,
         _: OperatorConfig,
     ) -> anyhow::Result<OperatorNode> {
-        Ok(OperatorNode::from_operator(
-            Box::new(PreviewSink::default()),
-        ))
+        Ok(OperatorNode::from_operator(Box::<PreviewSink>::default()))
     }
 }

--- a/crates/arroyo-connectors/src/preview/operator.rs
+++ b/crates/arroyo-connectors/src/preview/operator.rs
@@ -53,7 +53,7 @@ impl ArrowOperator for PreviewSink {
                     timestamp: to_micros(
                         timestamp
                             .map(|nanos| from_nanos(nanos as u128))
-                            .unwrap_or_else(|| SystemTime::now()),
+                            .unwrap_or_else(SystemTime::now),
                     ),
                     value,
                     done: false,

--- a/crates/arroyo-connectors/src/single_file/sink.rs
+++ b/crates/arroyo-connectors/src/single_file/sink.rs
@@ -63,6 +63,7 @@ impl ArrowOperator for SingleFileSink {
         } else {
             OpenOptions::new()
                 .write(true)
+                .truncate(true)
                 .create(true)
                 .open(&self.output_path)
                 .await

--- a/crates/arroyo-connectors/src/single_file/source.rs
+++ b/crates/arroyo-connectors/src/single_file/source.rs
@@ -39,7 +39,7 @@ impl SingleFileSourceFunc {
         let state: &mut arroyo_state::tables::global_keyed_map::GlobalKeyedView<String, usize> =
             ctx.table_manager.get_global_keyed_state("f").await.unwrap();
 
-        self.lines_read = state.get(&self.input_file).map(|v| *v).unwrap_or_default();
+        self.lines_read = state.get(&self.input_file).copied().unwrap_or_default();
 
         let file = File::open(&self.input_file).await.expect(&self.input_file);
         let mut lines = BufReader::new(file).lines();

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -68,7 +68,7 @@ impl Connector for SSEConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn from_config(
@@ -138,7 +138,7 @@ impl Connector for SSEConnector {
             SseTable {
                 endpoint,
                 events,
-                headers: headers.map(|s| VarStr::new(s)),
+                headers: headers.map(VarStr::new),
             },
             schema,
         )
@@ -150,7 +150,7 @@ impl Connector for SSEConnector {
         table: Self::TableT,
         config: OperatorConfig,
     ) -> anyhow::Result<OperatorNode> {
-        SSESourceFunc::new(table, config)
+        SSESourceFunc::new_operator(table, config)
     }
 }
 

--- a/crates/arroyo-connectors/src/sse/operator.rs
+++ b/crates/arroyo-connectors/src/sse/operator.rs
@@ -33,7 +33,7 @@ pub struct SSESourceFunc {
 }
 
 impl SSESourceFunc {
-    pub fn new(table: SseTable, config: OperatorConfig) -> anyhow::Result<OperatorNode> {
+    pub fn new_operator(table: SseTable, config: OperatorConfig) -> anyhow::Result<OperatorNode> {
         let headers = table
             .headers
             .as_ref()
@@ -48,7 +48,7 @@ impl SSESourceFunc {
             events: table
                 .events
                 .map(|e| e.split(',').map(|e| e.to_string()).collect())
-                .unwrap_or_else(std::vec::Vec::new),
+                .unwrap_or_default(),
             format: config.format.expect("SSE requires a format"),
             framing: config.framing,
             bad_data: config.bad_data,
@@ -170,7 +170,7 @@ impl SSESourceFunc {
 
                                         if events.is_empty() || events.contains(&event.event_type) {
                                             ctx.deserialize_slice(
-                                                &event.data.as_bytes(), SystemTime::now()).await?;
+                                                event.data.as_bytes(), SystemTime::now()).await?;
 
                                             if ctx.should_flush() {
                                                 ctx.flush_buffer().await?;

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -38,7 +38,7 @@ pub struct WebhookConnector {}
 impl WebhookConnector {
     fn construct_test_request(client: &Client, config: &WebhookTable) -> anyhow::Result<Request> {
         let req = client
-            .post(&config.endpoint.sub_env_vars()?)
+            .post(config.endpoint.sub_env_vars()?)
             // TODO: use the schema to construct a correctly-formatted message
             .body(
                 serde_json::to_string(&json! {{
@@ -132,7 +132,7 @@ impl Connector for WebhookConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Sink;
+        ConnectionType::Sink
     }
 
     fn from_config(
@@ -184,7 +184,7 @@ impl Connector for WebhookConnector {
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
 
-        let headers = options.remove("headers").map(|s| VarStr::new(s));
+        let headers = options.remove("headers").map(VarStr::new);
 
         let table = WebhookTable {
             endpoint: VarStr::new(endpoint),

--- a/crates/arroyo-connectors/src/websocket/mod.rs
+++ b/crates/arroyo-connectors/src/websocket/mod.rs
@@ -210,7 +210,7 @@ impl Connector for WebsocketConnector {
     }
 
     fn table_type(&self, _: Self::ProfileT, _: Self::TableT) -> ConnectionType {
-        return ConnectionType::Source;
+        ConnectionType::Source
     }
 
     fn from_config(
@@ -299,7 +299,7 @@ impl Connector for WebsocketConnector {
             EmptyConfig {},
             WebsocketTable {
                 endpoint,
-                headers: headers.map(|s| VarStr::new(s)),
+                headers: headers.map(VarStr::new),
                 subscription_message: None,
                 subscription_messages,
             },
@@ -327,14 +327,7 @@ impl Connector for WebsocketConnector {
 
         let headers = header_map(table.headers)
             .into_iter()
-            .map(|(k, v)| {
-                (
-                    (&k).try_into()
-                        .expect(&format!("invalid header name {}", k)),
-                    (&v).try_into()
-                        .expect(&format!("invalid header value {}", v)),
-                )
-            })
+            .map(|(k, v)| ((&k).into(), (&v).into()))
             .collect();
 
         Ok(OperatorNode::from_source(Box::new(WebsocketSourceFunc {

--- a/crates/arroyo-connectors/src/websocket/operator.rs
+++ b/crates/arroyo-connectors/src/websocket/operator.rs
@@ -209,7 +209,7 @@ impl WebsocketSourceFunc {
                             Some(Ok(msg)) => {
                                 match msg {
                                     tungstenite::Message::Text(t) => {
-                                        self.handle_message(&t.as_bytes(), ctx).await?
+                                        self.handle_message(t.as_bytes(), ctx).await?
                                     },
                                     tungstenite::Message::Binary(bs) => {
                                         self.handle_message(&bs, ctx).await?

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -378,7 +378,7 @@ impl RunningJobModel {
                 // compact the operator's state and notify the workers to load the new files
                 self.job_id.clone(),
                 operator_id.clone(),
-                self.epoch.clone(),
+                self.epoch,
             )
             .await?;
 
@@ -560,8 +560,7 @@ impl JobController {
             model: RunningJobModel {
                 job_id: config.id.clone(),
                 state: JobState::Running,
-                checkpoint_state: commit_state
-                    .map(|state| CheckpointingOrCommittingState::Committing(state)),
+                checkpoint_state: commit_state.map(CheckpointingOrCommittingState::Committing),
                 epoch,
                 min_epoch,
                 last_checkpoint: Instant::now(),

--- a/crates/arroyo-controller/src/schedulers/kubernetes.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes.rs
@@ -23,10 +23,10 @@ use std::env;
 use std::time::Duration;
 use tonic::Status;
 
-const CLUSTER_LABEL: &'static str = "cluster";
-const JOB_ID_LABEL: &'static str = "job_id";
-const RUN_ID_LABEL: &'static str = "run_id";
-const JOB_NAME_LABEL: &'static str = "job_name";
+const CLUSTER_LABEL: &str = "cluster";
+const JOB_ID_LABEL: &str = "job_id";
+const RUN_ID_LABEL: &str = "run_id";
+const JOB_NAME_LABEL: &str = "job_name";
 
 pub struct KubernetesScheduler {
     client: Option<Client>,
@@ -167,7 +167,7 @@ impl KubernetesScheduler {
             "apiVersion": "apps/v1",
             "kind": "ReplicaSet",
             "metadata": {
-                "name": format!("{}-{}-{}", self.name, req.job_id.to_ascii_lowercase().replace("_", "-"), req.run_id),
+                "name": format!("{}-{}-{}", self.name, req.job_id.to_ascii_lowercase().replace('_', "-"), req.run_id),
                 "namespace": self.namespace,
                 "labels": labels,
                 "annotations": annotations,
@@ -283,7 +283,7 @@ impl Scheduler for KubernetesScheduler {
         for i in 0..20 {
             tokio::time::sleep(Duration::from_millis(i * 10)).await;
 
-            if self.workers_for_job(&job_id, run_id).await?.len() == 0 {
+            if self.workers_for_job(job_id, run_id).await?.is_empty() {
                 return Ok(());
             }
         }
@@ -321,16 +321,16 @@ impl Scheduler for KubernetesScheduler {
 
 #[cfg(test)]
 mod test {
+    use arroyo_datastream::logical::LogicalProgram;
+
     use crate::schedulers::kubernetes::KubernetesScheduler;
     use crate::schedulers::StartPipelineReq;
 
-    #[ignore]
     #[test]
-    #[allow(unreachable_code, unused)]
     fn test_resource_creation() {
         let req = StartPipelineReq {
             name: "test_pipeline".to_string(),
-            program: todo!(),
+            program: LogicalProgram::default(),
             wasm_path: "file:///wasm".to_string(),
             job_id: "job123".to_string(),
             hash: "12123123h".to_string(),

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -419,6 +419,7 @@ impl Transition {
     }
 }
 
+#[allow(clippy::needless_lifetimes)]
 async fn execute_state<'a>(
     state: Box<dyn State>,
     mut ctx: JobContext<'a>,
@@ -596,10 +597,10 @@ impl StateMachine {
     }
 
     fn decode_program(bs: &[u8]) -> anyhow::Result<LogicalProgram> {
-        Ok(ArrowProgram::decode(&bs[..])
+        ArrowProgram::decode(bs)
             .map_err(|e| anyhow!("Failed to decode program: {:?}", e))?
             .try_into()
-            .map_err(|e| anyhow!("Failed to construct graph from program: {:?}", e))?)
+            .map_err(|e| anyhow!("Failed to construct graph from program: {:?}", e))
     }
 
     async fn get_program(

--- a/crates/arroyo-datastream/src/logical.rs
+++ b/crates/arroyo-datastream/src/logical.rs
@@ -185,12 +185,12 @@ pub struct DylibUdfConfig {
     pub is_async: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ProgramConfig {
     pub udf_dylibs: HashMap<String, DylibUdfConfig>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LogicalProgram {
     pub graph: LogicalGraph,
     pub program_config: ProgramConfig,
@@ -439,7 +439,7 @@ impl From<LogicalProgram> for ArrowProgram {
                         .projection
                         .as_ref()
                         .map(|p| p.iter().map(|v| *v as u32).collect())
-                        .unwrap_or(vec![]),
+                        .unwrap_or_default(),
                 }
             })
             .collect();

--- a/crates/arroyo-df/src/extension/aggregate.rs
+++ b/crates/arroyo-df/src/extension/aggregate.rs
@@ -37,7 +37,7 @@ use crate::{
 
 use super::{ArroyoExtension, NodeWithIncomingEdges, TimestampAppendExtension};
 
-pub(crate) const AGGREGATE_EXTENSION_NAME: &'static str = "AggregateExtension";
+pub(crate) const AGGREGATE_EXTENSION_NAME: &str = "AggregateExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct AggregateExtension {

--- a/crates/arroyo-df/src/extension/debezium.rs
+++ b/crates/arroyo-df/src/extension/debezium.rs
@@ -16,8 +16,8 @@ use crate::builder::{NamedNode, Planner};
 
 use super::{ArroyoExtension, NodeWithIncomingEdges};
 
-pub(crate) const DEBEZIUM_UNROLLING_EXTENSION_NAME: &'static str = "DebeziumUnrollingExtension";
-pub(crate) const TO_DEBEZIUM_EXTENSION_NAME: &'static str = "ToDebeziumExtension";
+pub(crate) const DEBEZIUM_UNROLLING_EXTENSION_NAME: &str = "DebeziumUnrollingExtension";
+pub(crate) const TO_DEBEZIUM_EXTENSION_NAME: &str = "ToDebeziumExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DebeziumUnrollingExtension {

--- a/crates/arroyo-df/src/extension/join.rs
+++ b/crates/arroyo-df/src/extension/join.rs
@@ -13,7 +13,7 @@ use datafusion_proto::physical_plan::AsExecutionPlan;
 use prost::Message;
 use std::sync::Arc;
 
-pub(crate) const JOIN_NODE_NAME: &'static str = "JoinNode";
+pub(crate) const JOIN_NODE_NAME: &str = "JoinNode";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JoinExtension {

--- a/crates/arroyo-df/src/extension/key_calculation.rs
+++ b/crates/arroyo-df/src/extension/key_calculation.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::{ArroyoExtension, NodeWithIncomingEdges};
 
-pub(crate) const KEY_CALCULATION_NAME: &'static str = "KeyCalculationExtension";
+pub(crate) const KEY_CALCULATION_NAME: &str = "KeyCalculationExtension";
 
 /* Calculation for computing keyed data, with a vec of keys
    that will be used for shuffling data to the correct nodes.

--- a/crates/arroyo-df/src/extension/remote_table.rs
+++ b/crates/arroyo-df/src/extension/remote_table.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::{ArroyoExtension, NodeWithIncomingEdges};
 
-pub(crate) const REMOTE_TABLE_NAME: &'static str = "RemoteTableExtension";
+pub(crate) const REMOTE_TABLE_NAME: &str = "RemoteTableExtension";
 
 /* Lightweight extension that allows us to segment the graph and merge nodes with the same name.
   An Extension Planner will be used to isolate computation to individual nodes.
@@ -49,13 +49,13 @@ impl ArroyoExtension for RemoteTableExtension {
         input_schemas: Vec<ArroyoSchemaRef>,
     ) -> Result<NodeWithIncomingEdges> {
         match input_schemas.len() {
-            1 => {}
             0 => bail!("RemoteTableExtension should have exactly one input"),
-            multiple_inputs => {
+            1 => {}
+            _multiple_inputs => {
                 // check they are all the same
                 let first = input_schemas[0].clone();
-                for i in 1..multiple_inputs {
-                    if input_schemas[i] != first {
+                for schema in input_schemas.iter().skip(1) {
+                    if *schema != first {
                         bail!("If a node has multiple inputs, they must all have the same schema");
                     }
                 }

--- a/crates/arroyo-df/src/extension/sink.rs
+++ b/crates/arroyo-df/src/extension/sink.rs
@@ -25,7 +25,7 @@ use super::{
     NodeWithIncomingEdges,
 };
 
-pub(crate) const SINK_NODE_NAME: &'static str = "SinkExtension";
+pub(crate) const SINK_NODE_NAME: &str = "SinkExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct SinkExtension {

--- a/crates/arroyo-df/src/extension/table_source.rs
+++ b/crates/arroyo-df/src/extension/table_source.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use super::{ArroyoExtension, DebeziumUnrollingExtension, NodeWithIncomingEdges};
-pub(crate) const TABLE_SOURCE_NAME: &'static str = "TableSourceExtension";
+pub(crate) const TABLE_SOURCE_NAME: &str = "TableSourceExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TableSourceExtension {

--- a/crates/arroyo-df/src/extension/updating_aggregate.rs
+++ b/crates/arroyo-df/src/extension/updating_aggregate.rs
@@ -13,7 +13,7 @@ use crate::builder::{NamedNode, SplitPlanOutput};
 use super::{ArroyoExtension, IsRetractExtension, NodeWithIncomingEdges};
 use prost::Message;
 
-pub(crate) const UPDATING_AGGREGATE_EXTENSION_NAME: &'static str = "UpdatingAggregateExtension";
+pub(crate) const UPDATING_AGGREGATE_EXTENSION_NAME: &str = "UpdatingAggregateExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct UpdatingAggregateExtension {
@@ -158,7 +158,7 @@ impl ArroyoExtension for UpdatingAggregateExtension {
         };
         let node = LogicalNode {
             operator_id: format!("updating_aggregate_{}", index),
-            description: format!("UpdatingAggregate"),
+            description: "UpdatingAggregate".to_string(),
             operator_name: OperatorName::UpdatingAggregate,
             operator_config: config.encode_to_vec(),
             parallelism: 1,

--- a/crates/arroyo-df/src/extension/watermark_node.rs
+++ b/crates/arroyo-df/src/extension/watermark_node.rs
@@ -12,7 +12,7 @@ use prost::Message;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-pub(crate) const WATERMARK_NODE_NAME: &'static str = "WatermarkNode";
+pub(crate) const WATERMARK_NODE_NAME: &str = "WatermarkNode";
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WatermarkNode {
     pub input: LogicalPlan,

--- a/crates/arroyo-df/src/extension/window_fn.rs
+++ b/crates/arroyo-df/src/extension/window_fn.rs
@@ -14,7 +14,7 @@ use crate::physical::ArroyoPhysicalExtensionCodec;
 
 use super::{ArroyoExtension, NodeWithIncomingEdges};
 
-pub(crate) const WINDOW_FUNCTION_EXTENSION_NAME: &'static str = "WindowFunctionExtension";
+pub(crate) const WINDOW_FUNCTION_EXTENSION_NAME: &str = "WindowFunctionExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct WindowFunctionExtension {

--- a/crates/arroyo-df/src/lib.rs
+++ b/crates/arroyo-df/src/lib.rs
@@ -472,9 +472,7 @@ pub fn rewrite_plan(
 ) -> DFResult<LogicalPlan> {
     plan.rewrite(&mut UnnestRewriter {})?
         // .rewrite(&mut AsyncUdfRewriter::new(&schema_provider))?
-        .rewrite(&mut ArroyoRewriter {
-            schema_provider: &schema_provider,
-        })
+        .rewrite(&mut ArroyoRewriter { schema_provider })
 }
 
 pub async fn parse_and_get_arrow_program(

--- a/crates/arroyo-formats/src/ser.rs
+++ b/crates/arroyo-formats/src/ser.rs
@@ -214,7 +214,7 @@ mod tests {
     fn test_raw_string() {
         let mut serializer = ArrowSerializer::new(Format::RawString(RawStringFormat {}));
 
-        let data: Vec<_> = vec!["a", "b", "blah", "whatever"]
+        let data: Vec<_> = ["a", "b", "blah", "whatever"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -261,7 +261,7 @@ mod tests {
             timestamp_format: Default::default(),
         }));
 
-        let text: Vec<_> = vec!["a", "b", "blah", "whatever"]
+        let text: Vec<_> = ["a", "b", "blah", "whatever"]
             .iter()
             .map(|s| s.to_string())
             .collect();

--- a/crates/arroyo-metrics/src/lib.rs
+++ b/crates/arroyo-metrics/src/lib.rs
@@ -18,7 +18,7 @@ pub fn gauge_for_task(
     mut labels: HashMap<String, String>,
 ) -> Option<IntGauge> {
     let mut opts = Opts::new(name, help);
-    labels.extend(task_info.metric_label_map().into_iter());
+    labels.extend(task_info.metric_label_map());
 
     opts.const_labels = labels;
 
@@ -32,7 +32,7 @@ pub fn histogram_for_task(
     mut labels: HashMap<String, String>,
     buckets: Vec<f64>,
 ) -> Option<Histogram> {
-    labels.extend(task_info.metric_label_map().into_iter());
+    labels.extend(task_info.metric_label_map());
     let opts = HistogramOpts::new(name, help)
         .const_labels(labels)
         .buckets(buckets);
@@ -98,6 +98,7 @@ pub enum TaskCounters {
     DeserializationErrors,
 }
 
+#[allow(clippy::type_complexity)]
 impl TaskCounters {
     fn metric(&self) -> &'static IntCounterVec {
         match self {
@@ -147,7 +148,7 @@ pub fn register_queue_gauge<T>(
     name: &'static str,
     help: &'static str,
     task_info: &TaskInfo,
-    out_qs: &Vec<Vec<T>>,
+    out_qs: &[Vec<T>],
 ) -> QueueGauges {
     out_qs
         .iter()

--- a/crates/arroyo-openapi/src/lib.rs
+++ b/crates/arroyo-openapi/src/lib.rs
@@ -1,3 +1,3 @@
 // build.rs generates the OpenAPI spec and client
-
+#![allow(clippy::all)]
 include!("../client/src/lib.rs");

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -22,6 +22,7 @@ pub struct Connection {
     pub description: String,
 }
 
+#[allow(clippy::wrong_self_convention)]
 pub trait Connector: Send {
     type ProfileT: DeserializeOwned + Serialize;
     type TableT: DeserializeOwned + Serialize;
@@ -107,7 +108,8 @@ pub trait Connector: Send {
         config: OperatorConfig,
     ) -> anyhow::Result<OperatorNode>;
 }
-
+#[allow(clippy::type_complexity)]
+#[allow(clippy::wrong_self_convention)]
 pub trait ErasedConnector: Send {
     fn name(&self) -> &'static str;
 

--- a/crates/arroyo-operator/src/lib.rs
+++ b/crates/arroyo-operator/src/lib.rs
@@ -33,9 +33,9 @@ pub fn server_for_hash_array(
 ) -> anyhow::Result<PrimitiveArray<UInt64Type>> {
     let range_size = u64::MAX / (n as u64);
     let range_scalar = UInt64Array::new_scalar(range_size);
-    let mut server_scalar = UInt64Array::new_scalar(n as u64);
+    let server_scalar = UInt64Array::new_scalar(n as u64);
     let division = div(hash, &range_scalar)?;
-    let mod_array = rem(&division, &mut server_scalar)?;
+    let mod_array = rem(&division, &server_scalar)?;
     let result: &PrimitiveArray<UInt64Type> = mod_array.as_any().downcast_ref().unwrap();
     Ok(result.clone())
 }
@@ -149,9 +149,9 @@ impl<T: OperatorConstructor> ErasedConstructor for T {
     }
 }
 
-pub fn get_timestamp_col<'a, 'b>(
+pub fn get_timestamp_col<'a>(
     batch: &'a RecordBatch,
-    ctx: &'b mut ArrowContext,
+    ctx: &mut ArrowContext,
 ) -> &'a PrimitiveArray<TimestampNanosecondType> {
     batch
         .column(ctx.out_schema.as_ref().unwrap().timestamp_index)
@@ -162,6 +162,12 @@ pub fn get_timestamp_col<'a, 'b>(
 
 pub struct RateLimiter {
     last: Instant,
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RateLimiter {

--- a/crates/arroyo-operator/src/udfs.rs
+++ b/crates/arroyo-operator/src/udfs.rs
@@ -45,7 +45,7 @@ pub struct ArroyoUdaf {
 impl ArroyoUdaf {
     pub fn new(args: Vec<UdafArg>, output_type: Arc<DataType>, udf: Arc<SyncUdfDylib>) -> Self {
         assert!(
-            args.len() > 0,
+            !args.is_empty(),
             "UDAF {} has no arguments, but UDAFs must have at least one",
             udf.name()
         );
@@ -110,7 +110,7 @@ impl Accumulator for ArroyoUdaf {
             .iter()
             .map(|arg| Ok(ScalarValue::List(Arc::new(arg.concatenate_array()?))))
             .collect();
-        Ok(states?)
+        states
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -260,14 +260,16 @@ impl ConnectionSchema {
         match &self.format {
             Some(Format::RawString(_)) => {
                 if self.fields.len() != 1
-                    || self.fields.get(0).unwrap().field_type.r#type
+                    || self.fields.first().unwrap().field_type.r#type
                         != FieldType::Primitive(PrimitiveType::String)
-                    || self.fields.get(0).unwrap().field_name != "value"
+                    || self.fields.first().unwrap().field_name != "value"
                 {
                     bail!("raw_string format requires a schema with a single field called `value` of type TEXT");
                 }
             }
-            _ => {}
+            _ => {
+                // Right now only RawString has checks, but we may add checks for other formats in the future
+            }
         }
 
         Ok(self)
@@ -278,9 +280,9 @@ impl ConnectionSchema {
     }
 }
 
-impl Into<ArroyoSchema> for ConnectionSchema {
-    fn into(self) -> ArroyoSchema {
-        let fields: Vec<Field> = self.fields.into_iter().map(|f| f.into()).collect();
+impl From<ConnectionSchema> for ArroyoSchema {
+    fn from(val: ConnectionSchema) -> Self {
+        let fields: Vec<Field> = val.fields.into_iter().map(|f| f.into()).collect();
         ArroyoSchema::from_fields(fields)
     }
 }

--- a/crates/arroyo-rpc/src/api_types/udfs.rs
+++ b/crates/arroyo-rpc/src/api_types/udfs.rs
@@ -8,10 +8,10 @@ pub struct Udf {
     pub definition: String,
 }
 
-impl Into<api_proto::Udf> for Udf {
-    fn into(self) -> api_proto::Udf {
+impl From<Udf> for api_proto::Udf {
+    fn from(val: Udf) -> Self {
         api_proto::Udf {
-            definition: self.definition,
+            definition: val.definition,
         }
     }
 }

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -218,7 +218,7 @@ impl AvroFormat {
         static RE: OnceLock<Regex> = OnceLock::new();
         let re = RE.get_or_init(|| Regex::new(r"[^a-zA-Z0-9_.]").unwrap());
 
-        re.replace_all(&s, "_").replace('.', "__")
+        re.replace_all(s, "_").replace('.', "__")
     }
 }
 
@@ -323,7 +323,8 @@ impl NewlineDelimitedFraming {
             .map(|t| u64::from_str(&t))
             .transpose()
             .map_err(|_| {
-                format!("invalid value for framing.newline.max_length; must be an unsigned integer")
+                "invalid value for framing.newline.max_length; must be an unsigned integer"
+                    .to_string()
             })?;
 
         Ok(NewlineDelimitedFraming { max_line_length })

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -190,7 +190,6 @@ impl Default for OperatorConfig {
 
 pub fn error_chain(e: anyhow::Error) -> String {
     e.chain()
-        .into_iter()
         .map(|e| e.to_string())
         .collect::<Vec<_>>()
         .join(": ")
@@ -224,7 +223,7 @@ impl Converter {
                 Ok(row_converter.convert_columns(columns)?.row(0).owned())
             }
             Converter::Empty(row_converter, array) => Ok(row_converter
-                .convert_columns(&vec![array.clone()])?
+                .convert_columns(&[array.clone()])?
                 .row(0)
                 .owned()),
         }

--- a/crates/arroyo-rpc/src/schema_resolver.rs
+++ b/crates/arroyo-rpc/src/schema_resolver.rs
@@ -22,6 +22,12 @@ pub trait SchemaResolver: Send {
 /// dynamically resolve them.
 pub struct FailingSchemaResolver {}
 
+impl Default for FailingSchemaResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FailingSchemaResolver {
     pub fn new() -> Self {
         FailingSchemaResolver {}
@@ -285,9 +291,7 @@ impl ConfluentSchemaRegistryClient {
             })?;
 
         match resp.status() {
-            StatusCode::OK => {
-                return Ok(());
-            }
+            StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => {
                 bail!("schema registry returned 404 Not Found; check the endpoint is correct")
             }

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -119,7 +119,7 @@ pub fn log_event(name: &str, mut props: Value) {
     if telemetry_enabled() {
         let name = name.to_string();
         tokio::task::spawn(async move {
-            let client = CLIENT.get_or_init(|| Client::new());
+            let client = CLIENT.get_or_init(Client::new);
 
             if let Some(props) = props.as_object_mut() {
                 props.insert("distinct_id".to_string(), Value::String(cluster_id));

--- a/crates/arroyo-state/src/checkpoint_state.rs
+++ b/crates/arroyo-state/src/checkpoint_state.rs
@@ -72,7 +72,7 @@ impl OperatorState {
         HashMap<String, TableCheckpointMetadata>,
     )> {
         self.subtasks_checkpointed += 1;
-        self.watermarks.push(c.watermark.map(|w| from_micros(w)));
+        self.watermarks.push(c.watermark.map(from_micros));
         self.start_time = match self.start_time {
             Some(existing_start_time) => Some(existing_start_time.min(from_micros(c.start_time))),
             None => Some(from_micros(c.start_time)),

--- a/crates/arroyo-state/src/parquet.rs
+++ b/crates/arroyo-state/src/parquet.rs
@@ -244,7 +244,8 @@ impl ParquetBackend {
                     .get(table_name)
                     .unwrap()
                     .clone();
-                let files = match table_config.table_type() {
+
+                match table_config.table_type() {
                     grpc::TableEnum::MissingTableType => todo!("should handle error"),
                     grpc::TableEnum::GlobalKeyValue => {
                         GlobalKeyedTable::files_to_keep(table_config, metadata.clone()).unwrap()
@@ -252,8 +253,7 @@ impl ParquetBackend {
                     grpc::TableEnum::ExpiringKeyedTimeTable => {
                         ExpiringTimeKeyTable::files_to_keep(table_config, metadata.clone()).unwrap()
                     }
-                };
-                files
+                }
             })
             .collect();
 
@@ -279,7 +279,8 @@ impl ParquetBackend {
                         .ok_or_else(|| anyhow::anyhow!("missing table config for operator {}, table {}, metadata is {:?}, operator_metadata is {:?}",
                          operator_id, table_name, metadata, operator_metadata)).unwrap()
                         .clone();
-                    let files = match table_config.table_type() {
+
+                    match table_config.table_type() {
                         grpc::TableEnum::MissingTableType => todo!("should handle error"),
                         grpc::TableEnum::GlobalKeyValue => {
                             GlobalKeyedTable::files_to_keep(table_config, metadata.clone()).unwrap()
@@ -288,8 +289,7 @@ impl ParquetBackend {
                             ExpiringTimeKeyTable::files_to_keep(table_config, metadata.clone())
                                 .unwrap()
                         }
-                    };
-                    files
+                    }
                 })
             {
                 if !paths_to_keep.contains(&file) && !deleted_paths.contains(&file) {

--- a/crates/arroyo-state/src/schemas/mod.rs
+++ b/crates/arroyo-state/src/schemas/mod.rs
@@ -61,7 +61,7 @@ impl SchemaWithHashAndOperation {
         ));
         let state_schema = Arc::new(ArroyoSchema::new(
             state_schema,
-            memory_schema.timestamp_index.clone(),
+            memory_schema.timestamp_index,
             memory_schema.key_indices.clone(),
         ));
         Self {
@@ -141,8 +141,8 @@ impl SchemaWithHashAndOperation {
             .as_any()
             .downcast_ref::<UInt64Array>()
             .ok_or_else(|| anyhow!("should be able to convert hash array to UInt64Array"))?;
-        let hash_min = min(&hash_array).expect("should have min hash value");
-        let hash_max = max(&hash_array).expect("should have max hash value");
+        let hash_min = min(hash_array).expect("should have min hash value");
+        let hash_max = max(hash_array).expect("should have max hash value");
         let timestamp_array = batch
             .column(self.state_schema.timestamp_index)
             .as_any()
@@ -164,9 +164,9 @@ impl SchemaWithHashAndOperation {
             .memory_schema
             .key_indices
             .as_ref()
-            .map(|key_indices| record_batch.project(&key_indices))
+            .map(|key_indices| record_batch.project(key_indices))
             .transpose()?
-            .unwrap_or_else(|| record_batch.project(&vec![]).unwrap());
+            .unwrap_or_else(|| record_batch.project(&[]).unwrap());
 
         let mut hash_buffer = vec![0u64; key_batch.num_rows()];
         let _hashes = create_hashes(key_batch.columns(), &get_hasher(), &mut hash_buffer)?;

--- a/crates/arroyo-state/src/tables/global_keyed_map.rs
+++ b/crates/arroyo-state/src/tables/global_keyed_map.rs
@@ -65,9 +65,7 @@ impl GlobalKeyedTable {
             .as_any()
             .downcast_ref::<arrow_array::BinaryArray>()
             .ok_or_else(|| anyhow!("failed to downcast value column to BinaryArray"))?;
-        Ok(cast_key_column
-            .into_iter()
-            .zip(cast_value_column.into_iter()))
+        Ok(cast_key_column.into_iter().zip(cast_value_column))
     }
     pub async fn memory_view<K: Key, V: Data>(
         &self,
@@ -78,7 +76,7 @@ impl GlobalKeyedTable {
             let contents = self.storage_provider.get(file).await?;
             let reader = ParquetRecordBatchReaderBuilder::try_new(contents)?.build()?;
             for batch in reader {
-                for (key, value) in self.get_key_value_iterator(&batch?)?.into_iter() {
+                for (key, value) in self.get_key_value_iterator(&batch?)? {
                     let key =
                         key.ok_or_else(|| anyhow!("unexpected null key from record batch"))?;
                     let value =

--- a/crates/arroyo-state/src/tables/table_manager.rs
+++ b/crates/arroyo-state/src/tables/table_manager.rs
@@ -252,10 +252,9 @@ impl TableManager {
         let tables = table_configs
             .iter()
             .map(|(table_name, table_config)| {
-                let table_restore_from = checkpoint_metadata
-                    .as_ref()
-                    .map(|metadata| metadata.table_checkpoint_metadata.get(table_name).cloned())
-                    .flatten();
+                let table_restore_from = checkpoint_metadata.as_ref().and_then(|metadata| {
+                    metadata.table_checkpoint_metadata.get(table_name).cloned()
+                });
                 let erased_table = match table_config.table_type() {
                     TableEnum::MissingTableType => bail!("should have table type"),
                     TableEnum::GlobalKeyValue => {

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -475,16 +475,16 @@ impl<T: Data> TryFrom<DebeziumShadow<T>> for Debezium<T> {
     fn try_from(value: DebeziumShadow<T>) -> Result<Self, Self::Error> {
         match (value.op, &value.before, &value.after) {
             (DebeziumOp::Create, _, None) => {
-                return Err("`after` must be set for Debezium create messages");
+                Err("`after` must be set for Debezium create messages")
             }
             (DebeziumOp::Update, None, _) => {
-                return Err("`before` must be set for Debezium update messages; for Postgres you may need to set REPLICA IDENTIFY FULL on your database");
+                Err("`before` must be set for Debezium update messages; for Postgres you may need to set REPLICA IDENTIFY FULL on your database")
             }
             (DebeziumOp::Update, _, None) => {
-                return Err("`after` must be set for Debezium update messages");
+                Err("`after` must be set for Debezium update messages")
             }
             (DebeziumOp::Delete, None, _) => {
-                return Err("`before` must be set for Debezium delete messages");
+                Err("`before` must be set for Debezium delete messages")
             }
             _ => Ok(Debezium {
                 before: value.before,

--- a/crates/arroyo-udf/arroyo-udf-common/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-common/src/lib.rs
@@ -55,12 +55,9 @@ impl FfiArrays {
     pub fn into_vec(self) -> Vec<ArrayData> {
         let vec = unsafe { Vec::from_raw_parts(self.ptr, self.len, self.capacity) };
 
-        let args = vec
-            .into_iter()
+        vec.into_iter()
             .map(|FfiArraySchema(array, schema)| unsafe { from_ffi(array, &schema).unwrap() })
-            .collect();
-
-        args
+            .collect()
     }
 }
 

--- a/crates/arroyo-udf/arroyo-udf-common/src/parse.rs
+++ b/crates/arroyo-udf/arroyo-udf-common/src/parse.rs
@@ -262,7 +262,7 @@ impl ParsedUdf {
                         } else {
                             return Err(meta.error(format!(
                                 "unsupported attribute '{}'",
-                                meta.path.to_token_stream().to_string()
+                                meta.path.to_token_stream()
                             )));
                         }
                         Ok(())

--- a/crates/arroyo-udf/arroyo-udf-host/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-host/src/lib.rs
@@ -308,7 +308,7 @@ impl AsyncUdfDylib {
                 .__send(handle, id, FfiArrays::from_vec(data))
                 .await
         }
-        .then(|| ())
+        .then_some(())
         .ok_or_else(|| anyhow!("cannot send; Aync UDF {} has shut down", self.name))
     }
 
@@ -345,7 +345,7 @@ impl Drop for AsyncUdfDylib {
 
 impl SyncUdfDylib {
     pub fn invoke_udaf(&self, args: &[ArrayRef]) -> DFResult<ScalarValue> {
-        let data: Vec<_> = args.into_iter().map(|a| a.to_data()).collect();
+        let data: Vec<_> = args.iter().map(|a| a.to_data()).collect();
 
         let args = FfiArrays::from_vec(data);
 

--- a/crates/arroyo-udf/arroyo-udf-host/src/test.rs
+++ b/crates/arroyo-udf/arroyo-udf-host/src/test.rs
@@ -23,7 +23,7 @@ fn test_udf() {
     let udf = test_udf_1::__local().config;
     let sync_udf: SyncUdfDylib = (&udf).try_into().unwrap();
     let result = sync_udf
-        .invoke(&vec![
+        .invoke(&[
             ColumnarValue::Array(Arc::new(Int32Array::from(vec![1, 10, 20]))),
             ColumnarValue::Array(Arc::new(StringArray::from(vec!["a", "b", "c"]))),
         ])
@@ -55,9 +55,7 @@ fn test_udaf() {
     let udf = test_udaf::__local().config;
     let sync_udf: SyncUdfDylib = (&udf).try_into().unwrap();
     let result = sync_udf
-        .invoke_udaf(&vec![
-            Arc::new(UInt64Array::from(vec![1, 10, 20])) as ArrayRef
-        ])
+        .invoke_udaf(&[Arc::new(UInt64Array::from(vec![1, 10, 20])) as ArrayRef])
         .unwrap();
 
     assert_eq!(result, ScalarValue::UInt64(Some(3)));

--- a/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
@@ -20,7 +20,7 @@ fn data_type_to_arrow_type_token(data_type: &DataType) -> TokenStream {
         DataType::UInt64 => quote!(UInt64Type),
         DataType::Float32 => quote!(Float32Type),
         DataType::Float64 => quote!(Float64Type),
-        DataType::List(f) => data_type_to_arrow_type_token(&f.data_type()),
+        DataType::List(f) => data_type_to_arrow_type_token(f.data_type()),
         _ => panic!("Unsupported data type: {:?}", data_type),
     }
 }
@@ -89,7 +89,7 @@ pub fn local_udf(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let input_str = input.to_string();
-    let def = format!("#[udf({})]{}", attr.to_string(), input_str);
+    let def = format!("#[udf({})]{}", attr, input_str);
     let parsed: ParsedFunction = syn::parse(input).unwrap();
     let name = parsed.0.name.clone();
 

--- a/crates/arroyo-udf/arroyo-udf-plugin/src/async_udf.rs
+++ b/crates/arroyo-udf/arroyo-udf-plugin/src/async_udf.rs
@@ -40,6 +40,14 @@ impl<T: Send, F: Future<Output = T> + Send + 'static> FuturesEnum<F> {
             FuturesEnum::Unordered(futures) => futures.len(),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            FuturesEnum::Ordered(futures) => futures.is_empty(),
+            FuturesEnum::Unordered(futures) => futures.is_empty(),
+        }
+    }
+
     pub fn is_ordered(&self) -> bool {
         match self {
             FuturesEnum::Ordered(_) => true,
@@ -64,7 +72,7 @@ pub async fn send(handle: SendableFfiAsyncUdfHandle, id: u64, arrays: FfiArrays)
 
     unsafe {
         let handle = handle.ptr as *mut AsyncUdfHandle;
-        (&mut *handle).tx.send((id, args))
+        (*handle).tx.send((id, args))
     }
     .await
     .is_ok()
@@ -177,7 +185,7 @@ impl<
         let mut results = self.results.lock().unwrap();
         match result {
             Ok(value) => {
-                results.0.append_value(id as u64);
+                results.0.append_value(id);
                 value.append_to(&mut results.1);
             }
             Err(_) => {

--- a/crates/arroyo-worker/src/arrow/async_udf.rs
+++ b/crates/arroyo-worker/src/arrow/async_udf.rs
@@ -192,7 +192,7 @@ impl ArrowOperator for AsyncUdfOperator {
         // and the old partitions are not aligned in the actual dataflow. To fix this we need
         // to retain keys throughout the dataflow.
         gs.get_all()
-            .into_iter()
+            .iter()
             .filter(|(task_index, _)| {
                 **task_index % ctx.task_info.parallelism == ctx.task_info.task_index
             })
@@ -271,7 +271,7 @@ impl ArrowOperator for AsyncUdfOperator {
             let args: Vec<_> = arg_batch
                 .iter()
                 .map(|v| {
-                    arrow::compute::take(&*v, &UInt64Array::from(vec![i as u64]), None)
+                    arrow::compute::take(v, &UInt64Array::from(vec![i as u64]), None)
                         .unwrap()
                         .to_data()
                 })
@@ -300,10 +300,7 @@ impl ArrowOperator for AsyncUdfOperator {
             rows.push(row.row());
         }
 
-        let mut cols = self
-            .input_row_converter
-            .convert_rows(rows.into_iter())
-            .unwrap();
+        let mut cols = self.input_row_converter.convert_rows(rows).unwrap();
         cols.push(make_array(results));
 
         let batch = RecordBatch::try_new(self.input_schema.as_ref().unwrap().clone(), cols)

--- a/crates/arroyo-worker/src/arrow/join_with_expiration.rs
+++ b/crates/arroyo-worker/src/arrow/join_with_expiration.rs
@@ -136,7 +136,7 @@ impl JoinWithExpiration {
 #[async_trait::async_trait]
 impl ArrowOperator for JoinWithExpiration {
     fn name(&self) -> String {
-        format!("JoinWithExpiration")
+        "JoinWithExpiration".to_string()
     }
 
     async fn process_batch(&mut self, _record_batch: RecordBatch, _ctx: &mut ArrowContext) {

--- a/crates/arroyo-worker/src/arrow/watermark_generator.rs
+++ b/crates/arroyo-worker/src/arrow/watermark_generator.rs
@@ -129,7 +129,7 @@ impl ArrowOperator for WatermarkGenerator {
         self.last_event = SystemTime::now();
 
         let timestamp_column = get_timestamp_col(&record, ctx);
-        let Some(max_timestamp) = kernels::aggregate::max(&timestamp_column) else {
+        let Some(max_timestamp) = kernels::aggregate::max(timestamp_column) else {
             return;
         };
         let max_timestamp = from_nanos(max_timestamp as u128);

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -196,7 +196,7 @@ impl Program {
 
         let mut registry = new_registry();
         for udf in udfs {
-            registry.add_local_udf(&udf);
+            registry.add_local_udf(udf);
         }
         Self::from_logical(name, logical, &assignments, registry)
     }
@@ -249,8 +249,7 @@ impl Program {
                         node.operator_name,
                         node.operator_config.clone(),
                         registry.clone(),
-                    )
-                    .into(),
+                    ),
                     projection: projection.clone(),
                 }));
             }
@@ -484,10 +483,9 @@ impl Engine {
             Some(
                 StateBackend::load_checkpoint_metadata(&self.job_id, epoch)
                     .await
-                    .expect(&format!(
-                        "failed to load checkpoint metadata for epoch {}",
-                        epoch
-                    )),
+                    .unwrap_or_else(|_| {
+                        panic!("failed to load checkpoint metadata for epoch {}", epoch)
+                    }),
             )
         } else {
             None
@@ -684,7 +682,7 @@ impl Engine {
                 if graph.edge_endpoints(edge).unwrap().1 == idx {
                     let weight = graph.edge_weight_mut(edge).unwrap();
                     in_qs_map
-                        .entry((weight.edge.clone(), weight.in_logical_idx))
+                        .entry((weight.edge, weight.in_logical_idx))
                         .or_default()
                         .push(weight.rx.take().unwrap());
                 }
@@ -831,5 +829,5 @@ pub fn construct_operator(
     };
 
     ctor.with_config(config, registry)
-        .expect(&format!("Failed to construct operator {:?}", operator))
+        .unwrap_or_else(|_| panic!("Failed to construct operator {:?}", operator))
 }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -155,7 +155,7 @@ impl WorkerServer {
     pub fn from_env(shutdown_guard: ShutdownGuard) -> Self {
         let graph = std::env::var(ARROYO_PROGRAM_ENV).expect("ARROYO_PROGRAM not set");
         let graph = general_purpose::STANDARD_NO_PAD
-            .decode(&graph)
+            .decode(graph)
             .expect("ARROYO_PROGRAM not valid base64");
 
         let graph =

--- a/crates/arroyo-worker/src/network_manager.rs
+++ b/crates/arroyo-worker/src/network_manager.rs
@@ -41,6 +41,12 @@ pub struct Senders {
     senders: HashMap<Quad, NetworkSender>,
 }
 
+impl Default for Senders {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Senders {
     pub fn new() -> Self {
         Self {
@@ -49,7 +55,7 @@ impl Senders {
     }
 
     pub fn merge(&mut self, other: Self) {
-        self.senders.extend(other.senders.into_iter())
+        self.senders.extend(other.senders)
     }
 
     pub fn add(&mut self, quad: Quad, schema: SchemaRef, tx: BatchSender) {
@@ -273,7 +279,7 @@ impl OutNetworkLink {
                             ArrowMessage::Data(data) => {
                                 let (_, encoded_message) = {
                                     let mut dictionary_tracker = dictionary_tracker.lock().await;
-                                    IpcDataGenerator {}.encoded_batch(&data, &mut *dictionary_tracker, &write_options)
+                                    IpcDataGenerator {}.encoded_batch(&data, &mut dictionary_tracker, &write_options)
                                       .expect("failed to encode batch")
                                 };
                                 write_message_and_header(&mut Pin::new(&mut self.stream), quad, encoded_message).await.unwrap();

--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -56,8 +56,7 @@ pub async fn main() {
 }
 
 async fn get_docker() -> anyhow::Result<Docker> {
-    Ok(Docker::connect_with_local_defaults()
-        .context("Failed to connect to docker -- is it running?")?)
+    Docker::connect_with_local_defaults().context("Failed to connect to docker -- is it running?")
 }
 
 async fn create_image(docker: &Docker, image: &str) -> Result<String> {
@@ -79,7 +78,7 @@ async fn create_image(docker: &Docker, image: &str) -> Result<String> {
 
     println!("Waiting for image to be available...");
     loop {
-        match docker.inspect_image(&image).await {
+        match docker.inspect_image(image).await {
             Ok(metadata) => {
                 println!();
                 return Ok(metadata.id.unwrap());
@@ -216,7 +215,7 @@ pub async fn start(tag: Option<String>, damon: bool) -> Result<()> {
 
     let docker = get_docker().await?;
 
-    let tag = tag.as_ref().map(|t| t.as_str()).unwrap_or("latest");
+    let tag = tag.as_deref().unwrap_or("latest");
     let image = format!("ghcr.io/arroyosystems/arroyo-single:{}", tag);
 
     let image_id = create_image(&docker, &image).await?;

--- a/crates/copy-artifacts/src/main.rs
+++ b/crates/copy-artifacts/src/main.rs
@@ -23,12 +23,12 @@ fn main() {
             .iter()
             .map(|src| {
                 let src = src.clone();
-                let name = src.split("/").last().unwrap();
-                let dst = PathBuf::from_str(&dst).unwrap().join(name);
+                let name = src.split('/').last().unwrap();
+                let dst = PathBuf::from_str(dst).unwrap().join(name);
                 tokio::spawn(async move {
                     let data: Vec<u8> = StorageProvider::get_url(&src)
                         .await
-                        .expect(&format!("Failed to download {}", src))
+                        .unwrap_or_else(|_| panic!("Failed to download {}", src))
                         .into();
 
                     tokio::fs::write(&dst, data).await.unwrap();

--- a/crates/integ/src/main.rs
+++ b/crates/integ/src/main.rs
@@ -44,7 +44,7 @@ pub fn run_service(name: String, args: &[&str], env: Vec<(String, String)>) -> R
 async fn wait_for_state(api_conf: &Configuration, pipeline_id: &str, expected_state: &str) {
     let mut last_state = "None".to_string();
     while last_state != expected_state {
-        let jobs = get_pipeline_jobs(&api_conf, &pipeline_id).await.unwrap();
+        let jobs = get_pipeline_jobs(api_conf, pipeline_id).await.unwrap();
         let job = jobs.data.first().unwrap();
 
         let state = job.state.clone();


### PR DESCRIPTION
`cargo clippy` now passes. I started with `cargo clippy --fix` and then did manual fixes for the rest. The main things I fixed manually:

* Switch single matches to `if let` blocks.
* Change &Vec<_> function args to &[_].
* Define some complex types.
* Add allows where it made sense.