### PR TITLE
Write program to file instead of environment variable

### DIFF
--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -88,6 +88,7 @@ pub const WORKER_ID_ENV: &str = "WORKER_ID_ENV";
 pub const JOB_ID_ENV: &str = "JOB_ID_ENV";
 pub const RUN_ID_ENV: &str = "RUN_ID_ENV";
 pub const ARROYO_PROGRAM_ENV: &str = "ARROYO_PROGRAM";
+pub const ARROYO_PROGRAM_FILE_ENV: &str = "ARROYO_PROGRAM_FILE";
 pub const COMPILER_ADDR_ENV: &str = "COMPILER_ADDR";
 pub const NOMAD_ENDPOINT_ENV: &str = "NOMAD_ENDPOINT";
 pub const NOMAD_DC_ENV: &str = "NOMAD_DC";


### PR DESCRIPTION
MacOS has a fairly low limit for max environment variable size, which could bit hit with large pipelines (in terms of number of nodes). This change adds the option to the worker to load the program from a file rather than environment variable, and makes use of that in the process and node schedulers.