### PR TITLE
Statically compiled lzma to prevent dynamic linking on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicase",
+ "xz2",
 ]
 
 [[package]]

--- a/crates/arroyo-df/Cargo.toml
+++ b/crates/arroyo-df/Cargo.toml
@@ -49,6 +49,8 @@ prettyplease = "0.2.4"
 unicase = "2.7.0"
 toml = "0.8.8"
 
+xz2 = { version = "0.1.7", features = ["static"] }
+
 [dev-dependencies]
 test-log = {version = "0.2.15", default-features = false, features = ["trace"]}
 rstest = { version = "0.18.2" }


### PR DESCRIPTION
This is helps to satisfy gatekeeper when providing MacOS builds, as liblzma is not provided by the system