### PR TITLE
Add a new config system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
     runs-on: ubicloud-standard-16
     env:
       DATABASE_URL: "postgres://arroyo:arroyo@localhost:5432/arroyo"
-      DATABASE_USER: arroyo
-      DATABASE_PASSWORD: arroyo
-      DATABASE_HOST: localhost
-      DATABASE_NAME: arroyo
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -98,12 +94,12 @@ jobs:
       - name: Integ postgres
         run: |
           mkdir /tmp/arroyo-integ
-          DISABLE_TELEMETRY=true CHECKPOINT_URL=file:///tmp/arroyo-integ ARTIFACT_URL=file:///tmp/artifacts target/debug/arroyo-bin cluster &
+          ARROYO__DISABLE_TELEMETRY=true ARROYO__CHECKPOINT_URL=file:///tmp/arroyo-integ ARROYO__COMPILER__ARTIFACT_URL=file:///tmp/artifacts target/debug/arroyo-bin cluster &
           cargo nextest run --package integ -E 'kind(test)'
       - name: Integ sqlite
         run: |
           killall arroyo-bin
-          DISABLE_TELEMETRY=true CHECKPOINT_URL=file:///tmp/arroyo-integ ARTIFACT_URL=file:///tmp/artifacts DATABASE=sqlite target/debug/arroyo-bin cluster &
+          ARROYO__DISABLE_TELEMETRY=true ARROYO__CHECKPOINT_URL=file:///tmp/arroyo-integ ARROYO__COMPILER__ARTIFACT_URL=file:///tmp/artifacts ARROYO__DATABASE__TYPE=sqlite target/debug/arroyo-bin cluster &
           timeout=10; while ! nc -z localhost 8000 && [ $timeout -gt 0 ]; do sleep 1; timeout=$((timeout - 1)); done; [ $timeout -gt 0 ]
           cargo nextest run --package integ -E 'kind(test)'
           

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
  "tonic-reflection",
  "tonic-web",
  "tower",
- "tower-http",
+ "tower-http 0.4.4",
  "tracing",
  "typify 0.0.13",
  "utoipa 3.5.0",
@@ -507,6 +507,7 @@ dependencies = [
  "arroyo-connectors",
  "arroyo-controller",
  "arroyo-node",
+ "arroyo-rpc",
  "arroyo-server-common",
  "arroyo-types",
  "arroyo-worker",
@@ -588,14 +589,14 @@ dependencies = [
  "regress 0.7.1",
  "reqwest",
  "rumqttc",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-tungstenite",
  "tonic",
@@ -852,6 +853,9 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
+ "dirs",
+ "figment",
+ "k8s-openapi",
  "log",
  "nanoid",
  "prost",
@@ -865,6 +869,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "url",
  "utoipa 4.2.3",
 ]
 
@@ -873,6 +878,7 @@ name = "arroyo-server-common"
 version = "0.11.0-dev"
 dependencies = [
  "anyhow",
+ "arroyo-rpc",
  "arroyo-types",
  "axum",
  "bytes",
@@ -885,9 +891,10 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "toml",
  "tonic",
  "tower",
- "tower-http",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-appender",
  "tracing-log",
@@ -1126,6 +1133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
+dependencies = [
+ "event-listener 5.3.0",
+ "event-listener-strategy 0.5.2",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,10 +1319,10 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring 0.17.8",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -1312,7 +1331,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -1457,6 +1476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1964,11 +1992,11 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.0",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -2210,12 +2238,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -2882,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -2960,8 +2982,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+dependencies = [
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -2979,14 +3011,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+dependencies = [
+ "darling_core 0.20.9",
+ "quote",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3567,7 +3624,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3883,8 +3940,8 @@ checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
 dependencies = [
  "futures",
  "hyper 0.14.28",
- "hyper-rustls",
- "hyper-timeout",
+ "hyper-rustls 0.24.2",
+ "hyper-timeout 0.4.1",
  "log",
  "pin-project",
  "rand 0.8.5",
@@ -3949,6 +4006,24 @@ name = "fiat-crypto"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot 0.12.2",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -4708,6 +4783,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,24 +4940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
-dependencies = [
- "http 0.2.12",
- "hyper 0.14.28",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot 0.12.2",
- "tokio",
- "tokio-openssl",
- "tower-layer",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4883,10 +4949,29 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "log",
+ "rustls 0.23.8",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -4899,6 +4984,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -5015,6 +5113,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -5168,14 +5272,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "jsonpath-rust"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
 dependencies = [
- "log",
- "serde",
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -5230,26 +5338,22 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
+checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
 dependencies = [
- "base64 0.21.7",
- "bytes",
+ "base64 0.22.1",
  "chrono",
- "http 0.2.12",
- "percent-encoding",
  "serde",
  "serde-value",
  "serde_json",
- "url",
 ]
 
 [[package]]
 name = "kube"
-version = "0.84.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bd236a6f6ddeac3fefa2863eb4e363cb3a2c49d66619e181b5b8f8f0787575"
+checksum = "264461a7ebf4fb0fcf23e4c7e4f9387c5696ee61d003de207d9b5a895ff37bfa"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -5260,27 +5364,29 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.84.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a28620131ca89b2509e52f5e1b71bfa3e61a50321836b2ae373bc18e0309e6"
+checksum = "47164ad6c47398ee4bdf90509c7b44026229721cb1377eb4623a1ec2a00a85e9"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-openssl",
- "hyper-timeout",
- "jsonpath_lib",
+ "home",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
- "pin-project",
+ "rustls 0.23.8",
+ "rustls-pemfile 2.1.2",
  "secrecy",
  "serde",
  "serde_json",
@@ -5289,22 +5395,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.84.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8227a989f1eeee3bcbf045165d6aca462af3744ecd4dfdcfba81051fb7de428e"
+checksum = "2797d3044a238825432129cd9537e12c2a6dacbbb5352381af5ea55e1505ed4f"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.12",
+ "http 1.1.0",
  "json-patch",
  "k8s-openapi",
- "once_cell",
  "schemars",
  "serde",
  "serde_json",
@@ -5313,28 +5418,31 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.84.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d227fcf3e12f53ea1a38d4766a8c29f8b27795579e4146464effb88d52dd99"
+checksum = "fcf837edaa0c478f85e9a3cddb17fa80d58a57c1afa722b3a9e55753ea162f41"
 dependencies = [
- "darling",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.84.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6834a4a1f53a8528d5f346cdd141a77dbda31beb33dab4bf24fa4ecf6c508744"
+checksum = "e463e89a1fb222c65a5469b568803153d1bf13d084a8dd42b659e6cca66edc6e"
 dependencies = [
  "ahash",
+ "async-broadcast",
+ "async-stream",
  "async-trait",
  "backoff",
  "derivative",
  "futures",
+ "hashbrown 0.14.5",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -5527,21 +5635,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -6317,12 +6410,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
-name = "pem"
-version = "1.1.1"
+name = "pear"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
 dependencies = [
- "base64 0.13.1",
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -6348,6 +6465,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "petgraph"
@@ -6675,6 +6837,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -7043,16 +7218,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "ryu",
  "sha1_smol",
  "socket2 0.4.10",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "url",
 ]
@@ -7251,7 +7426,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -7261,8 +7436,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7271,7 +7446,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -7398,12 +7573,12 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "url",
 ]
 
@@ -7625,8 +7800,23 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79adb16721f56eb2d843e67676896a61ce7a0fa622dc18d3e372477a029d2740"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -7637,6 +7827,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -7673,6 +7876,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -7966,9 +8180,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -8377,9 +8591,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supports-color"
@@ -8695,18 +8909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
-dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8749,7 +8951,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.8",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -8796,22 +9009,22 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.12",
+ "toml_edit 0.22.13",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -8829,9 +9042,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -8855,7 +9068,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
@@ -8907,7 +9120,7 @@ dependencies = [
  "pin-project",
  "tokio-stream",
  "tonic",
- "tower-http",
+ "tower-http 0.4.4",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8954,6 +9167,25 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9199,6 +9431,21 @@ dependencies = [
  "serde_tokenstream",
  "syn 2.0.61",
  "typify-impl 0.0.16",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -9835,6 +10082,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "z85"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "apache-avro",
+ "arc-swap",
  "arrow",
  "arrow-array",
  "arrow-ord",
@@ -9272,6 +9273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9281,12 +9292,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/arroyo-api/build.rs
+++ b/crates/arroyo-api/build.rs
@@ -1,4 +1,3 @@
-use arroyo_types::DatabaseConfig;
 use cornucopia::{CodegenSettings, Error};
 use postgres::{Client, NoTls};
 
@@ -16,15 +15,16 @@ fn main() -> Result<(), Error> {
     println!("cargo:rerun-if-changed=migrations");
     println!("cargo:rerun-if-changed=sqlite_migrations");
 
-    let config = DatabaseConfig::load();
     let mut client = Client::configure()
-        .dbname(&config.name)
-        .host(&config.host)
-        .port(config.port)
-        .user(&config.user)
-        .password(&config.password)
+        .dbname("arroyo")
+        .host("localhost")
+        .port(5432)
+        .user("arroyo")
+        .password("arroyo")
         .connect(NoTls)
-        .unwrap_or_else(|_| panic!("Could not connect to postgres: {:?}", config));
+        .unwrap_or_else(|_| {
+            panic!("Could not connect to postgres: arroyo:arroyo@localhost:5432/arroyo")
+        });
 
     let mut sqlite =
         rusqlite::Connection::open_in_memory().expect("Couldn't open sqlite memory connection");

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -8,7 +8,6 @@ use http::StatusCode;
 
 use petgraph::{Direction, EdgeDirection};
 use std::collections::HashMap;
-use std::env;
 
 use petgraph::visit::NodeRef;
 use std::time::Duration;
@@ -51,6 +50,7 @@ use crate::types::public::{PipelineType, RestartMode, StopMode};
 use crate::udfs::build_udf;
 use crate::AuthData;
 use crate::{connection_tables, to_micros};
+use arroyo_rpc::config::config;
 use cornucopia_async::{Database, DatabaseSource};
 
 const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(10);
@@ -301,7 +301,7 @@ pub(crate) async fn create_pipeline_int<'a>(
 
     set_parallelism(&mut compiled.program, 1);
 
-    if is_preview && !env::var("PREVIEW_SINKS").is_ok_and(|s| s == "true") {
+    if is_preview && !config().sinks_in_preview {
         for node in compiled.program.graph.node_weights_mut() {
             // replace all sink connectors with websink for preview
             if node.operator_name == OperatorName::ConnectorSink {

--- a/crates/arroyo-api/src/udfs.rs
+++ b/crates/arroyo-api/src/udfs.rs
@@ -8,10 +8,10 @@ use crate::rest_utils::{
 use crate::{compiler_service, to_micros};
 use arroyo_rpc::api_types::udfs::{GlobalUdf, UdfPost, UdfValidationResult, ValidateUdfPost};
 use arroyo_rpc::api_types::GlobalUdfCollection;
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::compiler_grpc_client::CompilerGrpcClient;
 use arroyo_rpc::grpc::{BuildUdfReq, UdfCrate};
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
-use arroyo_types::{bool_config, USE_LOCAL_UDF_LIB_ENV};
 use arroyo_udf_host::ParsedUdfFile;
 use axum::extract::{Path, State};
 use axum::Json;
@@ -189,7 +189,7 @@ pub async fn build_udf(
     };
 
     let mut dependencies = file.dependencies;
-    let plugin_dep = if bool_config(USE_LOCAL_UDF_LIB_ENV, false) {
+    let plugin_dep = if config().compiler.use_local_udf_crate {
         toml::Value::Table(
             [(
                 "path".to_string(),

--- a/crates/arroyo-bin/Cargo.toml
+++ b/crates/arroyo-bin/Cargo.toml
@@ -15,6 +15,7 @@ arroyo-worker = { path = "../arroyo-worker" }
 arroyo-server-common = { path = "../arroyo-server-common" }
 arroyo-compiler-service = { path = "../arroyo-compiler-service" }
 arroyo-node = { path = "../arroyo-node" }
+arroyo-rpc = { path = "../arroyo-rpc" }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/arroyo-bin/src/main.rs
+++ b/crates/arroyo-bin/src/main.rs
@@ -119,7 +119,7 @@ async fn pg_pool() -> Pool {
     cfg.host = Some(config.host.clone());
     cfg.port = Some(config.port);
     cfg.user = Some(config.user.clone());
-    cfg.password = Some(config.password.clone());
+    cfg.password = Some((*config.password).clone());
     cfg.manager = Some(ManagerConfig {
         recycling_method: RecyclingMethod::Fast,
     });
@@ -242,7 +242,7 @@ async fn connect(
             .host(&config.host)
             .port(config.port)
             .user(&config.user)
-            .password(&config.password)
+            .password(&*config.password)
             .dbname(&config.database_name)
             .connect(NoTls)
             .await

--- a/crates/arroyo-compiler-service/src/lib.rs
+++ b/crates/arroyo-compiler-service/src/lib.rs
@@ -103,6 +103,7 @@ impl CompileService {
         let dependencies: Table = VarStr::new(udf_crate.dependencies)
             .sub_env_vars()
             .and_then(|deps| {
+                
                 toml::from_str(&deps).map_err(|e| anyhow!("Invalid dependency in RPC: {:?}", e))
             })?;
 

--- a/crates/arroyo-compiler-service/src/lib.rs
+++ b/crates/arroyo-compiler-service/src/lib.rs
@@ -103,7 +103,6 @@ impl CompileService {
         let dependencies: Table = VarStr::new(udf_crate.dependencies)
             .sub_env_vars()
             .and_then(|deps| {
-                
                 toml::from_str(&deps).map_err(|e| anyhow!("Invalid dependency in RPC: {:?}", e))
             })?;
 

--- a/crates/arroyo-connectors/src/nexmark/operator.rs
+++ b/crates/arroyo-connectors/src/nexmark/operator.rs
@@ -2,12 +2,13 @@ use crate::nexmark::{auction_fields, bid_fields, person_fields, NexmarkTable};
 use arrow::array::{
     Int64Builder, RecordBatch, StringBuilder, StructBuilder, TimestampNanosecondBuilder,
 };
+use arroyo_formats::should_flush;
 use arroyo_operator::context::ArrowContext;
 use arroyo_operator::operator::SourceOperator;
 use arroyo_operator::SourceFinishType;
 use arroyo_rpc::grpc::{StopMode, TableConfig};
 use arroyo_rpc::ControlMessage;
-use arroyo_types::{should_flush, to_millis, to_nanos};
+use arroyo_types::{to_millis, to_nanos};
 use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use rand::{

--- a/crates/arroyo-connectors/src/preview/operator.rs
+++ b/crates/arroyo-connectors/src/preview/operator.rs
@@ -4,9 +4,10 @@ use std::time::SystemTime;
 
 use arroyo_operator::context::ArrowContext;
 use arroyo_operator::operator::ArrowOperator;
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::controller_grpc_client::ControllerGrpcClient;
 use arroyo_rpc::grpc::SinkDataReq;
-use arroyo_types::{default_controller_addr, from_nanos, to_micros, SignalMessage};
+use arroyo_types::{from_nanos, to_micros, SignalMessage};
 use tonic::transport::Channel;
 
 #[derive(Default)]
@@ -21,11 +22,8 @@ impl ArrowOperator for PreviewSink {
     }
 
     async fn on_start(&mut self, _: &mut ArrowContext) {
-        let controller_addr = std::env::var(arroyo_types::CONTROLLER_ADDR_ENV)
-            .unwrap_or_else(|_| default_controller_addr());
-
         self.client = Some(
-            ControllerGrpcClient::connect(controller_addr)
+            ControllerGrpcClient::connect(config().controller_endpoint())
                 .await
                 .unwrap(),
         );

--- a/crates/arroyo-controller/Cargo.toml
+++ b/crates/arroyo-controller/Cargo.toml
@@ -41,8 +41,8 @@ serde = "1"
 anyhow = "1.0.70"
 
 # Kubernetes
-kube = { version = "0.84", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.18.0", features = ["v1_26"] }
+kube = { version = "0.91", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 serde_yaml = {version = "0.9"}
 
 # json-schema support

--- a/crates/arroyo-controller/build.rs
+++ b/crates/arroyo-controller/build.rs
@@ -1,4 +1,3 @@
-use arroyo_types::DatabaseConfig;
 use cornucopia::{CodegenSettings, Error};
 use postgres::{Client, NoTls};
 
@@ -16,15 +15,16 @@ fn main() -> Result<(), Error> {
     println!("cargo:rerun-if-changed=../arroyo-api/migrations");
     println!("cargo:rerun-if-changed=../arroyo-api/sqlite_migrations");
 
-    let config = DatabaseConfig::load();
     let mut client = Client::configure()
-        .dbname(&config.name)
-        .host(&config.host)
-        .port(config.port)
-        .user(&config.user)
-        .password(&config.password)
+        .dbname("arroyo")
+        .host("localhost")
+        .port(5432)
+        .user("arroyo")
+        .password("arroyo")
         .connect(NoTls)
-        .unwrap_or_else(|_| panic!("Could not connect to postgres: {:?}", config));
+        .unwrap_or_else(|_| {
+            panic!("Could not connect to postgres: arroyo:arroyo@localhost:5432/arroyo")
+        });
 
     let mut sqlite =
         rusqlite::Connection::open_in_memory().expect("Couldn't open sqlite memory connection");

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{
     collections::HashMap,
-    env,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -20,6 +19,7 @@ use time::OffsetDateTime;
 
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_rpc::api_types::metrics::MetricName;
+use arroyo_rpc::config::config;
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_state::checkpoint_state::CheckpointState;
 use arroyo_state::parquet::ParquetBackend;
@@ -369,12 +369,7 @@ impl RunningJobModel {
     }
 
     async fn compact_state(&mut self) -> anyhow::Result<()> {
-        let compaction_enabled = match env::var("COMPACTION_ENABLED") {
-            Ok(val) => val.to_lowercase() == "true",
-            Err(_) => false,
-        };
-
-        if !compaction_enabled {
+        if !config().controller.compaction.enabled {
             info!("Compaction is disabled, skipping compaction");
             return Ok(());
         }

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::type_complexity)]
 
 use anyhow::Result;
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::controller_grpc_server::{ControllerGrpc, ControllerGrpcServer};
 use arroyo_rpc::grpc::{
     GrpcOutputSubscription, HeartbeatNodeReq, HeartbeatNodeResp, HeartbeatReq, HeartbeatResp,
@@ -18,7 +19,7 @@ use arroyo_rpc::grpc::{
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_server_common::wrap_start;
-use arroyo_types::{from_micros, grpc_port, ports, NodeId, WorkerId};
+use arroyo_types::{from_micros, NodeId, WorkerId};
 use cornucopia_async::DatabaseSource;
 use lazy_static::lazy_static;
 use prometheus::{register_gauge, Gauge};
@@ -603,12 +604,10 @@ impl ControllerServer {
             .build()
             .unwrap();
 
-        let addr: SocketAddr = format!(
-            "0.0.0.0:{}",
-            grpc_port("controller", ports::CONTROLLER_GRPC)
-        )
-        .parse()
-        .expect("Invalid port");
+        let addr = SocketAddr::new(
+            config().controller.bind_address,
+            config().controller.rpc_port,
+        );
 
         info!("Starting arroyo-controller on {}", addr);
 

--- a/crates/arroyo-controller/src/schedulers/embedded.rs
+++ b/crates/arroyo-controller/src/schedulers/embedded.rs
@@ -1,7 +1,8 @@
 use crate::schedulers::{Scheduler, SchedulerError, StartPipelineReq};
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::{HeartbeatNodeReq, RegisterNodeReq, WorkerFinishedReq};
 use arroyo_server_common::shutdown::Shutdown;
-use arroyo_types::{default_controller_addr, WorkerId};
+use arroyo_types::WorkerId;
 use arroyo_worker::WorkerServer;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -58,7 +59,7 @@ impl Scheduler for EmbeddedScheduler {
                 worker_id,
                 (*req.job_id).clone(),
                 req.run_id.to_string(),
-                default_controller_addr(),
+                config().controller_endpoint(),
                 req.program,
                 guard,
             );

--- a/crates/arroyo-controller/src/schedulers/kubernetes.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes.rs
@@ -126,13 +126,6 @@ impl KubernetesScheduler {
                                 ],
                                 "env": env,
                                 "volumeMounts": c.worker.volume_mounts,
-                                "envFrom": c.worker.config_map.as_ref().map(|name| {
-                                  json!([
-                                    {"configMapRef": {
-                                         "name": name
-                                    }}
-                                  ])
-                                }).unwrap_or_else(|| json!([]))
                             }
                         ],
                         "serviceAccountName": c.worker.service_account_name,

--- a/crates/arroyo-controller/src/schedulers/kubernetes.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes.rs
@@ -1,25 +1,16 @@
 use crate::schedulers::{Scheduler, SchedulerError, StartPipelineReq};
 use anyhow::bail;
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::{api, HeartbeatNodeReq, RegisterNodeReq, WorkerFinishedReq};
-use arroyo_types::{
-    string_config, u32_config, WorkerId, ADMIN_PORT_ENV, ARROYO_PROGRAM_ENV, CONTROLLER_ADDR_ENV,
-    GRPC_PORT_ENV, JOB_ID_ENV, K8S_NAMESPACE_ENV, K8S_WORKER_ANNOTATIONS_ENV,
-    K8S_WORKER_CONFIG_MAP_ENV, K8S_WORKER_IMAGE_ENV, K8S_WORKER_IMAGE_PULL_POLICY_ENV,
-    K8S_WORKER_LABELS_ENV, K8S_WORKER_NAME_ENV, K8S_WORKER_RESOURCES_ENV,
-    K8S_WORKER_SERVICE_ACCOUNT_NAME_ENV, K8S_WORKER_SLOTS_ENV, K8S_WORKER_VOLUMES_ENV,
-    K8S_WORKER_VOLUME_MOUNTS_ENV, NODE_ID_ENV, RUN_ID_ENV, TASK_SLOTS_ENV,
-};
+use arroyo_types::{WorkerId, ARROYO_PROGRAM_ENV, JOB_ID_ENV, RUN_ID_ENV};
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use k8s_openapi::api::apps::v1::ReplicaSet;
-use k8s_openapi::api::core::v1::{Pod, ResourceRequirements, Volume, VolumeMount};
+use k8s_openapi::api::core::v1::Pod;
 use kube::api::{DeleteParams, ListParams};
 use kube::{Api, Client};
 use prost::Message;
-use serde::de::DeserializeOwned;
-use serde_json::{json, Value};
-use std::collections::BTreeMap;
-use std::env;
+use serde_json::json;
 use std::time::Duration;
 use tonic::Status;
 
@@ -30,27 +21,6 @@ const JOB_NAME_LABEL: &str = "job_name";
 
 pub struct KubernetesScheduler {
     client: Option<Client>,
-    namespace: String,
-    name: String,
-    labels: BTreeMap<String, String>,
-    annotations: BTreeMap<String, String>,
-    image: String,
-    image_pull_policy: String,
-    service_account_name: String,
-    resources: ResourceRequirements,
-    slots_per_pod: u32,
-    volumes: Vec<Volume>,
-    volume_mounts: Vec<VolumeMount>,
-    config_map: Option<String>,
-}
-
-fn yaml_config<T: DeserializeOwned>(var: &str, default: T) -> T {
-    env::var(var)
-        .map(|s| {
-            serde_yaml::from_str(&s)
-                .unwrap_or_else(|e| panic!("Invalid configuration for '{}': {:?}", var, e))
-        })
-        .unwrap_or(default)
 }
 
 impl KubernetesScheduler {
@@ -59,72 +29,25 @@ impl KubernetesScheduler {
     }
 
     pub fn new(client: Option<Client>) -> Self {
-        Self {
-            client,
-            namespace: string_config(K8S_NAMESPACE_ENV, "default"),
-            name: format!("{}-worker", string_config(K8S_WORKER_NAME_ENV, "arroyo")),
-            image: string_config(K8S_WORKER_IMAGE_ENV, "ghcr.io/arroyosystems/arroyo:latest"),
-            labels: yaml_config(K8S_WORKER_LABELS_ENV, BTreeMap::new()),
-            annotations: yaml_config(K8S_WORKER_ANNOTATIONS_ENV, BTreeMap::new()),
-            image_pull_policy: string_config(K8S_WORKER_IMAGE_PULL_POLICY_ENV, "IfNotPresent"),
-            service_account_name: string_config(K8S_WORKER_SERVICE_ACCOUNT_NAME_ENV, "default"),
-            resources: yaml_config(
-                K8S_WORKER_RESOURCES_ENV,
-                ResourceRequirements {
-                    claims: None,
-                    limits: None,
-                    requests: Some(
-                        [
-                            ("cpu".to_string(), serde_json::from_str("\"400m\"").unwrap()),
-                            (
-                                "memory".to_string(),
-                                serde_json::from_str("\"200Mi\"").unwrap(),
-                            ),
-                        ]
-                        .into(),
-                    ),
-                },
-            ),
-            slots_per_pod: u32_config(K8S_WORKER_SLOTS_ENV, 4),
-            volumes: yaml_config(K8S_WORKER_VOLUMES_ENV, vec![]),
-            volume_mounts: yaml_config(K8S_WORKER_VOLUME_MOUNTS_ENV, vec![]),
-            config_map: env::var(K8S_WORKER_CONFIG_MAP_ENV).ok(),
-        }
+        Self { client }
     }
 
     fn make_replicaset(&self, req: StartPipelineReq) -> ReplicaSet {
-        let replicas = (req.slots as f32 / self.slots_per_pod as f32).ceil() as usize;
+        let c = &config().kubernetes_scheduler;
+        let replicas = (req.slots as f32 / c.worker.task_slots as f32).ceil() as usize;
 
-        let mut labels = json!({
-            CLUSTER_LABEL: self.name,
-            JOB_ID_LABEL: req.job_id,
-            RUN_ID_LABEL: format!("{}", req.run_id),
-            JOB_NAME_LABEL: req.name,
-        });
-        for (k, v) in &self.labels {
-            labels
-                .as_object_mut()
-                .unwrap()
-                .insert(k.clone(), Value::String(v.clone()));
-        }
-
-        let mut annotations = json!({});
-        for (k, v) in &self.annotations {
-            annotations
-                .as_object_mut()
-                .unwrap()
-                .insert(k.clone(), Value::String(v.clone()));
-        }
+        let mut labels = c.worker.labels.clone();
+        labels.insert(CLUSTER_LABEL.to_string(), c.worker.name());
+        labels.insert(JOB_ID_LABEL.to_string(), (*req.job_id).clone());
+        labels.insert(RUN_ID_ENV.to_string(), format!("{}", req.run_id));
+        labels.insert(JOB_NAME_LABEL.to_string(), req.name.clone());
 
         let mut env = json!([
             {
                 "name": "PROD", "value": "true",
             },
             {
-                "name": TASK_SLOTS_ENV, "value": format!("{}", self.slots_per_pod),
-            },
-            {
-                "name": NODE_ID_ENV, "value": "1",
+                "name": "ARROYO_WORKER_TASK_SLOTS", "value": format!("{}", c.worker.task_slots),
             },
             {
                 "name": JOB_ID_ENV, "value": req.job_id,
@@ -133,10 +56,10 @@ impl KubernetesScheduler {
                 "name": RUN_ID_ENV, "value": format!("{}", req.run_id),
             },
             {
-                "name": GRPC_PORT_ENV, "value": "6900",
+                "name": "ARROYO_WORKER_RPC_PORT", "value": "6900",
             },
             {
-                "name": ADMIN_PORT_ENV, "value": "6901",
+                "name": "ARROYO_ADMIN_HTTP_PORT", "value": "6901",
             },
             {
                 "name": ARROYO_PROGRAM_ENV,
@@ -147,14 +70,11 @@ impl KubernetesScheduler {
                 "name": "WASM_BIN",
                 "value": req.wasm_path
             },
+            {
+                "name": "ARROYO_CONTROLLER_ENDPOINT",
+                "value": config().controller_endpoint(),
+            }
         ]);
-
-        if let Ok(addr) = std::env::var(CONTROLLER_ADDR_ENV) {
-            env.as_array_mut().unwrap().push(json!({
-                "name": CONTROLLER_ADDR_ENV,
-                "value": addr,
-            }));
-        }
 
         for (key, value) in req.env_vars.into_iter() {
             env.as_array_mut().unwrap().push(json!({
@@ -167,10 +87,10 @@ impl KubernetesScheduler {
             "apiVersion": "apps/v1",
             "kind": "ReplicaSet",
             "metadata": {
-                "name": format!("{}-{}-{}", self.name, req.job_id.to_ascii_lowercase().replace('_', "-"), req.run_id),
-                "namespace": self.namespace,
+                "name": format!("{}-{}-{}", c.worker.name(), req.job_id.to_ascii_lowercase().replace('_', "-"), req.run_id),
+                "namespace": c.namespace,
                 "labels": labels,
-                "annotations": annotations,
+                "annotations": c.worker.annotations,
             },
             "spec": {
                 "replicas": replicas,
@@ -183,17 +103,17 @@ impl KubernetesScheduler {
                 "template": {
                     "metadata": {
                         "labels": labels,
-                        "annotations": annotations,
+                        "annotations": c.worker.annotations,
                     },
                     "spec": {
-                        "volumes": self.volumes,
+                        "volumes": c.worker.volumes,
                         "containers": [
                             {
                                 "name": "worker",
-                                "image": self.image,
+                                "image": c.worker.image,
                                 "command": ["/app/arroyo-bin", "worker"],
-                                "imagePullPolicy": self.image_pull_policy,
-                                "resources": self.resources,
+                                "imagePullPolicy": c.worker.image_pull_policy,
+                                "resources": c.worker.resources,
                                 "ports": [
                                     {
                                         "containerPort": 6900,
@@ -205,8 +125,8 @@ impl KubernetesScheduler {
                                     }
                                 ],
                                 "env": env,
-                                "volumeMounts": self.volume_mounts,
-                                "envFrom": self.config_map.as_ref().map(|name| {
+                                "volumeMounts": c.worker.volume_mounts,
+                                "envFrom": c.worker.config_map.as_ref().map(|name| {
                                   json!([
                                     {"configMapRef": {
                                          "name": name
@@ -215,7 +135,7 @@ impl KubernetesScheduler {
                                 }).unwrap_or_else(|| json!([]))
                             }
                         ],
-                        "serviceAccountName": self.service_account_name,
+                        "serviceAccountName": c.worker.service_account_name,
                     }
                 }
             }

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -175,9 +175,9 @@ impl Scheduler for ProcessScheduler {
                 let mut child = command
                     .arg("worker")
                     .env("RUST_LOG", "info")
-                    .env("ARROYO_ADMIN_HTTP_PORT", "0")
-                    .env("ARROYO_WORKER_TASK_SLOTS", format!("{}", slots_here))
-                    .env("ARROYO_WORKER_ID", format!("{}", worker_id)) // start at 100 to make same length
+                    .env("ARROYO__ADMIN__HTTP_PORT", "0")
+                    .env("ARROYO__WORKER__TASK_SLOTS", format!("{}", slots_here))
+                    .env("ARROYO__WORKER__ID", format!("{}", worker_id)) // start at 100 to make same length
                     .env(JOB_ID_ENV, &*job_id)
                     .env(RUN_ID_ENV, format!("{}", start_pipeline_req.run_id))
                     .env(ARROYO_PROGRAM_FILE_ENV, program_file)

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -21,6 +21,7 @@ use crate::queries::controller_queries;
 use crate::types::public::StopMode;
 use crate::{schedulers::Scheduler, JobConfig, JobMessage, JobStatus};
 use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::config::config;
 use arroyo_server_common::shutdown::ShutdownGuard;
 use prost::Message;
 
@@ -447,7 +448,7 @@ async fn execute_state<'a>(
                     "job_id": ctx.config.id,
                     "from": state_name,
                     "to": s.state.name(),
-                    "scheduler": std::env::var("SCHEDULER").unwrap_or_else(|_| "process".to_string()),
+                    "scheduler": &config().controller.scheduler,
                     "duration_ms": ctx.last_transitioned_at.elapsed().as_millis() as u64,
                 }),
             );

--- a/crates/arroyo-controller/src/states/running.rs
+++ b/crates/arroyo-controller/src/states/running.rs
@@ -12,6 +12,7 @@ use crate::states::restarting::Restarting;
 use crate::states::{fatal, stop_if_desired_running};
 use crate::JobMessage;
 use crate::{job_controller::ControllerProgress, states::StateError};
+use arroyo_rpc::config::config;
 use arroyo_server_common::log_event;
 use serde_json::json;
 
@@ -138,7 +139,7 @@ impl State for Running {
                         json!({
                             "service": "controller",
                             "job_id": ctx.config.id,
-                            "scheduler": std::env::var("SCHEDULER").unwrap_or_else(|_| "process".to_string()),
+                            "scheduler": &config().controller.scheduler,
                             "duration_ms": ctx.last_transitioned_at.elapsed().as_millis() as u64,
                         }),
                     );

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -12,9 +12,9 @@ use tracing::{error, info, warn};
 
 use anyhow::anyhow;
 use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::config::config;
 use arroyo_state::{
     committing_state::CommittingState,
-    parquet::get_storage_env_vars,
     tables::{global_keyed_map::GlobalKeyedTable, ErasedTable},
     BackingStore, StateBackend,
 };
@@ -178,7 +178,12 @@ impl Scheduling {
                     name: ctx.config.pipeline_name.clone(),
                     hash: ctx.program.get_hash(),
                     slots: slots_needed,
-                    env_vars: get_storage_env_vars(),
+                    env_vars: [(
+                        "ARROYO_CHECKPOINT_URL".to_string(),
+                        config().checkpoint_url.clone(),
+                    )]
+                    .into_iter()
+                    .collect(),
                 })
                 .await
             {

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -179,7 +179,7 @@ impl Scheduling {
                     hash: ctx.program.get_hash(),
                     slots: slots_needed,
                     env_vars: [(
-                        "ARROYO_CHECKPOINT_URL".to_string(),
+                        "ARROYO__CHECKPOINT_URL".to_string(),
                         config().checkpoint_url.clone(),
                     )]
                     .into_iter()

--- a/crates/arroyo-df/src/extension/updating_aggregate.rs
+++ b/crates/arroyo-df/src/extension/updating_aggregate.rs
@@ -1,17 +1,17 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalNode, OperatorName};
 use arroyo_rpc::{df::ArroyoSchema, grpc::api::UpdatingAggregateOperator, TIMESTAMP_FIELD};
-use arroyo_types::UPDATE_AGGREGATE_FLUSH_MS_ENV;
-use datafusion::common::{plan_err, DFSchemaRef, OwnedTableReference};
+use datafusion::common::{DFSchemaRef, OwnedTableReference};
 use datafusion::logical_expr::{Extension, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion_proto::protobuf::{physical_plan_node::PhysicalPlanType, PhysicalPlanNode};
 
 use crate::builder::{NamedNode, SplitPlanOutput};
 
 use super::{ArroyoExtension, IsRetractExtension, NodeWithIncomingEdges};
+use arroyo_rpc::config::config;
 use prost::Message;
 
 pub(crate) const UPDATING_AGGREGATE_EXTENSION_NAME: &str = "UpdatingAggregateExtension";
@@ -144,21 +144,6 @@ impl ArroyoExtension for UpdatingAggregateExtension {
             physical_plan_type: Some(PhysicalPlanType::Aggregate(Box::new(combine_aggregate))),
         };
 
-        let flush_interval = std::env::var(UPDATE_AGGREGATE_FLUSH_MS_ENV)
-            .ok()
-            .map(|s| {
-                let Ok(millis): Result<u64, _> = s.parse() else {
-                    return plan_err!(
-                        "Failed to parse {} to a number for {}",
-                        s,
-                        UPDATE_AGGREGATE_FLUSH_MS_ENV
-                    );
-                };
-                Ok(Duration::from_millis(millis))
-            })
-            .transpose()?
-            .unwrap_or_else(|| Duration::from_secs(1));
-
         let config = UpdatingAggregateOperator {
             name: "UpdatingAggregate".to_string(),
             partial_schema: Some(partial_schema.try_into()?),
@@ -167,7 +152,10 @@ impl ArroyoExtension for UpdatingAggregateExtension {
             partial_aggregation_plan: partial_aggregation_plan.encode_to_vec(),
             combine_plan: combine_plan.encode_to_vec(),
             final_aggregation_plan: finish_plan.encode_to_vec(),
-            flush_interval_micros: flush_interval.as_micros() as u64,
+            flush_interval_micros: config()
+                .pipeline
+                .update_aggregate_flush_interval
+                .as_micros() as u64,
         };
         let node = LogicalNode {
             operator_id: format!("updating_aggregate_{}", index),

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -1,4 +1,5 @@
 use crate::avro::de;
+use crate::should_flush;
 use arrow::compute::kernels;
 use arrow_array::builder::{
     ArrayBuilder, GenericByteBuilder, StringBuilder, TimestampNanosecondBuilder,
@@ -8,7 +9,7 @@ use arrow_array::RecordBatch;
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::formats::{AvroFormat, BadData, Format, Framing, FramingMethod, JsonFormat};
 use arroyo_rpc::schema_resolver::{FailingSchemaResolver, FixedSchemaResolver, SchemaResolver};
-use arroyo_types::{should_flush, to_nanos, SourceError};
+use arroyo_types::{to_nanos, SourceError};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};

--- a/crates/arroyo-formats/src/lib.rs
+++ b/crates/arroyo-formats/src/lib.rs
@@ -1,9 +1,17 @@
 extern crate core;
 
+use arroyo_rpc::config::config;
 use serde_json::json;
+use std::time::Instant;
 
 pub mod avro;
 pub mod json;
 
 pub mod de;
 pub mod ser;
+
+pub fn should_flush(size: usize, time: Instant) -> bool {
+    size > 0
+        && (size >= config().pipeline.source_batch_size
+            || time.elapsed() >= *config().pipeline.source_batch_linger)
+}

--- a/crates/arroyo-node/src/lib.rs
+++ b/crates/arroyo-node/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail};
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::{
     controller_grpc_client::ControllerGrpcClient, node_grpc_server::NodeGrpc,
     node_grpc_server::NodeGrpcServer, GetWorkersReq, GetWorkersResp, HeartbeatNodeReq,
@@ -18,9 +19,7 @@ use arroyo_rpc::grpc::{
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_server_common::wrap_start;
 use arroyo_types::{
-    default_controller_addr, grpc_port, ports, to_millis, to_nanos, NodeId, WorkerId,
-    ARROYO_PROGRAM_FILE_ENV, CONTROLLER_ADDR_ENV, JOB_ID_ENV, NODE_ID_ENV, RUN_ID_ENV,
-    TASK_SLOTS_ENV, WORKER_ID_ENV,
+    to_millis, to_nanos, NodeId, WorkerId, ARROYO_PROGRAM_FILE_ENV, JOB_ID_ENV, RUN_ID_ENV,
 };
 use base64::engine::general_purpose;
 use base64::Engine;
@@ -117,10 +116,9 @@ impl NodeServer {
         let mut child = command
             .arg("worker")
             .env("RUST_LOG", "info")
-            .env(WORKER_ID_ENV, format!("{}", worker_id.0))
-            .env(NODE_ID_ENV, format!("{}", node_id.0))
+            .env("ARROYO_WORKER_ID", format!("{}", worker_id.0))
             .env(JOB_ID_ENV, req.job_id.clone())
-            .env(TASK_SLOTS_ENV, format!("{}", slots))
+            .env("ARROYO_WORKER_TASK_SLOTS", format!("{}", slots))
             .env(RUN_ID_ENV, format!("{}", req.run_id))
             .env(ARROYO_PROGRAM_FILE_ENV, program_file.to_str().unwrap())
             .kill_on_drop(true)
@@ -256,14 +254,7 @@ impl NodeGrpc for NodeServer {
 }
 
 pub async fn start_server(guard: ShutdownGuard) -> NodeId {
-    let controller_addr =
-        std::env::var(CONTROLLER_ADDR_ENV).unwrap_or_else(|_| default_controller_addr());
-
-    let task_slots = std::env::var("NODE_SLOTS")
-        .map(|s| usize::from_str(&s).unwrap())
-        .unwrap_or(16);
-
-    let grpc = grpc_port("node", ports::NODE_GRPC);
+    let config = config();
 
     let node_id = NodeId(random());
 
@@ -275,10 +266,10 @@ pub async fn start_server(guard: ShutdownGuard) -> NodeId {
         worker_finished_tx,
     };
 
-    let bind_addr: SocketAddr = format!("0.0.0.0:{}", grpc).parse().unwrap();
+    let bind_addr: SocketAddr = SocketAddr::new(config.node.bind_address, config.node.rpc_port);
     info!(
         "Starting node server on {} with {} slots",
-        bind_addr, task_slots
+        bind_addr, config.node.task_slots
     );
 
     guard.spawn_task(
@@ -293,7 +284,11 @@ pub async fn start_server(guard: ShutdownGuard) -> NodeId {
         ),
     );
 
-    let req_addr = format!("{}:{}", local_ip_address::local_ip().unwrap(), grpc);
+    let req_addr = format!(
+        "{}:{}",
+        local_ip_address::local_ip().unwrap(),
+        config.node.rpc_port
+    );
 
     // TODO: replace this with some sort of hook on server startup
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -307,12 +302,12 @@ pub async fn start_server(guard: ShutdownGuard) -> NodeId {
     guard.into_spawn_task(async move {
         let mut attempts = 0;
         loop {
-            match ControllerGrpcClient::connect(controller_addr.clone()).await {
+            match ControllerGrpcClient::connect(config.controller_endpoint()).await {
                 Ok(mut controller) => {
                     controller
                         .register_node(Request::new(RegisterNodeReq {
                             node_id: node_id.0,
-                            task_slots: task_slots as u64,
+                            task_slots: config.node.task_slots as u64,
                             addr: req_addr.clone(),
                         }))
                         .await
@@ -346,7 +341,7 @@ pub async fn start_server(guard: ShutdownGuard) -> NodeId {
                     if attempts % 50 == 0 {
                         info!(
                             "failed to connect to controller on {}..., {:?}",
-                            controller_addr, e
+                            config.controller_endpoint(), e
                         );
                     }
 

--- a/crates/arroyo-node/src/lib.rs
+++ b/crates/arroyo-node/src/lib.rs
@@ -116,9 +116,9 @@ impl NodeServer {
         let mut child = command
             .arg("worker")
             .env("RUST_LOG", "info")
-            .env("ARROYO_WORKER_ID", format!("{}", worker_id.0))
+            .env("ARROYO__WORKER__ID", format!("{}", worker_id.0))
             .env(JOB_ID_ENV, req.job_id.clone())
-            .env("ARROYO_WORKER_TASK_SLOTS", format!("{}", slots))
+            .env("ARROYO__WORKER__TASK_SLOTS", format!("{}", slots))
             .env(RUN_ID_ENV, format!("{}", req.run_id))
             .env(ARROYO_PROGRAM_FILE_ENV, program_file.to_str().unwrap())
             .kill_on_drop(true)

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -3,6 +3,7 @@ use arrow::array::{make_builder, Array, ArrayBuilder, PrimitiveArray, RecordBatc
 use arrow::compute::{partition, sort_to_indices, take};
 use arrow::datatypes::{SchemaRef, UInt64Type};
 use arroyo_formats::de::ArrowDeserializer;
+use arroyo_formats::should_flush;
 use arroyo_metrics::{register_queue_gauge, QueueGauges, TaskCounters};
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::formats::{BadData, Format, Framing};
@@ -12,8 +13,7 @@ use arroyo_rpc::{get_hasher, CompactionResult, ControlMessage, ControlResp};
 use arroyo_state::tables::table_manager::TableManager;
 use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::{
-    from_micros, should_flush, ArrowMessage, CheckpointBarrier, SourceError, TaskInfo, UserError,
-    Watermark,
+    from_micros, ArrowMessage, CheckpointBarrier, SourceError, TaskInfo, UserError, Watermark,
 };
 use datafusion::common::hash_utils;
 use rand::Rng;

--- a/crates/arroyo-rpc/Cargo.toml
+++ b/crates/arroyo-rpc/Cargo.toml
@@ -31,6 +31,13 @@ base64 = "0.21.5"
 ahash = "0.8.7"
 strum_macros = "0.26.2"
 strum = "0.26.2"
+figment = { version = "0.10", features = ["toml", "env", "yaml", "json"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
+url = { version = "2", features = ["serde"] }
+dirs = "5.0.1"
 
 [build-dependencies]
 tonic-build = { workspace = true }
+
+[dev-dependencies]
+figment = {version = "0.10", features = ["test"]}

--- a/crates/arroyo-rpc/Cargo.toml
+++ b/crates/arroyo-rpc/Cargo.toml
@@ -35,6 +35,7 @@ figment = { version = "0.10", features = ["toml", "env", "yaml", "json"] }
 k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 url = { version = "2", features = ["serde"] }
 dirs = "5.0.1"
+arc-swap = "1.7.1"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -1,0 +1,67 @@
+checkpoint-url = "/tmp/arroyo/checkpoints"
+
+# Services
+
+[api]
+bind-address = "0.0.0.0"
+http-port = 8000
+
+[controller]
+bind-address = "0.0.0.0"
+rpc-port = 9190
+scheduler = "process"
+
+[compiler]
+bind-address = "0.0.0.0"
+rpc-port = 9191
+install-clang = true
+install-rustc = true
+artifact-url = "/tmp/arroyo/artifacts"
+build-dir = "/tmp/arroyo/build-dir"
+
+[worker]
+bind-address = "0.0.0.0"
+rpc-port = 0
+data-port = 0
+task-slots = 16
+queue-size = 8192
+
+[node]
+bind-address = "0.0.0.0"
+rpc-port = 9192
+task-slots = 16
+
+[admin]
+bind-address = "0.0.0.0"
+http-port = 8001
+
+[pipeline]
+source-batch-size = 512
+source-batch-linger = "100ms"
+update-aggregate-flush-interval = "1s"
+
+# Schedulers
+
+[process-scheduler]
+slots-per-process = 16
+
+[kubernetes-scheduler]
+namespace = "default"
+
+[kubernetes-scheduler.worker]
+name-prefix = "arroyo"
+image = "ghcr.io/arroyosystems/arroyo:latest"
+image-pull-policy = "IfNotPresent"
+service-account-name = "default"
+resources = { requests = { cpu = "400m",  memory = "200Mi" } }
+task-slots = 4
+
+[database]
+type = "postgres"
+
+[database.postgres]
+database-name = "arroyo"
+host = "localhost"
+port = 5432
+user = "arroyo"
+password = "arroyo"

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -11,6 +11,11 @@ bind-address = "0.0.0.0"
 rpc-port = 9190
 scheduler = "process"
 
+[controller.compaction]
+enabled = false
+checkpoints-to-compact = 4
+
+
 [compiler]
 bind-address = "0.0.0.0"
 rpc-port = 9191
@@ -65,3 +70,5 @@ host = "localhost"
 port = 5432
 user = "arroyo"
 password = "arroyo"
+
+[logging]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -1,0 +1,471 @@
+use figment::providers::{Env, Format, Json, Toml, Yaml};
+use figment::Figment;
+use k8s_openapi::api::core::v1::{EnvVar, ResourceRequirements, Volume, VolumeMount};
+use regex::Regex;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fmt::{Debug, Formatter};
+use std::net::IpAddr;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+use std::str::FromStr;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use url::Url;
+
+const DEFAULT_CONFIG: &str = include_str!("../default.toml");
+
+static CONFIG: OnceLock<Arc<Config>> = OnceLock::new();
+
+pub fn initialize_config(path: Option<&Path>) {
+    if let Some(path) = path {
+        if !path.exists() {
+            eprintln!(
+                "Cannot load configuration from {}; file does not exist",
+                path.to_string_lossy()
+            );
+            exit(1);
+        }
+    }
+
+    CONFIG
+        .set(match load_config(path).extract() {
+            Ok(config) => Arc::new(config),
+            Err(errors) => {
+                eprintln!("Configuration is invalid!");
+                for err in errors {
+                    eprintln!("  • {err}");
+                }
+
+                exit(1);
+            }
+        })
+        .expect("Unable to initialize global config!");
+}
+
+pub fn config() -> &'static Arc<Config> {
+    CONFIG
+        .get()
+        .expect("Configuration was accessed before initialization!")
+}
+
+fn load_config(path: Option<&Path>) -> Figment {
+    // Priority (from highest to lowest) is:
+    //   1. ARROYO_* environment variables
+    //   2. The config file specified in <path>
+    //   3. arroyo.toml in the current directory
+    //   4. $(confdir)/arroyo/config.toml
+    //   5. ../default.toml
+    let mut figment = Figment::from(Toml::string(DEFAULT_CONFIG));
+
+    if let Some(config_dir) = dirs::config_dir() {
+        figment = figment.merge(Toml::file(config_dir.join("arroyo/config.toml")));
+    }
+
+    figment = figment.merge(Toml::file("arroyo.toml"));
+
+    if let Some(path) = path {
+        match path.extension().and_then(OsStr::to_str) {
+            Some("yaml") => {
+                figment = figment.merge(Yaml::file(path));
+            }
+            Some("json") => {
+                figment = figment.merge(Json::file(path));
+            }
+            _ => {
+                figment = figment.merge(Toml::file(path));
+            }
+        }
+    };
+
+    figment.merge(Env::prefixed("ARROYO_").split("_"))
+}
+
+/// Arroyo configuration
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    /// API service configuration
+    pub api: ApiConfig,
+
+    /// Controller service configuration
+    pub controller: ControllerConfig,
+
+    /// Compiler service configuration
+    pub compiler: CompilerConfig,
+
+    /// Node service configuration
+    pub node: NodeConfig,
+
+    /// Worker configuration
+    pub worker: WorkerConfig,
+
+    /// Admin service configuration
+    pub admin: AdminConfig,
+
+    /// Default pipeline configuration
+    pub pipeline: PipelineConfig,
+
+    /// Database configuration
+    pub database: DatabaseConfig,
+
+    /// Process scheduler configuration
+    pub process_scheduler: ProcessSchedulerConfig,
+
+    // Kubernetes scheduler configuration
+    pub kubernetes_scheduler: KubernetesSchedulerConfig,
+
+    /// URL of an object store or filesystem for storing checkpoints
+    pub checkpoint_url: String,
+
+    /// The endpoint of the controller, used by other services to connect to it. This must be set
+    /// if running the controller on a separate machine from the other services or on a separate
+    /// process with a non-standard port.
+    controller_endpoint: Option<Url>,
+
+    // The endpoint of the API service, used by the Web UI
+    pub api_endpoint: Option<Url>,
+
+    /// The endpoint of the compiler, used by the API server to connect to it. This must be set
+    /// if running the compiler on a separate machine from the other services or on a separate
+    /// process with a non-standard port.
+    compiler_endpoint: Option<Url>,
+
+    /// Telemetry config
+    #[serde(default)]
+    pub disable_telemetry: bool,
+}
+
+impl Config {
+    pub fn controller_endpoint(&self) -> String {
+        self.controller_endpoint
+            .as_ref()
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| format!("http://localhost:{}", self.controller.rpc_port))
+    }
+
+    pub fn compiler_endpoint(&self) -> String {
+        self.compiler_endpoint
+            .as_ref()
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| format!("http://localhost:{}", self.compiler.rpc_port))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ApiConfig {
+    /// The host the API service should bind to
+    pub bind_address: IpAddr,
+
+    /// The HTTP port for the API service
+    pub http_port: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ControllerConfig {
+    /// The host the controller should bind to
+    pub bind_address: IpAddr,
+
+    /// The RPC port for the controller
+    pub rpc_port: u16,
+
+    /// The scheduler to use
+    pub scheduler: Scheduler,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CompilerConfig {
+    /// Bind address for the compiler
+    pub bind_address: IpAddr,
+
+    /// RPC port for the compiler
+    pub rpc_port: u16,
+
+    /// Whether the compiler should attempt to install clang if it's not already installed
+    pub install_clang: bool,
+
+    /// Whether the compiler should attempt to install rustc if it's not already installed
+    pub install_rustc: bool,
+
+    /// Where to store compilation artifacts
+    pub artifact_url: String,
+
+    /// Directory to build artifacts in
+    pub build_dir: String,
+
+    /// Whether to use a local version of the UDF library or the published crate (only
+    /// enable in development environments)
+    #[serde(default)]
+    pub use_local_udf_crate: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct WorkerConfig {
+    /// Bind address for the worker RPC socket
+    pub bind_address: IpAddr,
+
+    /// RPC port for the worker to listen on; set to 0 to use a random available port
+    pub rpc_port: u16,
+
+    /// Data port for the worker to listen on; set to 0 to use a random available port
+    pub data_port: u16,
+
+    /// Number of task slots for this worker
+    pub task_slots: u32,
+
+    /// ID for this worker
+    pub id: Option<u64>,
+
+    /// Name to identify this worker (e.g., e.g., its hostname or a pod name)
+    pub name: String,
+
+    /// Size of the queues between nodes in the dataflow graph
+    pub queue_size: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct NodeConfig {
+    /// Bind address for the node service
+    pub bind_address: IpAddr,
+
+    /// RPC port for the node service
+    pub rpc_port: u16,
+
+    /// Number of task slots for this node
+    pub task_slots: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct AdminConfig {
+    /// Bind address for the admin service
+    pub bind_address: IpAddr,
+
+    /// HTTP port the admin service will listen on
+    pub http_port: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PipelineConfig {
+    /// Batch size
+    pub source_batch_size: usize,
+
+    /// Batch linger time (how long to wait before flushing)
+    pub source_batch_linger: HumanReadableDuration,
+
+    // How often to flush aggregates
+    pub update_aggregate_flush_interval: HumanReadableDuration,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DatabaseType {
+    Postgres,
+    Sqlite,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DatabaseConfig {
+    pub r#type: DatabaseType,
+    pub postgres: PostgresConfig,
+    #[serde(default)]
+    pub sqlite: SqliteConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PostgresConfig {
+    pub database_name: String,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SqliteConfig {
+    pub path: PathBuf,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            path: dirs::config_dir()
+                .map(|p| p.join("arroyo/config.sqlite"))
+                .unwrap_or_else(|| PathBuf::from_str("config.sqlite").unwrap()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Scheduler {
+    Embedded,
+    Process,
+    Node,
+    Kubernetes,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ProcessSchedulerConfig {
+    pub slots_per_process: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KubernetesSchedulerConfig {
+    pub namespace: String,
+    pub worker: KubernetesWorkerConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KubernetesWorkerConfig {
+    name_prefix: String,
+
+    name: Option<String>,
+
+    pub image: String,
+
+    pub image_pull_policy: String,
+
+    pub service_account_name: String,
+
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+
+    #[serde(default)]
+    pub annotations: BTreeMap<String, String>,
+
+    #[serde(default)]
+    pub env: Vec<EnvVar>,
+
+    pub resources: ResourceRequirements,
+
+    pub task_slots: u32,
+
+    #[serde(default)]
+    pub volumes: Vec<Volume>,
+
+    #[serde(default)]
+    pub volume_mounts: Vec<VolumeMount>,
+
+    pub config_map: Option<String>,
+}
+
+impl KubernetesWorkerConfig {
+    pub fn name(&self) -> String {
+        self.name
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| format!("{}-worker", self.name_prefix))
+    }
+}
+
+pub struct HumanReadableDuration {
+    duration: Duration,
+    original: String,
+}
+
+impl Deref for HumanReadableDuration {
+    type Target = Duration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.duration
+    }
+}
+
+impl Debug for HumanReadableDuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.original.fmt(f)
+    }
+}
+
+impl Serialize for HumanReadableDuration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.original)
+    }
+}
+
+impl<'de> Deserialize<'de> for HumanReadableDuration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let str = String::deserialize(deserializer)?;
+
+        let r = Regex::new(r"^(\d+)\s*([a-zA-Zµ]+)$").unwrap();
+        let captures = r.captures(&str).ok_or_else(|| {
+            de::Error::custom(format!("invalid duration specification '{}'", str))
+        })?;
+        let mut capture = captures.iter();
+
+        capture.next();
+
+        let n: u64 = capture.next().unwrap().unwrap().as_str().parse().unwrap();
+        let unit = capture.next().unwrap().unwrap().as_str();
+
+        let duration = match unit {
+            "ns" | "nanos" => Duration::from_nanos(n),
+            "µs" | "micros" => Duration::from_micros(n),
+            "ms" | "millis" => Duration::from_millis(n),
+            "s" | "secs" | "seconds" => Duration::from_secs(n),
+            "m" | "mins" | "minutes" => Duration::from_secs(n * 60),
+            "h" | "hrs" | "hours" => Duration::from_secs(n * 60 * 60),
+            x => return Err(de::Error::custom(format!("unknown time unit '{}'", x))),
+        };
+
+        Ok(HumanReadableDuration {
+            duration,
+            original: str,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{load_config, Config, DatabaseType, SqliteConfig};
+
+    #[test]
+    fn test_config() {
+        figment::Jail::expect_with(|jail| {
+            // test default loading
+            let _config: Config = load_config(None).extract().unwrap();
+
+            // try overriding database by config file
+            jail.create_file(
+                "arroyo.toml",
+                r#"
+            [database]
+            type = "sqlite"
+            "#,
+            )
+            .unwrap();
+
+            let config: Config = load_config(None).extract().unwrap();
+            assert_eq!(config.database.sqlite.path, SqliteConfig::default().path);
+            assert_eq!(config.database.r#type, DatabaseType::Sqlite);
+
+            // try overriding with environment variables
+            jail.set_env("ARROYO_ADMIN_HTTP-PORT", 9111);
+            let config: Config = load_config(None).extract().unwrap();
+            assert_eq!(config.admin.http_port, 9111);
+
+            Ok(())
+        });
+    }
+}

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -24,6 +24,7 @@ use tonic::{
     service::Interceptor,
 };
 
+pub mod config;
 pub mod df;
 
 pub mod grpc {

--- a/crates/arroyo-server-common/Cargo.toml
+++ b/crates/arroyo-server-common/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 arroyo-types = { path = "../arroyo-types" }
+arroyo-rpc = { path = "../arroyo-rpc" }
 
 # logging
 tracing = "0.1"
@@ -29,6 +30,7 @@ serde_json = "1.0.96"
 tokio-util = "0.7.10"
 anyhow = "1.0.82"
 bytes = "1.6.0"
+toml = "0.8.13"
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/crates/arroyo-server-common/Cargo.toml
+++ b/crates/arroyo-server-common/Cargo.toml
@@ -10,7 +10,7 @@ arroyo-rpc = { path = "../arroyo-rpc" }
 # logging
 tracing = "0.1"
 tracing-logfmt = "0.2.0"
-tracing-subscriber = {version = "0.3", features = [ "env-filter" ]}
+tracing-subscriber = {version = "0.3", features = [ "env-filter", "json" ]}
 tracing-appender = "0.2"
 tracing-log = "0.2"
 

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -255,7 +255,10 @@ async fn run_and_checkpoint(job_id: Arc<String>, program: Program, checkpoint_in
         })
         .await;
     info!("Smoke test checkpointing enabled");
-    env::set_var("MIN_FILES_TO_COMPACT", "2");
+    env::set_var(
+        "ARROYO__CONTROLLER__COMPACTION__CHECKPOINTS_TO_COMPACT",
+        "2",
+    );
 
     let ctx = &mut SmokeTestContext {
         job_id: job_id.clone(),

--- a/crates/arroyo-state/src/parquet.rs
+++ b/crates/arroyo-state/src/parquet.rs
@@ -6,10 +6,10 @@ use anyhow::{bail, Context, Result};
 use arroyo_rpc::grpc;
 use arroyo_rpc::grpc::{CheckpointMetadata, OperatorCheckpointMetadata, TableCheckpointMetadata};
 use arroyo_storage::StorageProvider;
-use arroyo_types::{CHECKPOINT_URL_ENV, S3_ENDPOINT_ENV, S3_REGION_ENV};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
+use arroyo_rpc::config::config;
 use prost::Message;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -25,15 +25,12 @@ pub const GENERATIONS_TO_COMPACT: u32 = 1; // only compact generation 0 files
 async fn get_storage_provider() -> anyhow::Result<StorageProvider> {
     // TODO: this should be encoded in the config so that the controller doesn't need
     // to be synchronized with the workers
-    let storage_url =
-        env::var(CHECKPOINT_URL_ENV).unwrap_or_else(|_| "file:///tmp/arroyo".to_string());
+    let storage_url = &config().checkpoint_url;
 
-    StorageProvider::for_url(&storage_url)
-        .await
-        .context(format!(
-            "failed to construct checkpoint backend for URL {}",
-            storage_url
-        ))
+    StorageProvider::for_url(storage_url).await.context(format!(
+        "failed to construct checkpoint backend for URL {}",
+        storage_url
+    ))
 }
 
 pub struct ParquetBackend;
@@ -326,11 +323,4 @@ impl ParquetStats {
         self.min_routing_key = self.min_routing_key.min(other.min_routing_key);
         self.max_routing_key = self.max_routing_key.max(other.max_routing_key);
     }
-}
-
-pub fn get_storage_env_vars() -> HashMap<String, String> {
-    [S3_REGION_ENV, S3_ENDPOINT_ENV, CHECKPOINT_URL_ENV]
-        .iter()
-        .filter_map(|&var| env::var(var).ok().map(|v| (var.to_string(), v)))
-        .collect()
 }

--- a/crates/arroyo-state/src/parquet.rs
+++ b/crates/arroyo-state/src/parquet.rs
@@ -12,7 +12,6 @@ use futures::StreamExt;
 use arroyo_rpc::config::config;
 use prost::Message;
 use std::collections::{HashMap, HashSet};
-use std::env;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -171,9 +170,7 @@ impl ParquetBackend {
         operator_id: String,
         epoch: u32,
     ) -> Result<HashMap<String, TableCheckpointMetadata>> {
-        let min_files_to_compact = env::var("MIN_FILES_TO_COMPACT")
-            .unwrap_or_else(|_| "4".to_string())
-            .parse()?;
+        let min_files_to_compact = config().controller.compaction.checkpoints_to_compact as usize;
 
         let operator_checkpoint_metadata =
             Self::load_operator_metadata(&job_id, &operator_id, epoch)

--- a/crates/arroyo-state/src/tables/table_manager.rs
+++ b/crates/arroyo-state/src/tables/table_manager.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use std::{collections::HashMap, env, sync::Arc, time::SystemTime};
+use std::{collections::HashMap, sync::Arc, time::SystemTime};
 
 use anyhow::{anyhow, bail, Context, Result};
 use arroyo_rpc::CompactionResult;
@@ -12,12 +12,13 @@ use arroyo_rpc::{
     CheckpointCompleted, ControlResp,
 };
 use arroyo_storage::{StorageProvider, StorageProviderRef};
-use arroyo_types::{to_micros, CheckpointBarrier, Data, Key, TaskInfoRef, CHECKPOINT_URL_ENV};
+use arroyo_types::{to_micros, CheckpointBarrier, Data, Key, TaskInfoRef};
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     oneshot,
 };
 
+use arroyo_rpc::config::config;
 use tracing::{debug, error, info, warn};
 
 use crate::{tables::global_keyed_map::GlobalKeyedTable, StateMessage};
@@ -227,15 +228,13 @@ impl BackendWriter {
 async fn get_storage_provider() -> anyhow::Result<StorageProviderRef> {
     // TODO: this should be encoded in the config so that the controller doesn't need
     // to be synchronized with the workers
-    let storage_url =
-        env::var(CHECKPOINT_URL_ENV).unwrap_or_else(|_| "file:///tmp/arroyo".to_string());
 
     Ok(Arc::new(
-        StorageProvider::for_url(&storage_url)
+        StorageProvider::for_url(&config().checkpoint_url)
             .await
             .context(format!(
                 "failed to construct checkpoint backend for URL {}",
-                storage_url
+                config().checkpoint_url
             ))?,
     ))
 }

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -6,7 +6,6 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use arroyo_types::{S3_ENDPOINT_ENV, S3_REGION_ENV};
 use aws::ArroyoCredentialProvider;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
@@ -216,13 +215,11 @@ impl BackendConfig {
 
         let region = last([
             std::env::var("AWS_DEFAULT_REGION").ok(),
-            std::env::var(S3_REGION_ENV).ok(),
             matches.name("region").map(|m| m.as_str().to_string()),
         ]);
 
         let endpoint = last([
             std::env::var("AWS_ENDPOINT").ok(),
-            std::env::var(S3_ENDPOINT_ENV).ok(),
             matches
                 .name("endpoint")
                 .map(|endpoint| -> Result<String, StorageError> {

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -8,7 +8,6 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::{Range, RangeInclusive};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -97,14 +96,6 @@ pub struct WorkerId(pub u64);
 
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
 pub struct NodeId(pub u64);
-
-impl NodeId {
-    pub fn from_env() -> Option<NodeId> {
-        std::env::var("NODE_ID")
-            .map(|s| NodeId(u64::from_str(&s).unwrap()))
-            .ok()
-    }
-}
 
 pub fn to_millis(time: SystemTime) -> u64 {
     time.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::ports::CONTROLLER_GRPC;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow_array::RecordBatch;
 use bincode::{Decode, Encode};
@@ -6,13 +5,12 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::env;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::{Range, RangeInclusive};
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Copy, Hash, Debug, Clone, Eq, PartialEq, Encode, Decode, PartialOrd, Ord, Deserialize)]
 pub struct Window {
@@ -76,126 +74,15 @@ impl Serialize for Window {
     }
 }
 
-pub const DEFAULT_LINGER: Duration = Duration::from_millis(100);
-pub const DEFAULT_BATCH_SIZE: usize = 512;
-pub const QUEUE_SIZE_ENV: &str = "QUEUE_SIZE";
-pub const DEFAULT_QUEUE_SIZE: u32 = 8 * 1024;
-pub const TASK_SLOTS_ENV: &str = "TASK_SLOTS";
-pub const CONTROLLER_ADDR_ENV: &str = "CONTROLLER_ADDR";
-pub const API_ADDR_ENV: &str = "API_ADDR";
-pub const NODE_ID_ENV: &str = "NODE_ID_ENV";
-pub const WORKER_ID_ENV: &str = "WORKER_ID_ENV";
-pub const JOB_ID_ENV: &str = "JOB_ID_ENV";
-pub const RUN_ID_ENV: &str = "RUN_ID_ENV";
 pub const ARROYO_PROGRAM_ENV: &str = "ARROYO_PROGRAM";
 pub const ARROYO_PROGRAM_FILE_ENV: &str = "ARROYO_PROGRAM_FILE";
-pub const COMPILER_ADDR_ENV: &str = "COMPILER_ADDR";
-pub const NOMAD_ENDPOINT_ENV: &str = "NOMAD_ENDPOINT";
-pub const NOMAD_DC_ENV: &str = "NOMAD_DC";
 
-pub const DATABASE_ENV: &str = "DATABASE";
-// postgres configs
-pub const DATABASE_NAME_ENV: &str = "DATABASE_NAME";
-pub const DATABASE_HOST_ENV: &str = "DATABASE_HOST";
-pub const DATABASE_PORT_ENV: &str = "DATABASE_PORT";
-pub const DATABASE_USER_ENV: &str = "DATABASE_USER";
-pub const DATABASE_PASSWORD_ENV: &str = "DATABASE_PASSWORD";
-// sqlite configs
-pub const DATABASE_PATH_ENV: &str = "DATABASE_PATH";
-
-pub const ADMIN_PORT_ENV: &str = "ADMIN_PORT";
-pub const GRPC_PORT_ENV: &str = "GRPC_PORT";
-pub const HTTP_PORT_ENV: &str = "HTTP_PORT";
-pub const COMPILER_PORT_ENV: &str = "COMPILER_PORT";
-
-pub const UPDATE_AGGREGATE_FLUSH_MS_ENV: &str = "UPDATE_AGGREGATE_FLUSH_MS";
-pub const BATCH_SIZE_ENV: &str = "BATCH_SIZE";
-pub const BATCH_LINGER_MS_ENV: &str = "BATCH_LINGER_MS";
-pub const USE_LOCAL_UDF_LIB_ENV: &str = "USE_LOCAL_UDF_LIB";
-
-pub const ASSET_DIR_ENV: &str = "ASSET_DIR";
-// Endpoint that the frontend should query for the API
-pub const API_ENDPOINT_ENV: &str = "API_ENDPOINT";
-// The rate parameter (e.g., "15s") used by the API when querying prometheus metrics -- this should
-// be at least 4x the configured scrape interval for your prometheus config
-pub const API_METRICS_RATE_ENV: &str = "API_METRICS_RATE";
-
-// storage configuration
-pub const S3_ENDPOINT_ENV: &str = "S3_ENDPOINT";
-pub const S3_REGION_ENV: &str = "S3_REGION";
-pub const CHECKPOINT_URL_ENV: &str = "CHECKPOINT_URL";
-
-// compiler service
-pub const ARTIFACT_URL_ENV: &str = "ARTIFACT_URL";
-pub const ARTIFACT_URL_DEFAULT: &str = "/tmp/arroyo/artifacts";
-pub const COMPILER_FEATURES_ENV: &str = "COMPILER_FEATURES";
-pub const INSTALL_CLANG_ENV: &str = "INSTALL_CLANG";
-pub const INSTALL_RUSTC_ENV: &str = "INSTALL_RUSTC";
-
-// process scheduler
-pub const SLOTS_PER_NODE: &str = "SLOTS_PER_NODE";
-
-// kubernetes scheduler configuration
-pub const K8S_NAMESPACE_ENV: &str = "K8S_NAMESPACE";
-pub const K8S_WORKER_NAME_ENV: &str = "K8S_WORKER_NAME";
-pub const K8S_WORKER_IMAGE_ENV: &str = "K8S_WORKER_IMAGE";
-pub const K8S_WORKER_IMAGE_PULL_POLICY_ENV: &str = "K8S_WORKER_IMAGE_PULL_POLICY";
-pub const K8S_WORKER_SERVICE_ACCOUNT_NAME_ENV: &str = "K8S_WORKER_SERVICE_ACCOUNT_NAME";
-pub const K8S_WORKER_LABELS_ENV: &str = "K8S_WORKER_LABELS";
-pub const K8S_WORKER_ANNOTATIONS_ENV: &str = "K8S_WORKER_ANNOTATIONS";
-pub const K8S_WORKER_RESOURCES_ENV: &str = "K8S_WORKER_RESOURCES";
-pub const K8S_WORKER_SLOTS_ENV: &str = "K8S_WORKER_SLOTS";
-pub const K8S_WORKER_VOLUMES_ENV: &str = "K8S_WORKER_VOLUMES";
-pub const K8S_WORKER_VOLUME_MOUNTS_ENV: &str = "K8S_WORKER_VOLUME_MOUNTS";
-pub const K8S_WORKER_CONFIG_MAP_ENV: &str = "K8S_WORKER_CONFIG_MAP";
-
-// node
-pub const NODE_SLOTS_ENV: &str = "NODE_SLOTS";
+// worker configuration
+pub const JOB_ID_ENV: &str = "JOB_ID";
+pub const RUN_ID_ENV: &str = "RUN_ID";
 
 // telemetry configuration
-pub const DISABLE_TELEMETRY_ENV: &str = "DISABLE_TELEMETRY";
 pub const POSTHOG_KEY: &str = "phc_ghJo7Aa9QOo4inoWFYZP7o2aKszllEUyH77QeFgznUe";
-pub fn telemetry_enabled() -> bool {
-    match env::var(DISABLE_TELEMETRY_ENV) {
-        Ok(val) => val != "true",
-        Err(_) => true,
-    }
-}
-
-pub fn bool_config(var: &str, default: bool) -> bool {
-    if let Ok(v) = env::var(var) {
-        match v.to_lowercase().as_str() {
-            "true" | "yes" | "1" => {
-                return true;
-            }
-            "false" | "no" | "0" => {
-                return false;
-            }
-            _ => {}
-        }
-    };
-    default
-}
-
-pub fn string_config(var: &str, default: &str) -> String {
-    env::var(var).unwrap_or_else(|_| default.to_string())
-}
-
-pub fn u32_config(var: &str, default: u32) -> u32 {
-    env::var(var)
-        .map(|s| u32::from_str(&s).unwrap_or(default))
-        .unwrap_or(default)
-}
-
-pub fn duration_millis_config(var: &str, default: Duration) -> Duration {
-    env::var(var)
-        .map(|s| {
-            u64::from_str(&s)
-                .map(Duration::from_millis)
-                .unwrap_or(default)
-        })
-        .unwrap_or(default)
-}
 
 // These seeds were randomly generated; changing them will break existing state
 pub const HASH_SEEDS: [u64; 4] = [
@@ -205,92 +92,15 @@ pub const HASH_SEEDS: [u64; 4] = [
     17942305062735447798,
 ];
 
-#[derive(Debug, Clone)]
-pub struct DatabaseConfig {
-    pub name: String,
-    pub host: String,
-    pub port: u16,
-    pub user: String,
-    pub password: String,
-}
-
-impl Display for DatabaseConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}@{}:{}/{}", self.user, self.host, self.port, self.name)
-    }
-}
-
-impl DatabaseConfig {
-    pub fn load() -> Self {
-        DatabaseConfig {
-            name: env::var(DATABASE_NAME_ENV).unwrap_or_else(|_| "arroyo".to_string()),
-            host: env::var(DATABASE_HOST_ENV).unwrap_or_else(|_| "localhost".to_string()),
-            port: u16::from_str(
-                &env::var(DATABASE_PORT_ENV).unwrap_or_else(|_| "5432".to_string()),
-            )
-            .unwrap_or(5432),
-            user: env::var(DATABASE_USER_ENV).unwrap_or_else(|_| "arroyo".to_string()),
-            password: env::var(DATABASE_PASSWORD_ENV).unwrap_or_else(|_| "arroyo".to_string()),
-        }
-    }
-}
-
-// default ports for development; overridden in production to
-pub mod ports {
-    pub const CONTROLLER_GRPC: u16 = 9190;
-    pub const CONTROLLER_ADMIN: u16 = 9191;
-
-    pub const NODE_GRPC: u16 = 9290;
-    pub const NODE_ADMIN: u16 = 9291;
-
-    pub const API_HTTP: u16 = 8000;
-    pub const API_ADMIN: u16 = 8001;
-
-    pub const COMPILER_GRPC: u16 = 9000;
-    pub const COMPILER_ADMIN: u16 = 9001;
-}
-
-pub fn grpc_port(service: &str, default: u16) -> u16 {
-    service_port(service, default, GRPC_PORT_ENV)
-}
-
-pub fn admin_port(service: &str, default: u16) -> u16 {
-    service_port(service, default, ADMIN_PORT_ENV)
-}
-
-pub fn service_port(service: &str, default: u16, env_var: &str) -> u16 {
-    env::var(format!("{}_{}", service.to_uppercase(), env_var))
-        .ok()
-        .or(env::var(env_var).ok())
-        .map(|s| u16::from_str(&s).unwrap_or_else(|_| panic!("Invalid setting for {}", env_var)))
-        .unwrap_or(default)
-}
-
-pub fn default_controller_addr() -> String {
-    format!(
-        "http://localhost:{}",
-        grpc_port("controller", CONTROLLER_GRPC)
-    )
-}
-
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
 pub struct WorkerId(pub u64);
-
-impl WorkerId {
-    pub fn from_env() -> Option<WorkerId> {
-        std::env::var(WORKER_ID_ENV)
-            .map(|s| u64::from_str(&s).unwrap())
-            .ok()
-            .map(WorkerId)
-    }
-}
 
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
 pub struct NodeId(pub u64);
 
 impl NodeId {
     pub fn from_env() -> Option<NodeId> {
-        std::env::var(NODE_ID_ENV)
+        std::env::var("NODE_ID")
             .map(|s| NodeId(u64::from_str(&s).unwrap()))
             .ok()
     }
@@ -780,18 +590,6 @@ pub fn range_for_server(i: usize, n: usize) -> RangeInclusive<u64> {
         start + range_size - 1
     };
     start..=end
-}
-
-pub fn should_flush(size: usize, time: Instant) -> bool {
-    static FLUSH_SIZE: OnceLock<usize> = OnceLock::new();
-    let flush_size =
-        FLUSH_SIZE.get_or_init(|| u32_config(BATCH_SIZE_ENV, DEFAULT_BATCH_SIZE as u32) as usize);
-
-    static FLUSH_LINGER: OnceLock<Duration> = OnceLock::new();
-    let flush_linger =
-        FLUSH_LINGER.get_or_init(|| duration_millis_config(BATCH_LINGER_MS_ENV, DEFAULT_LINGER));
-
-    size > 0 && (size >= *flush_size || time.elapsed() >= *flush_linger)
 }
 
 #[cfg(test)]

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -31,12 +31,11 @@ use arroyo_operator::context::{batch_bounded, ArrowContext, BatchReceiver, Batch
 use arroyo_operator::operator::OperatorNode;
 use arroyo_operator::operator::Registry;
 use arroyo_operator::ErasedConstructor;
+use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::{api, CheckpointMetadata, TaskAssignment};
 use arroyo_rpc::{ControlMessage, ControlResp};
 use arroyo_state::{BackingStore, StateBackend};
-use arroyo_types::{
-    range_for_server, u32_config, Key, TaskInfo, WorkerId, DEFAULT_QUEUE_SIZE, QUEUE_SIZE_ENV,
-};
+use arroyo_types::{range_for_server, Key, TaskInfo, WorkerId};
 use arroyo_udf_host::LocalUdf;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
@@ -253,7 +252,7 @@ impl Program {
             }
         }
 
-        let queue_size = u32_config(QUEUE_SIZE_ENV, DEFAULT_QUEUE_SIZE);
+        let queue_size = config().worker.queue_size;
 
         for idx in logical.edge_indices() {
             let edge = logical.edge_weight(idx).unwrap();

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -235,7 +235,7 @@ impl WorkerServer {
     }
 
     pub async fn start_async(self) -> Result<(), Box<dyn std::error::Error>> {
-        let node_id = NodeId::from_env().unwrap_or(NodeId(0));
+        let node_id = NodeId(config().node.id.unwrap_or(0));
 
         let config = config();
         let listener = TcpListener::bind(SocketAddr::new(

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -15,8 +15,8 @@ use arroyo_rpc::grpc::{
     TaskFinishedReq, TaskStartedReq, WorkerErrorReq, WorkerResources,
 };
 use arroyo_types::{
-    default_controller_addr, from_millis, grpc_port, to_micros, CheckpointBarrier, NodeId,
-    WorkerId, ARROYO_PROGRAM_ENV, ARROYO_PROGRAM_FILE_ENV, JOB_ID_ENV, RUN_ID_ENV,
+    from_millis, to_micros, CheckpointBarrier, NodeId, WorkerId, ARROYO_PROGRAM_ENV,
+    ARROYO_PROGRAM_FILE_ENV, JOB_ID_ENV, RUN_ID_ENV,
 };
 use local_ip_address::local_ip;
 use rand::random;
@@ -27,7 +27,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
-use std::str::FromStr;
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use tokio::net::TcpListener;
@@ -44,6 +44,7 @@ use prost::Message;
 
 use arroyo_datastream::logical::{LogicalGraph, LogicalProgram, ProgramConfig};
 use arroyo_df::physical::new_registry;
+use arroyo_rpc::config::config;
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_server_common::wrap_start;
 
@@ -174,7 +175,7 @@ impl WorkerServer {
         }
     }
 
-    pub fn from_env(shutdown_guard: ShutdownGuard) -> Self {
+    pub fn from_config(shutdown_guard: ShutdownGuard) -> Self {
         let graph = Self::get_program();
         let graph = general_purpose::STANDARD_NO_PAD
             .decode(graph)
@@ -184,22 +185,19 @@ impl WorkerServer {
 
         let logical = LogicalProgram::try_from(graph).expect("Failed to create LogicalProgram");
 
-        let id = WorkerId::from_env().unwrap_or_else(|| WorkerId(random()));
+        let id = WorkerId(config().worker.id.unwrap_or_else(|| random()));
         let job_id =
             std::env::var(JOB_ID_ENV).unwrap_or_else(|_| panic!("{} is not set", JOB_ID_ENV));
 
         let run_id =
             std::env::var(RUN_ID_ENV).unwrap_or_else(|_| panic!("{} is not set", RUN_ID_ENV));
 
-        let controller_addr = std::env::var(arroyo_types::CONTROLLER_ADDR_ENV)
-            .unwrap_or_else(|_| default_controller_addr());
-
         WorkerServer::new(
             "program",
             id,
             job_id,
             run_id,
-            controller_addr,
+            config().controller_endpoint(),
             logical,
             shutdown_guard,
         )
@@ -237,15 +235,14 @@ impl WorkerServer {
     }
 
     pub async fn start_async(self) -> Result<(), Box<dyn std::error::Error>> {
-        let slots = std::env::var(arroyo_types::TASK_SLOTS_ENV)
-            .map(|s| usize::from_str(&s).unwrap())
-            .unwrap_or(8);
+        let node_id = NodeId::from_env().unwrap_or(NodeId(0));
 
-        let node_id = NodeId::from_env();
-
-        let grpc_port = grpc_port("worker", 0);
-
-        let listener = TcpListener::bind(format!("0.0.0.0:{}", grpc_port)).await?;
+        let config = config();
+        let listener = TcpListener::bind(SocketAddr::new(
+            config.worker.bind_address,
+            config.worker.rpc_port,
+        ))
+        .await?;
         let local_addr = listener.local_addr()?;
 
         info!("Started worker-rpc for {} on {}", self.name, local_addr);
@@ -286,14 +283,14 @@ impl WorkerServer {
         client
             .register_worker(Request::new(RegisterWorkerReq {
                 worker_id: id.0,
-                node_id: node_id.map(|n| n.0).unwrap_or(1),
+                node_id: node_id.0,
                 job_id,
                 rpc_address,
                 data_address,
                 resources: Some(WorkerResources {
                     slots: std::thread::available_parallelism().unwrap().get() as u64,
                 }),
-                slots: slots as u64,
+                slots: config.worker.task_slots as u64,
             }))
             .await
             .unwrap();

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETPLATFORM}-${P
     sudo -u postgres psql -c "CREATE USER arroyo WITH PASSWORD 'arroyo' SUPERUSER;" && \
     sudo -u postgres createdb arroyo && \
     refinery migrate -c refinery.toml -p crates/arroyo-api/migrations && \
-    CARGO_PROFILE_RELEASE_DEBUG=false cargo build --profile ${PROFILE} --bin arroyo-bin --all-features && \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_PROFILE_RELEASE_DEBUG=false cargo build --profile ${PROFILE} --bin arroyo-bin --all-features && \
     mv target/release/arroyo-bin /arroyo-bin
 
 FROM debian:bookworm-slim AS arroyo-single

--- a/k8s/arroyo/templates/_helpers.tpl
+++ b/k8s/arroyo/templates/_helpers.tpl
@@ -91,64 +91,10 @@ Create the name of the role to use
 {{- end }}
 {{- end }}
 
-{{/*
-Database environment variables
-*/}}
-{{- define "arroyo.databaseEnvVars" -}}
-{{- if .Values.postgresql.deploy }}
-- name: DATABASE_HOST
-  value: "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.cluster.local"
-- name: DATABASE_PORT
-  value: "{{ default "5432" .Values.postgresql.auth.port }}"
-- name: DATABASE_NAME
-  value: arroyo
-- name: DATABASE_USER
-  value: arroyo
-- name: DATABASE_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "arroyo.fullname" . }}-postgresql
-      key: password
-{{- else -}}
-- name: DATABASE_HOST
-  value: "{{ .Values.postgresql.externalDatabase.host }}"
-- name: DATABASE_PORT
-  value: "{{ .Values.postgresql.externalDatabase.port }}"
-- name: DATABASE_NAME
-  value: "{{ .Values.postgresql.externalDatabase.name }}"
-- name: DATABASE_USER
-  value: "{{ .Values.postgresql.externalDatabase.user }}"
-- name: DATABASE_PASSWORD
-  value: "{{ .Values.postgresql.externalDatabase.password }}"
-{{- end }}
-{{- end }}
-
-{{/*
-Generic storage env vars
-*/}}
-{{- define "arroyo.storageEnvVars" -}}
-{{- if .Values.s3.region -}}
-- name: S3_REGION
-  value: {{ .Values.s3.region }}
-{{- end -}}
-{{- end -}}
-
 {{- define "tplvalues.render" -}}
     {{- if typeIs "string" .value }}
         {{- tpl .value .context }}
     {{- else }}
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
-{{- end -}}
-
-
-{{/*
-Mount a config map with custom configuration
-*/}}
-{{- define "arroyo.existingConfigMap" -}}
-{{- if .Values.existingConfigMap  -}}
-envFrom:
-- configMapRef:
-    name: {{ .Values.existingConfigMap }}
-{{- end -}}
 {{- end -}}

--- a/k8s/arroyo/templates/configmap.yaml
+++ b/k8s/arroyo/templates/configmap.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "arroyo.fullname" . }}-config
+data:
+  config.yaml: |-
+    checkpoint-url: "{{ required "A valid .Values.checkpointUrl entry required!" .Values.checkpointUrl }}"
+    controller-endpoint: "http://{{ include "arroyo.fullname" . }}:{{ .Values.controller.service.grpcPort }}"
+    
+    controller:
+      rpc-port: {{ .Values.controller.service.grpcPort }}
+      scheduler: "kubernetes"
+
+    admin:
+      http-port: {{ .Values.controller.service.adminPort }}
+
+    api:
+      http-port: {{ .Values.controller.service.httpPort }}
+    
+    compiler:
+      rpc-port: {{ .Values.controller.service.compilerPort }}
+      artifact-url: {{ required "A valid .Values.artifactUrl entry required!" .Values.artifactUrl }}
+
+    database:
+      type: "postgres"
+      postgres:
+    {{- if .Values.postgresql.deploy }}
+        host = "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.cluster.local"
+        port = {{ default "5432" .Values.postgresql.auth.port }}
+        database-name = "arroyo"
+        user = "arroyo"
+    {{- else -}}
+        host = "{{ .Values.postgresql.externalDatabase.host }}"
+        port = {{ .Values.postgresql.externalDatabase.port }}
+        database-name = "{{ .Values.postgresql.externalDatabase.name }}"
+        user = "{{ .Values.postgresql.externalDatabase.user }}"
+        password = "{{ .Values.postgresql.externalDatabase.password }}"
+    {{- end }}
+
+    kubernetes-scheduler:
+      worker:
+        name-prefix: "{{ include "arroyo.fullname" . }}"
+        task-slots: {{ .Values.worker.slots }}
+        labels: {{- include "arroyo.labels" . | nindent 10 }}
+        annotations:
+          {{- if .Values.prometheus.setAnnotations }}
+          prometheus.io/scrape: "true"
+          prometheus.io/path: /metrics
+          prometheus.io/port: "8001"
+          {{- end }}    
+          {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}    
+        image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+        image-pull-policy: "{{ .Values.worker.image.pullPolicy }}"
+        resources: {{ .Values.worker.resources | toYaml | nindent 10 }}
+        service-account-name: {{ .Values.serviceAccount.name | quote }}
+        volumes: {{ .Values.volumes | toYaml | nindent 10 }}
+          - name: arroyo-config
+            configMap:
+              name: {{ include "arroyo.fullname" . }}-config
+          {{ if .Values.existingConfigMap}}
+          - name: arroyo-user-config
+            configMap:
+              name: {{ .Values.existingConfigMap }}
+          {{ end }}
+        volume-mounts: {{ .Values.volumeMounts | toYaml | nindent 10 }}
+          - name: arroyo-config
+            mountPath: /root/.config/arroyo
+          {{- if .Values.existingConfigMap }}
+          - name: arroyo-user-config
+            mountPath: /app
+          {{- end }}

--- a/k8s/arroyo/templates/configmap.yaml
+++ b/k8s/arroyo/templates/configmap.yaml
@@ -25,16 +25,16 @@ data:
       type: "postgres"
       postgres:
     {{- if .Values.postgresql.deploy }}
-        host = "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.cluster.local"
-        port = {{ default "5432" .Values.postgresql.auth.port }}
-        database-name = "arroyo"
-        user = "arroyo"
+        host: "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.cluster.local"
+        port: {{ default "5432" .Values.postgresql.auth.port }}
+        database-name: "arroyo"
+        user: "arroyo"
     {{- else -}}
-        host = "{{ .Values.postgresql.externalDatabase.host }}"
-        port = {{ .Values.postgresql.externalDatabase.port }}
-        database-name = "{{ .Values.postgresql.externalDatabase.name }}"
-        user = "{{ .Values.postgresql.externalDatabase.user }}"
-        password = "{{ .Values.postgresql.externalDatabase.password }}"
+        host: "{{ .Values.postgresql.externalDatabase.host }}"
+        port: {{ .Values.postgresql.externalDatabase.port }}
+        database-name: "{{ .Values.postgresql.externalDatabase.name }}"
+        user: "{{ .Values.postgresql.externalDatabase.user }}"
+        password: "{{ .Values.postgresql.externalDatabase.password }}"
     {{- end }}
 
     kubernetes-scheduler:

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -30,10 +30,18 @@ spec:
       serviceAccountName: {{ template "arroyo.serviceAccountName" . }}
       volumes:
       {{- if .Values.volumes }}
-      {{- include "tplvalues.render" (dict "value" .Values.volumes "context" $) | nindent 10 }}
+      {{- include "tplvalues.render" (dict "value" .Values.volumes "context" $) | nindent 6 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      - name: arroyo-config
+        configMap:
+          name: {{ include "arroyo.fullname" . }}-config
+      {{- if .Values.existingConfigMap }}
+      - name: arroyo-user-config
+        configMap:
+          name: {{ .Values.existingConfigMap }}
+      {{- end }}
       imagePullSecrets:
+      {{- with .Values.imagePullSecrets }}
       {{- toYaml . | nindent 10 }}
       {{- end }}
       initContainers:
@@ -41,8 +49,22 @@ spec:
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         command: [ "/app/arroyo-bin", "migrate", "--wait", "300" ]
+        volumeMounts:
+          - name: arroyo-config
+            mountPath: /root/.config/arroyo
+          {{- if .Values.existingConfigMap }}
+          - name: arroyo-user-config
+            mountPath: /app
+          {{- end }}
+          
         env:
-        {{- include "arroyo.databaseEnvVars" . | nindent 8 }}
+        {{- if .Values.postgresql.deploy }}
+          - name: ARROYO_DATABASE_POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "arroyo.fullname" . }}-postgresql
+                key: password
+          {{- end }}
       containers:
       - name: arroyo-controller
         securityContext:
@@ -52,71 +74,18 @@ spec:
         command: ["/app/arroyo-bin", "cluster"]
 
         env:
-        {{- include "arroyo.storageEnvVars" . | nindent 8 }}
-        - name: CHECKPOINT_URL
-          value: {{ required "A valid .Values.checkpointUrl entry required!" .Values.checkpointUrl }}
-        - name: ARTIFACT_URL
-          value: {{ required "A valid .Values.artifactUrl entry required!" .Values.artifactUrl }}
+        {{- if .Values.postgresql.deploy }}
+        - name: ARROYO_DATABASE__POSTGRES__PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "arroyo.fullname" . }}-postgresql
+              key: password
+          {{- end }}
 
-        {{- include "arroyo.databaseEnvVars" . | nindent 8 }}
-        - name: CONTROLLER_ADDR
-          value: "http://{{ include "arroyo.fullname" . }}:{{ .Values.controller.service.grpcPort }}"
-        - name: GRPC_PORT
-          value: {{ .Values.controller.service.grpcPort | quote }}
-        - name: ADMIN_PORT
-          value: {{ .Values.controller.service.adminPort | quote }}
-        - name: HTTP_PORT
-          value: {{ .Values.controller.service.httpPort | quote }}
-        - name: COMPILER_GRPC_PORT
-          value: {{ .Values.controller.service.compilerPort | quote }}
-        - name: PROM_ENDPOINT
-          value: "{{ include "arroyo.prometheusEndpoint" .}}"
-        - name: API_METRICS_RATE
-          value: "{{ .Values.prometheus.queryRate }}"
-        - name: SCHEDULER
-          value: "kubernetes"
-        - name: K8S_NAMESPACE
+        - name: ARROYO_KUBERNETES__SCHEDULER__WORKER__NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.namespace
-        - name: K8S_WORKER_NAME
-          value: "{{ include "arroyo.fullname" . }}"
-        - name: K8S_WORKER_LABELS
-          value: {{ include "arroyo.labels" . | quote }}
-        - name: K8S_WORKER_ANNOTATIONS
-        {{- if .Values.prometheus.setAnnotations }}
-          {{- $merged := merge (dict "prometheus.io/scrape" "true" "prometheus.io/path" "/metrics" "prometheus.io/port" "6901") .Values.podAnnotations  }}
-          value: {{ toYaml $merged | quote }}
-        {{- else }}
-          value: {{ .Values.podAnnotations | toYaml | quote }}
-        {{- end }}
-        - name: K8S_WORKER_IMAGE
-          value: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
-        - name: K8S_WORKER_IMAGE_PULL_POLICY
-          value: "{{ .Values.worker.image.pullPolicy }}"
-        # TODO: image pull secret
-        {{- if .Values.serviceAccount.name }}
-        - name: K8S_WORKER_SERVICE_ACCOUNT_NAME
-          value: "{{ template "arroyo.serviceAccountName" . }}"
-        {{- end }}
-        - name: K8S_WORKER_RESOURCES
-          value: {{ .Values.worker.resources | toYaml | quote }}
-        - name: K8S_WORKER_SLOTS
-          value: {{ .Values.worker.slots | quote }}
-        {{- if .Values.volumes }}
-        - name: K8S_WORKER_VOLUMES
-          value: {{ .Values.volumes | toYaml | quote }}
-        {{- end }}
-        {{- if .Values.volumeMounts }}
-        - name: K8S_WORKER_VOLUME_MOUNTS
-          value: {{ .Values.volumeMounts | toYaml | quote }}
-        {{- end }}
-        {{- if .Values.existingConfigMap }}
-        - name: K8S_WORKER_CONFIG_MAP
-          value: {{ .Values.existingConfigMap }}
-        {{- end }}
-
-        {{- include "arroyo.existingConfigMap" . | nindent 8 }}
+              fieldPath: metadata.namespace        
 
         ports:
         - containerPort: {{ .Values.controller.service.grpcPort }}
@@ -137,7 +106,13 @@ spec:
           initialDelaySeconds: 5
         volumeMounts:
         {{- if .Values.volumeMounts }}
-        {{- include "tplvalues.render" (dict "value" .Values.volumeMounts "context" $) | nindent 10 }}
+        {{- include "tplvalues.render" (dict "value" .Values.volumeMounts "context" $) | nindent 8 }}
+        {{- end }}
+        - name: arroyo-config
+          mountPath: /root/.config/arroyo
+        {{- if .Values.existingConfigMap }}
+        - name: arroyo-user-config
+          mountPath: /app/arroyo.yaml
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -59,7 +59,7 @@ spec:
           
         env:
         {{- if .Values.postgresql.deploy }}
-          - name: ARROYO_DATABASE_POSTGRES_PASSWORD
+          - name: ARROYO__DATABASE__POSTGRES__PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ include "arroyo.fullname" . }}-postgresql
@@ -75,14 +75,14 @@ spec:
 
         env:
         {{- if .Values.postgresql.deploy }}
-        - name: ARROYO_DATABASE__POSTGRES__PASSWORD
+        - name: ARROYO__DATABASE__POSTGRES__PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "arroyo.fullname" . }}-postgresql
               key: password
           {{- end }}
 
-        - name: ARROYO_KUBERNETES__SCHEDULER__WORKER__NAMESPACE
+        - name: ARROYO__KUBERNETES_SCHEDULER__NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace        


### PR DESCRIPTION
This PR introduces a new, hierarchical configuration system for Arroyo, replacing the ad-hoc environment variable system currently in place. This will make it easier to configure the system, understand the available configuration options, and add new ones.

An example config file looks like this:

```toml
checkpoint-url = "s3://my-bucket/checkpoints"

[controller]
scheduler = "node"
rpc-port = 9292

[pipeline]
source-batch-linger = "1s"
```

The configuration file can be specified by passing `--config` to the binary, or by placing the config file in $(user-config-dir)/arroyo/config.toml (for example, on Linux this is `~/.config/arroyo/config.toml`, on MacOS `~/Library/Application\ Support/arroyo`).

Configurations can be overridden with environment variables with the prefix `ARROYO__`. To convert a toml config key to env var, paths (`.`) are replace with double-underscores (`__`) while hyphens are replaced with single underscores (`_`). So for example, the key `controller.rpc-port` would be expressed as `ARROYO__CONTROLLER__RPC_PORT`.

Most existing env var configs are also supported (like `CHECKPOINT_URL` or `DATABASE_NAME`) but will produce a warning if used, and support will be removed in 0.12. The helm config format is unchanged.