### PR TITLE
Add option to deploy kubernetes programs as configmaps rather than env vars

### DIFF
--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -79,6 +79,8 @@ spec:
           value: "{{ .Values.prometheus.queryRate }}"
         - name: SCHEDULER
           value: "kubernetes"
+        - name: ARROYO_K8S_PROGRAM_FILES
+          value: "true"
         - name: K8S_NAMESPACE
           valueFrom:
             fieldRef:

--- a/k8s/arroyo/templates/role.yaml
+++ b/k8s/arroyo/templates/role.yaml
@@ -9,6 +9,7 @@ rules:
    resources:
     - services
     - pods
+    - configmaps
    verbs:
     - create
     - get


### PR DESCRIPTION
This addresses the "argument list too long" error when trying to run a very large query in k8s.