### PR TITLE
Support per-slot k8s resource management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "log",
  "nanoid",
  "prost",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",
@@ -980,12 +981,14 @@ dependencies = [
 name = "arroyo-storage"
 version = "0.11.0-dev"
 dependencies = [
+ "arroyo-rpc",
  "arroyo-types",
  "async-trait",
  "bytes",
  "futures",
  "object_store",
  "once_cell",
+ "rand 0.8.5",
  "regex",
  "rusoto_core",
  "thiserror",

--- a/crates/arroyo-controller/src/schedulers/kubernetes/quantities.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/quantities.rs
@@ -1,0 +1,306 @@
+use anyhow::{anyhow, bail, Result};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use regex::Regex;
+use std::ops::Mul;
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+enum MemoryUnit {
+    m,
+    Base,
+    Ki,
+    Mi,
+    Gi,
+    Ti,
+    Pi,
+    k,
+    M,
+    G,
+    T,
+    P,
+}
+
+const UNITS: [MemoryUnit; 11] = [
+    MemoryUnit::P,
+    MemoryUnit::Ti,
+    MemoryUnit::T,
+    MemoryUnit::Gi,
+    MemoryUnit::G,
+    MemoryUnit::Mi,
+    MemoryUnit::M,
+    MemoryUnit::Ki,
+    MemoryUnit::k,
+    MemoryUnit::Base,
+    MemoryUnit::m,
+];
+
+impl MemoryUnit {
+    fn new(unit: &str) -> Result<Self> {
+        Ok(match unit {
+            "m" => Self::m,
+            "Ki" => Self::Ki,
+            "Mi" => Self::Mi,
+            "Gi" => Self::Gi,
+            "Ti" => Self::Ti,
+            "Pi" => Self::Pi,
+            "k" => Self::k,
+            "M" => Self::M,
+            "G" => Self::G,
+            "T" => Self::T,
+            "P" => Self::P,
+            "" => Self::Base,
+            _ => bail!("invalid memory unit {unit}"),
+        })
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            MemoryUnit::m => "m",
+            MemoryUnit::Base => "",
+            MemoryUnit::Ki => "Ki",
+            MemoryUnit::Mi => "Mi",
+            MemoryUnit::Gi => "Gi",
+            MemoryUnit::Ti => "Ti",
+            MemoryUnit::Pi => "Pi",
+            MemoryUnit::k => "k",
+            MemoryUnit::M => "M",
+            MemoryUnit::G => "G",
+            MemoryUnit::T => "T",
+            MemoryUnit::P => "P",
+        }
+    }
+
+    fn multiplier(&self) -> i128 {
+        match self {
+            MemoryUnit::m => 1,
+            MemoryUnit::Base => 1000,
+            MemoryUnit::Ki => 1000 * 1024,
+            MemoryUnit::Mi => 1000 * 1024 * 1024,
+            MemoryUnit::Gi => 1000 * 1024 * 1024 * 1024,
+            MemoryUnit::Ti => 1000 * 1024 * 1024 * 1024 * 1024,
+            MemoryUnit::Pi => 1000 * 1024 * 1024 * 1024 * 1024 * 1024,
+            MemoryUnit::k => 1000 * 1000,
+            MemoryUnit::M => 1000 * 1000 * 1000,
+            MemoryUnit::G => 1000 * 1000 * 1000 * 1000,
+            MemoryUnit::T => 1000 * 1000 * 1000 * 1000 * 1000,
+            MemoryUnit::P => 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
+        }
+    }
+}
+
+pub enum ParsedQuantity {
+    Cpu(i64),
+    Memory(i128),
+}
+
+impl ParsedQuantity {
+    #[allow(unused)]
+    pub fn value(&self) -> i128 {
+        match self {
+            ParsedQuantity::Cpu(i) => *i as i128,
+            ParsedQuantity::Memory(i) => *i,
+        }
+    }
+
+    pub fn to_canonical(&self) -> String {
+        match self {
+            ParsedQuantity::Cpu(i) => {
+                if *i % 1000 == 0 {
+                    format!("{}", i / 1000)
+                } else {
+                    format!("{}m", i)
+                }
+            }
+            ParsedQuantity::Memory(i) => {
+                let abs_value = i.abs();
+                let neg = if *i < 0 { "-" } else { "" };
+
+                for unit in UNITS {
+                    if abs_value % unit.multiplier() == 0 {
+                        return format!("{}{}{}", neg, abs_value / unit.multiplier(), unit.name());
+                    }
+                }
+
+                unreachable!("everything is divisible by 1")
+            }
+        }
+    }
+}
+
+impl Mul<i64> for ParsedQuantity {
+    type Output = ParsedQuantity;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        match self {
+            ParsedQuantity::Cpu(v) => ParsedQuantity::Cpu(v * rhs),
+            ParsedQuantity::Memory(v) => ParsedQuantity::Memory(v * rhs as i128),
+        }
+    }
+}
+
+pub trait QuantityParser {
+    fn parse_cpu(&self) -> Result<ParsedQuantity>;
+    fn parse_memory(&self) -> Result<ParsedQuantity>;
+}
+
+const REGEX: &str = r"^(-?[\d\.]+)([a-zA-Z]*)$";
+
+fn parse(s: &str) -> Result<(f64, String)> {
+    let regex = Regex::new(REGEX).unwrap();
+    let captures = regex
+        .captures(s)
+        .ok_or_else(|| anyhow!("invalid quantity {}", s))?;
+    let quantity: f64 = captures.get(1).unwrap().as_str().parse()?;
+    let unit = captures.get(2).unwrap().as_str();
+    Ok((quantity, unit.to_string()))
+}
+
+impl QuantityParser for Quantity {
+    fn parse_cpu(&self) -> Result<ParsedQuantity> {
+        let (quantity, unit) = parse(&self.0)?;
+        Ok(ParsedQuantity::Cpu(match unit.as_str() {
+            "" => (quantity * 1000.0) as i64,
+            "m" => quantity as i64,
+            _ => bail!("invalid cpu unit '{unit}'"),
+        }))
+    }
+
+    fn parse_memory(&self) -> Result<ParsedQuantity> {
+        let (quantity, unit) = parse(&self.0)?;
+        let quantity = (quantity * 1000.0) as i128;
+        Ok(ParsedQuantity::Memory(
+            quantity * MemoryUnit::new(unit.as_str())?.multiplier() / 1000,
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+
+    #[test]
+    fn test_parse_cpu_milli() {
+        let q = Quantity("500m".to_string());
+        assert_eq!(q.parse_cpu().unwrap().value(), 500);
+    }
+
+    #[test]
+    fn test_parse_cpu_no_unit() {
+        let q = Quantity("2".to_string());
+        assert_eq!(q.parse_cpu().unwrap().value(), 2000);
+    }
+
+    #[test]
+    fn test_parse_cpu_invalid_unit() {
+        let q = Quantity("2x".to_string());
+        assert!(q.parse_cpu().is_err());
+    }
+
+    #[test]
+    fn test_parse_cpu_negative_value() {
+        let q = Quantity("-500m".to_string());
+        assert_eq!(q.parse_cpu().unwrap().value(), -500);
+    }
+
+    #[test]
+    fn test_parse_cpu_with_decimal() {
+        let q = Quantity("1.5".to_string());
+        assert_eq!(q.parse_cpu().unwrap().value(), 1500);
+    }
+
+    #[test]
+    fn test_parse_memory_k() {
+        let q = Quantity("1k".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1_000_000);
+    }
+
+    #[test]
+    fn test_parse_memory_p() {
+        let q = Quantity("1P".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1_000_000_000_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_memory_no_unit() {
+        let q = Quantity("500".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 500_000);
+    }
+
+    #[test]
+    fn test_parse_memory_millis() {
+        let q = Quantity("1m".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1);
+    }
+
+    #[test]
+    fn test_parse_memory_ki() {
+        let q = Quantity("1Ki".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1_024_000);
+    }
+
+    #[test]
+    fn test_parse_memory_invalid_unit() {
+        let q = Quantity("500x".to_string());
+        assert!(q.parse_memory().is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_negative_value() {
+        let q = Quantity("-500Mi".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), -524288000000);
+    }
+
+    #[test]
+    fn test_parse_memory_with_decimal() {
+        let q = Quantity("1.5Gi".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1_610_612_736_000);
+    }
+
+    #[test]
+    fn test_parse_invalid_format() {
+        let q = Quantity("invalid".to_string());
+        assert!(q.parse_cpu().is_err());
+        assert!(q.parse_memory().is_err());
+    }
+
+    #[test]
+    fn test_parse_empty_string() {
+        let q = Quantity("".to_string());
+        assert!(q.parse_cpu().is_err());
+        assert!(q.parse_memory().is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_zero_value() {
+        let q = Quantity("0".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 0);
+    }
+
+    #[test]
+    fn test_parse_cpu_zero_value() {
+        let q = Quantity("0".to_string());
+        assert_eq!(q.parse_cpu().unwrap().value(), 0);
+    }
+
+    #[test]
+    fn test_parse_memory_large_value() {
+        let q = Quantity("1000T".to_string());
+        assert_eq!(q.parse_memory().unwrap().value(), 1_000_000_000_000_000_000);
+    }
+
+    fn test_mem(s: &str) {
+        let mem = Quantity(s.to_string()).parse_memory().unwrap();
+        assert_eq!(s, mem.to_canonical().as_str());
+    }
+
+    #[test]
+    fn test_to_canonical() {
+        test_mem("10T");
+        test_mem("100k");
+        test_mem("-55P");
+        test_mem("50");
+        test_mem("100Ki");
+    }
+}

--- a/crates/arroyo-rpc/Cargo.toml
+++ b/crates/arroyo-rpc/Cargo.toml
@@ -37,6 +37,7 @@ url = { version = "2", features = ["serde"] }
 dirs = "5.0.1"
 arc-swap = "1.7.1"
 datafusion-common = { workspace = true }
+rand = "0.8.5"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -52,14 +52,16 @@ slots-per-process = 16
 
 [kubernetes-scheduler]
 namespace = "default"
+resource-mode = "per-slot"
 
 [kubernetes-scheduler.worker]
 name-prefix = "arroyo"
 image = "ghcr.io/arroyosystems/arroyo:latest"
 image-pull-policy = "IfNotPresent"
 service-account-name = "default"
-resources = { requests = { cpu = "400m",  memory = "200Mi" } }
-task-slots = 4
+resources = { requests = { cpu = "900m",  memory = "500Mi" } }
+task-slots = 16
+command = "/app/arroyo-bin worker"
 
 [database]
 type = "postgres"

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -270,3 +270,33 @@ impl Converter {
 pub fn get_hasher() -> ahash::RandomState {
     ahash::RandomState::with_seeds(HASH_SEEDS[0], HASH_SEEDS[1], HASH_SEEDS[2], HASH_SEEDS[3])
 }
+
+#[macro_export]
+macro_rules! retry {
+    ($e:expr, $max_retries:expr, $base:expr, $max_delay:expr, |$err_var: ident| $error_handler:expr) => {{
+        use std::time::Duration;
+        use tracing::error;
+        let mut retries: u32 = 0;
+        use rand::Rng;
+        loop {
+            match $e {
+                Ok(value) => break Ok(value),
+                Err(e) if retries < $max_retries => {
+                    retries += 1;
+                    {
+                        let $err_var = e;
+                        $error_handler;
+                    }
+                    let tmp = $max_delay.min($base * (2u32.pow(retries)));
+                    let backoff = tmp / 2
+                        + Duration::from_micros(
+                            rand::thread_rng().gen_range(0..tmp.as_micros() as u64 / 2),
+                        );
+
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e) => break Err(e),
+            }
+        }
+    }};
+}

--- a/crates/arroyo-storage/Cargo.toml
+++ b/crates/arroyo-storage/Cargo.toml
@@ -9,12 +9,14 @@ default = []
 
 [dependencies]
 arroyo-types = { path = "../arroyo-types" }
+arroyo-rpc = { path = "../arroyo-rpc" }
 bytes = "1.4.0"
 tracing = "0.1"
 # used only for getting local AWS credentials; can be removed once we have a
 # better way to do this
 rusoto_core = "0.48.0"
 
+rand = "0.8"
 object_store = {workspace = true, features = ["aws", "gcp"]}
 regex = "1.9.5"
 thiserror = "1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,8 @@ FROM debian:bookworm-slim as arroyo
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get -y install libsasl2-2 ca-certificates curl pkg-config
+    apt-get -y install libsasl2-2 ca-certificates curl pkg-config && \
+    mkdir /config
 
 COPY --from=builder /arroyo-bin ./
 

--- a/k8s/arroyo/templates/configmap.yaml
+++ b/k8s/arroyo/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
         port: {{ default "5432" .Values.postgresql.auth.port }}
         database-name: "arroyo"
         user: "arroyo"
-    {{- else -}}
+    {{- else }}
         host: "{{ .Values.postgresql.externalDatabase.host }}"
         port: {{ .Values.postgresql.externalDatabase.port }}
         database-name: "{{ .Values.postgresql.externalDatabase.name }}"
@@ -81,5 +81,6 @@ data:
             mountPath: /root/.config/arroyo
           {{- if .Values.existingConfigMap }}
           - name: arroyo-user-config
-            mountPath: /app
+            mountPath: /config
           {{- end }}
+        command: "/app/arroyo-bin --config-dir /config worker"

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -48,13 +48,13 @@ spec:
       - name: migrate-database
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-        command: [ "/app/arroyo-bin", "migrate", "--wait", "300" ]
+        command: [ "/app/arroyo-bin", "--config-dir", "/config", "migrate", "--wait", "300" ]
         volumeMounts:
           - name: arroyo-config
             mountPath: /root/.config/arroyo
           {{- if .Values.existingConfigMap }}
           - name: arroyo-user-config
-            mountPath: /app
+            mountPath: /config
           {{- end }}
           
         env:
@@ -71,7 +71,7 @@ spec:
         {{- toYaml .Values.securityContext | nindent 12 }}
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-        command: ["/app/arroyo-bin", "cluster"]
+        command: ["/app/arroyo-bin", "--config-dir", "/config", "cluster"]
 
         env:
         {{- if .Values.postgresql.deploy }}
@@ -122,7 +122,7 @@ spec:
           mountPath: /root/.config/arroyo
         {{- if .Values.existingConfigMap }}
         - name: arroyo-user-config
-          mountPath: /app/arroyo.yaml
+          mountPath: /config
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -24,9 +24,9 @@ worker:
   resources:
     limits: {}
     requests:
-      memory: 4Gi
-      cpu: 4000m
-  slots: 4
+      memory: 490Mi
+      cpu: 900m
+  slots: 16
   image:
     repository: ghcr.io/arroyosystems/arroyo
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Currently, k8s resources are specified on a per-pod basis, with some number of task slots deployed per pod. However, this is inefficient if you are deploying a mix of small jobs (that just need a single slot) and large jobs. This PR adds a new (now default) option to configure resources on a _per slot_ basis instead. In this mode, the number of slots needed for the pod is calculated (up to a max number of task slots allowed on a single pod), then it is given `slots * per_slot_cpu` cpu and `slots * per_slot_mem` memory.

To restore the existing behavior, use this config:

```toml
[kubernetes-scheduler]
resource-mode = "per-pod"
```