### PR TITLE
Re-add support for joins on structs by rewriting expression

### DIFF
--- a/crates/arroyo-sql-testing/golden_outputs/nexmark_q5.json
+++ b/crates/arroyo-sql-testing/golden_outputs/nexmark_q5.json
@@ -1,0 +1,14 @@
+{"auction":1000,"count":770}
+{"auction":1100,"count":785}
+{"auction":1200,"count":804}
+{"auction":1200,"count":804}
+{"auction":1200,"count":804}
+{"auction":1200,"count":804}
+{"auction":1500,"count":769}
+{"auction":1600,"count":769}
+{"auction":1500,"count":769}
+{"auction":1600,"count":769}
+{"auction":1500,"count":769}
+{"auction":1600,"count":769}
+{"auction":1600,"count":768}
+{"auction":1700,"count":404}

--- a/crates/arroyo-sql-testing/src/test/queries/nexmark_q5.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/nexmark_q5.sql
@@ -1,0 +1,44 @@
+CREATE TABLE bids (
+  datetime TIMESTAMP,
+  auction BIGINT
+) WITH (
+  connector = 'single_file',
+  path = '$input_dir/nexmark_bids.json',
+  format = 'json',
+  type = 'source',
+  event_time_field = 'datetime'
+);
+CREATE TABLE top_auctions (
+  auction BIGINT,
+  count INT
+) WITH (
+  connector = 'single_file',
+  path = '$output_path',
+  format = 'json',
+  type = 'sink'
+);
+
+INSERT INTO top_auctions
+SELECT AuctionBids.auction, AuctionBids.num
+ FROM (
+   SELECT
+     auction,
+     count(*) AS num,
+     hop(interval '2 second', interval '10 seconds') as window
+    FROM bids
+    GROUP BY auction, window
+ ) AS AuctionBids
+ JOIN (
+   SELECT
+     max(CountBids.num) AS maxn,
+     CountBids.window
+   FROM (
+     SELECT
+       count(*) AS num,
+       hop(interval '2 second', interval '10 seconds') as window
+     FROM bids
+     GROUP BY auction, window
+     ) AS CountBids
+   GROUP BY CountBids.window
+ ) AS MaxBids
+ ON AuctionBids.window = MaxBids.window AND AuctionBids.num >= MaxBids.maxn;


### PR DESCRIPTION
This PR re-adds support for joining on struct fields (for example on a window), working around https://github.com/apache/datafusion/issues/9254.

Ultimately, this is the responsibility of arrow-ord, which should be able to compare structs as it does other datatypes. In lieu of solving the whole problem there, I've opted to work around the issue by rewriting struct eq expressions into an AND of eq expressions on the struct fields.

So for example,

```sql
ON A.window = B.window
```

gets rewritten into

```sql
ON A.window.start = B.window.start AND A.window.end = B.window.end
```

Currently, this rewriting is limited to structs that have a single level of nesting, with plan-time errors for unsupported expressions.