### PR TITLE
Fix regression in bad_data handling

### DIFF
--- a/crates/arroyo-formats/src/avro/schema.rs
+++ b/crates/arroyo-formats/src/avro/schema.rs
@@ -116,11 +116,18 @@ fn to_arrow_datatype(schema: &Schema) -> (DataType, bool, Option<ArroyoExtension
         Schema::Null => (DataType::Null, false, None),
         Schema::Boolean => (DataType::Boolean, false, None),
         Schema::Int | Schema::TimeMillis => (DataType::Int32, false, None),
-        Schema::Long
-        | Schema::TimeMicros
-        | Schema::TimestampMillis
-        | Schema::LocalTimestampMillis
-        | Schema::LocalTimestampMicros => (DataType::Int64, false, None),
+        Schema::Long => (DataType::Int64, false, None),
+        Schema::TimeMicros => (DataType::Time64(TimeUnit::Microsecond), false, None),
+        Schema::TimestampMillis | Schema::LocalTimestampMillis => (
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+            None,
+        ),
+        Schema::TimestampMicros | Schema::LocalTimestampMicros => (
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+            None,
+        ),
         Schema::Float => (DataType::Float32, false, None),
         Schema::Double => (DataType::Float64, false, None),
         Schema::Bytes | Schema::Fixed(_) | Schema::Decimal(_) => (DataType::Binary, false, None),

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -784,6 +784,7 @@ pub fn should_flush(size: usize, time: Instant) -> bool {
     let flush_linger =
         FLUSH_LINGER.get_or_init(|| duration_millis_config(BATCH_LINGER_MS_ENV, DEFAULT_LINGER));
 
+    println!("Should flush? {}", size);
     size > 0 && (size >= *flush_size || time.elapsed() >= *flush_linger)
 }
 

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -784,7 +784,6 @@ pub fn should_flush(size: usize, time: Instant) -> bool {
     let flush_linger =
         FLUSH_LINGER.get_or_init(|| duration_millis_config(BATCH_LINGER_MS_ENV, DEFAULT_LINGER));
 
-    println!("Should flush? {}", size);
     size > 0 && (size >= *flush_size || time.elapsed() >= *flush_linger)
 }
 


### PR DESCRIPTION
Fixes a regression introduced in #573 where bad_data=fail could be ignored in JSON handling. Also fixes an issue with avro timestamp encoding.