### PR TITLE
Add ability to set group_id prefix for kafka

### DIFF
--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -80,6 +80,7 @@ impl KafkaTopicTester {
             bootstrap_servers: self.server.clone(),
             topic: self.topic.clone(),
             group_id: self.group_id.clone(),
+            group_id_prefix: None,
             offset_mode: SourceOffset::Earliest,
             format: Format::RawString(RawStringFormat {}),
             framing: None,

--- a/crates/arroyo-connectors/src/kafka/table.json
+++ b/crates/arroyo-connectors/src/kafka/table.json
@@ -37,7 +37,12 @@
                         "group_id": {
                             "type": "string",
                             "title": "group id",
-                            "description": "Sets the Group ID of the consumer for Kafka source. If not specified, an automatically generated ID will be used. CAUTION: Using one consumer group for multiple pipelines may result in incomplete data"
+                            "description": "Sets the Group ID of the consumer for Kafka source. If not specified, an automatically generated ID will be used. Overrides group_id_prefix if set. CAUTION: Using one consumer group for multiple pipelines may result in incomplete data"
+                        },
+                        "group_id_prefix": {
+                            "type": "string",
+                            "title": "group id prefix",
+                            "description": "Optional prefix for the Group ID for the consumer for the Kafka source."
                         }
                     },
                     "required": [


### PR DESCRIPTION
Adds the ability to configure a group id prefix for kafka via the web ui or `source.group_id_prefix`. This is useful when the group id needs to conform to a particular naming schema, but you don't want to use the same group id for all pipelines that share a source.