### PR TITLE
Add object store cache for GCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "bytes",
  "futures",
  "object_store",
+ "once_cell",
  "regex",
  "rusoto_core",
  "thiserror",

--- a/crates/arroyo-storage/Cargo.toml
+++ b/crates/arroyo-storage/Cargo.toml
@@ -23,3 +23,4 @@ tokio-util = {version = "0.7.9", features = ["io"]}
 async-trait = "0.1.73"
 futures = "0.3.28"
 webpki = ">=0.22.2"
+once_cell = "1.19.0"

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -16,8 +16,13 @@ use object_store::multipart::PartId;
 use object_store::path::Path;
 use object_store::{aws::AmazonS3Builder, local::LocalFileSystem, ObjectStore};
 use object_store::{CredentialProvider, MultipartId};
+use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
+use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::{debug, trace};
+
 mod aws;
 
 /// A reference-counted reference to a [StorageProvider].
@@ -311,6 +316,18 @@ pub async fn get_current_credentials() -> Result<Arc<AwsCredential>, StorageErro
     Ok(credentials)
 }
 
+static OBJECT_STORE_CACHE: Lazy<RwLock<HashMap<String, CacheEntry<Arc<dyn ObjectStore>>>>> =
+    Lazy::new(Default::default);
+
+struct CacheEntry<T> {
+    value: T,
+    inserted_at: Instant,
+}
+
+// The bearer token should last for 3600 seconds,
+// but regenerating it every 5 minutes to avoid token expiry
+const GCS_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+
 impl StorageProvider {
     pub async fn for_url(url: &str) -> Result<Self, StorageError> {
         Self::for_url_with_options(url, HashMap::new()).await
@@ -441,6 +458,45 @@ impl StorageProvider {
         })
     }
 
+    async fn get_or_create_object_store(
+        builder: GoogleCloudStorageBuilder,
+        bucket: &str,
+    ) -> Result<Arc<dyn ObjectStore>, StorageError> {
+        let mut cache = OBJECT_STORE_CACHE.write().await;
+
+        if let Some(entry) = cache.get(bucket) {
+            if entry.inserted_at.elapsed() < GCS_CACHE_TTL {
+                trace!(
+                    "Cache hit - using cached object store for bucket {}",
+                    bucket
+                );
+                return Ok(entry.value.clone());
+            } else {
+                debug!(
+                    "Cache expired - constructing new object store for bucket {}",
+                    bucket
+                );
+            }
+        } else {
+            debug!(
+                "Cache miss - constructing new object store for bucket {}",
+                bucket
+            );
+        }
+
+        let new_store = Arc::new(builder.build().map_err(Into::<StorageError>::into)?);
+
+        cache.insert(
+            bucket.to_string(),
+            CacheEntry {
+                value: new_store.clone(),
+                inserted_at: Instant::now(),
+            },
+        );
+
+        Ok(new_store)
+    }
+
     async fn construct_gcs(config: GCSConfig) -> Result<Self, StorageError> {
         let mut builder = GoogleCloudStorageBuilder::from_env().with_bucket_name(&config.bucket);
 
@@ -456,9 +512,11 @@ impl StorageProvider {
 
         let object_store_base_url = format!("https://{}.storage.googleapis.com", config.bucket);
 
+        let object_store = Self::get_or_create_object_store(builder, &config.bucket).await?;
+
         Ok(Self {
             config: BackendConfig::GCS(config),
-            object_store: Arc::new(builder.build().map_err(Into::<StorageError>::into)?),
+            object_store,
             object_store_base_url,
             canonical_url,
             storage_options: HashMap::new(),

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -323,7 +323,7 @@ impl StorageProvider {
 
         match config {
             BackendConfig::S3(config) => Self::construct_s3(config, options).await,
-            BackendConfig::GCS(config) => Self::construct_gcs(config),
+            BackendConfig::GCS(config) => Self::construct_gcs(config).await,
             BackendConfig::Local(config) => Self::construct_local(config).await,
         }
     }
@@ -340,7 +340,7 @@ impl StorageProvider {
 
         let provider = match config {
             BackendConfig::S3(config) => Self::construct_s3(config, options).await,
-            BackendConfig::GCS(config) => Self::construct_gcs(config),
+            BackendConfig::GCS(config) => Self::construct_gcs(config).await,
             BackendConfig::Local(config) => Self::construct_local(config).await,
         }?;
 
@@ -441,7 +441,7 @@ impl StorageProvider {
         })
     }
 
-    fn construct_gcs(config: GCSConfig) -> Result<Self, StorageError> {
+    async fn construct_gcs(config: GCSConfig) -> Result<Self, StorageError> {
         let gcs = GoogleCloudStorageBuilder::from_env()
             .with_bucket_name(&config.bucket)
             .build()?;


### PR DESCRIPTION
Resolves https://github.com/ArroyoSystems/arroyo/issues/621

This PR:
1. Changes the `construct_gcs` function to async, which should hopefully improve performance
2. Adds a cache so to prevent redundant DNS lookups
3. Adds an alternative way to create the GCS builder via a GOOGLE_SERVICE_ACCOUNT_KEY

Currently, every checkpoint instantiates a ObjectStore leading to a large number of calls to the metadata server. This can lead to a high number of concurrent DNS lookups, which may cause network latency and other undesirable effects. While the GCE metadata service endpoint has no [official rate limit](https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/Rate-limits-on-metadata-server-access-token-requests/m-p/440525#M1001), we should avoid making unnecessary calls to it.

Took reference from Polars on this: https://github.com/pola-rs/polars/issues/14384#issuecomment-1948991697, https://github.com/pola-rs/polars/blob/main/crates/polars-io/src/cloud/object_store_setup.rs#L4

Note: the AWS metadata endpoint has a rate limit of 1024 packets per second, so it might be worth implementing this for the `construct_s3` function as well at some point. 