### PR TITLE
Suppress NATS heartbeat error

### DIFF
--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -422,7 +422,15 @@ impl NatsSourceFunc {
                                     }
                                 },
                                 Some(Err(msg)) => {
-                                    return Err(UserError::new("NATS message error", msg.to_string()));
+                                    match msg.kind() {
+                                        consumer::pull::MessagesErrorKind::MissingHeartbeat => {
+                                            // https://github.com/nats-io/nats.rs/discussions/1102#discussioncomment-9298901
+                                            info!("NATS error: {}", msg.to_string());
+                                        },
+                                        _ => {
+                                            return Err(UserError::new("NATS error", msg.to_string()));
+                                        }
+                                    }
                                 },
                                 None => {
                                     break

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -285,11 +285,11 @@ impl NatsSourceFunc {
             &consumer_info.created
         );
         info!(
-            "Consumer - last stream sequence of aknowledged messagee: {}",
+            "Consumer - last stream sequence of acknowledged messagee: {}",
             &consumer_info.ack_floor.stream_sequence
         );
         info!(
-            "Consumer - last consumer sequence of aknowledged message: {}",
+            "Consumer - last consumer sequence of acknowledged message: {}",
             &consumer_info.ack_floor.consumer_sequence
         );
         info!(


### PR DESCRIPTION
The `MissingHeartbeat` often indicates a temporary hiccup in networking/processing, and should not be treated as a breaking error by the worker/controller.

![image](https://github.com/ArroyoSystems/arroyo/assets/62495124/41349113-0bb5-4b34-8211-475372ff69d1)
