### PR TITLE
Run apt-get update before trying to install clang

### DIFF
--- a/crates/arroyo-compiler-service/src/lib.rs
+++ b/crates/arroyo-compiler-service/src/lib.rs
@@ -168,6 +168,35 @@ impl CompileService {
         }
     }
 
+    async fn run_command(action: &str, command: &mut Command) -> anyhow::Result<()> {
+        let output = timeout(
+            Duration::from_secs(2 * 60),
+            command
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .output(),
+        )
+        .await
+        .map_err(|e| anyhow!("Timed out while {action} for UDF compilation after {e}"))?
+        .map_err(|e| anyhow!("Failed while {action} via apt-get: {e}"))?;
+
+        if !output.status.success() {
+            error!(
+                "Failed to install clang, will not be able to compile UDFs\
+            \n------------------------------\
+            \napt-get stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            bail!(
+                "UDFs are unavailable because a C compiler is not installed and was not able to \
+            be installed. See controller logs for details."
+            );
+        }
+
+        Ok(())
+    }
+
     async fn check_cc(&self) -> anyhow::Result<()> {
         if binary_present("cc").await {
             return Ok(());
@@ -183,35 +212,17 @@ impl CompileService {
         info!(
             "cc is not available, but required for UDF compilation. Attempting to install clang."
         );
-        let output = timeout(
-            Duration::from_secs(2 * 60),
+
+        Self::run_command("updating apt", Command::new("apt-get").arg("update")).await?;
+
+        Self::run_command(
+            "installing clang",
             Command::new("apt-get")
                 .arg("-y")
                 .arg("install")
-                .arg("clang")
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit())
-                .output(),
+                .arg("clang"),
         )
-        .await
-        .map_err(|e| anyhow!("Timed out while installing clang for UDF compilation after {e}"))?
-        .map_err(|e| anyhow!("Failed to install clang via apt-get: {e}"))?;
-
-        if output.status.success() {
-            info!("clang successfully installed...");
-        } else {
-            error!(
-                "Failed to install clang, will not be able to compile UDFs\
-            \n------------------------------\
-            \napt-get stderr: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-
-            bail!(
-                "UDFs are unavailable because a C compiler is not installed and was not able to \
-            be installed. See controller logs for details."
-            );
-        }
+        .await?;
 
         Ok(())
     }


### PR DESCRIPTION
Addresses compilation environment setup issues with old Docker images whose apt archives have become out of date