### PR TITLE
state machine not started error

### DIFF
--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -729,7 +729,7 @@ impl StateMachine {
         if let Some(tx) = &self.tx {
             tx.send(msg).await.map_err(|_| "State machine is inactive")
         } else {
-            Err("State machine is inactive")
+            Err("State machine not started")
         }
     }
 


### PR DESCRIPTION
print "not started" error when calling send on none sender