### PR TITLE
Fix issue with multiple windows open to the pipeline editor

### DIFF
--- a/webui/pnpm-lock.yaml
+++ b/webui/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@babel/core':
     specifier: ^7.22.5
@@ -6299,7 +6303,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -327,6 +327,8 @@ export interface components {
       primitive: components["schemas"]["PrimitiveType"];
     }, {
       struct: components["schemas"]["StructType"];
+    }, {
+      list: components["schemas"]["SourceField"];
     }]>;
     Format: OneOf<[{
       json: components["schemas"]["JsonFormat"];
@@ -348,6 +350,7 @@ export interface components {
       createdAt: number;
       definition: string;
       description?: string | null;
+      dylibUrl: string;
       id: string;
       name: string;
       prefix: string;

--- a/webui/src/routes/pipelines/CreatePipeline.tsx
+++ b/webui/src/routes/pipelines/CreatePipeline.tsx
@@ -57,7 +57,6 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import PipelineEditorTabs from './PipelineEditorTabs';
 import ResourcePanel from './ResourcePanel';
-import useLocalStorage from 'use-local-storage';
 import { LocalUdf, LocalUdfsContext } from '../../udf_state';
 import UdfLabel from '../udfs/UdfLabel';
 import { PiFileSqlDuotone } from 'react-icons/pi';
@@ -100,7 +99,7 @@ export function CreatePipeline() {
   );
   const hasUdfValidationErrors = localUdfs.some(u => u.errors?.length);
   const hasValidationErrors = queryValidation?.errors?.length || hasUdfValidationErrors;
-  const [resourcePanelTab, setResourcePanelTab] = useLocalStorage('resourcePanelTabIndex', 0);
+  const [resourcePanelTab, setResourcePanelTab] = useState(0);
   const [udfValidationApiError, setUdfValidationApiError] = useState<any | undefined>(undefined);
   const [validationInProgress, setValidationInProgress] = useState<boolean>(false);
   const [startingPreview, setStartingPreview] = useState<boolean>(false);

--- a/webui/src/udf_state.ts
+++ b/webui/src/udf_state.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import useLocalStorage from 'use-local-storage';
 import { GlobalUdf, useGlobalUdfs } from './lib/data_fetching';
 import { generate_udf_id } from './lib/util';
@@ -49,12 +49,9 @@ export const LocalUdfsContext = React.createContext<{
 export const getLocalUdfsContextValue = () => {
   const [localUdfs, setLocalUdfs] = useLocalStorage<LocalUdf[]>('localUdfs', []);
   const { globalUdfs, deleteGlobalUdf: apiDeleteGlobalUdf } = useGlobalUdfs();
-  const [openedGlobalUdfs, setOpenedGlobalUdfs] = useLocalStorage<GlobalUdf[]>(
-    'openedGlobalUdfs',
-    []
-  );
-  const [editorTab, setEditorTab] = useLocalStorage('editorTabIndex', 0);
-  const [selectedUdfId, setSelectedUdfId] = useLocalStorage('selectedUdfId', '');
+  const [openedGlobalUdfs, setOpenedGlobalUdfs] = useState<GlobalUdf[]>([]);
+  const [editorTab, setEditorTab] = useState(0);
+  const [selectedUdfId, setSelectedUdfId] = useState<string | undefined>('');
 
   const openedUdfs = [...localUdfs.filter(u => u.open), ...openedGlobalUdfs];
   const openedUdfsIds = openedUdfs.map(u => u.id);


### PR DESCRIPTION
Fixes an issue where updates for selected tab saved to local storage would conflict between multiple windows, leading to an infinite loop of updates between the two views of the pipeline editor. The fix is to not manage active tabs in local storage.