### PR TITLE
Fix a bug in the k8s deployment where the worker. slots configuration…

### DIFF
--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -102,7 +102,7 @@ spec:
         - name: K8S_WORKER_RESOURCES
           value: {{ .Values.worker.resources | toYaml | quote }}
         - name: K8S_WORKER_SLOTS
-          value: {{ .Values.workerSlots | quote }}
+          value: {{ .Values.worker.slots | quote }}
         {{- if .Values.volumes }}
         - name: K8S_WORKER_VOLUMES
           value: {{ .Values.volumes | toYaml | quote }}


### PR DESCRIPTION
When I was deploying using k8s, I found that there seemed to be a problem with the configuration of the K8S_WORKER_SLOTS environment variable, and I fixed it to the correct value.

https://github.com/ArroyoSystems/arroyo/blob/5fc6fe06cbbdc866f232bd813eb5e8aff16bcb3a/k8s/arroyo/templates/controller.yaml#L104C1-L105C51

```
        - name: K8S_WORKER_SLOTS
          value: {{ .Values.workerSlots | quote }}
```

`.Values.workerSlots` does not exist,  `.Values.worker.slots` exists, so I modified it to  `.Values.worker.slots`