### PR TITLE
Fix regression in raw_json schema conversion

### DIFF
--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -156,7 +156,7 @@ pub fn primitive_to_sql(primitive_type: PrimitiveType) -> &'static str {
         | PrimitiveType::UnixMicros
         | PrimitiveType::UnixNanos
         | PrimitiveType::DateTime => "TIMESTAMP",
-        PrimitiveType::Json => "JSONB",
+        PrimitiveType::Json => "JSON",
     }
 }
 

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -629,7 +629,10 @@ pub struct RawJson {
 }
 
 pub fn raw_schema() -> Schema {
-    Schema::new(vec![Field::new("value", DataType::Utf8, false)])
+    Schema::new(vec![ArroyoExtensionType::add_metadata(
+        Some(ArroyoExtensionType::JSON),
+        Field::new("value", DataType::Utf8, false),
+    )])
 }
 
 pub static MESSAGES_RECV: &str = "arroyo_worker_messages_recv";


### PR DESCRIPTION
Now that JSON is stored as a `DataType::UTF8` with an extension type of JSON, we need to take into account the extension type when doing the conversion between arroyo source types and arrow types.