### PR TITLE
Support UDFs on raw_bytes

### DIFF
--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -360,7 +360,7 @@ mod tests {
     use arrow_array::builder::{make_builder, ArrayBuilder};
     use arrow_array::cast::AsArray;
     use arrow_array::types::{GenericBinaryType, Int64Type, TimestampNanosecondType};
-    use arrow_array::RecordBatch;
+    use arrow_array::{BinaryArray, RecordBatch};
     use arrow_schema::{Schema, TimeUnit};
     use arroyo_rpc::df::ArroyoSchema;
     use arroyo_rpc::formats::{

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -360,7 +360,7 @@ mod tests {
     use arrow_array::builder::{make_builder, ArrayBuilder};
     use arrow_array::cast::AsArray;
     use arrow_array::types::{GenericBinaryType, Int64Type, TimestampNanosecondType};
-    use arrow_array::{BinaryArray, RecordBatch};
+    use arrow_array::RecordBatch;
     use arrow_schema::{Schema, TimeUnit};
     use arroyo_rpc::df::ArroyoSchema;
     use arroyo_rpc::formats::{

--- a/crates/arroyo-planner/src/test/queries/bluesky_trends.sql
+++ b/crates/arroyo-planner/src/test/queries/bluesky_trends.sql
@@ -1,0 +1,23 @@
+create table firesky (
+    value BYTEA
+) with (
+    connector = 'websocket',
+    endpoint = 'wss://firesky.tv/ws/app',
+    format = 'raw_bytes'
+);
+ 
+create view tags as (
+    select unnest(extract_json(cbor_to_json(value),
+        '$.info.post.facets[*].features[*].tag')) as tag
+    from firesky);
+ 
+ 
+SELECT * FROM (
+    SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY window
+        ORDER BY count DESC) as row_num
+    FROM (SELECT count(*) as count,
+        tag,
+        hop(interval '5 seconds', interval '15 minutes') as window
+            FROM tags
+            group by tag, window)) WHERE row_num <= 5;

--- a/crates/arroyo-planner/src/test/udfs/cbor_to_json.rs
+++ b/crates/arroyo-planner/src/test/udfs/cbor_to_json.rs
@@ -1,0 +1,21 @@
+/*
+[dependencies]
+serde_cbor = "0.11"
+serde_json = "1"
+serde = {version = "1", features = ["derive"]}
+serde-transcode = "1"
+*/
+
+use arroyo_udf_plugin::udf;
+
+
+#[udf]
+fn cbor_to_json(data: &[u8]) -> Option<String> {
+    let mut deserializer = serde_cbor::Deserializer::from_slice(&data[..]);
+    let mut buf = std::io::BufWriter::new(Vec::new());
+    let mut serializer = serde_json::Serializer::new(&mut buf);
+    serde_transcode::transcode(&mut deserializer, &mut serializer).ok()?;
+    let bytes = buf.into_inner().unwrap();
+
+    Some(String::from_utf8(bytes).ok()?)
+}

--- a/crates/arroyo-planner/src/test/udfs/get_city.rs
+++ b/crates/arroyo-planner/src/test/udfs/get_city.rs
@@ -8,7 +8,7 @@ use arroyo_udf_plugin::udf;
 use reqwest::Client;
 
 #[udf(allowed_in_flight=100000, timeout="180s")]
-pub async fn get_city(ip: String) -> Option<String> {
+pub async fn get_city(ip: &str) -> Option<String> {
     use std::sync::OnceLock;
     static CLIENT: OnceLock<Client> = OnceLock::new();
     let client = CLIENT.get_or_init(|| {

--- a/crates/arroyo-planner/src/test/udfs/parse_log.rs
+++ b/crates/arroyo-planner/src/test/udfs/parse_log.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use std::time::{UNIX_EPOCH, Duration};
 
 #[udf]
-pub fn parse_log(input: String) -> Option<String> {
+pub fn parse_log(input: &str) -> Option<String> {
     let LogEntry::CommonLog(entry) =
         parse(LogType::CommonLog, &input).ok()? else {
         return None

--- a/crates/arroyo-planner/src/test/udfs/parse_prom.rs
+++ b/crates/arroyo-planner/src/test/udfs/parse_prom.rs
@@ -5,7 +5,7 @@ serde_json = "1.0"
 */
 
 #[udf]
-fn parse_prom(s: String) -> Option<String> {
+fn parse_prom(s: &str) -> Option<String> {
     use regex::Regex;
     use std::collections::HashMap;
 

--- a/crates/arroyo-udf/arroyo-udf-common/src/parse.rs
+++ b/crates/arroyo-udf/arroyo-udf-common/src/parse.rs
@@ -43,37 +43,89 @@ pub fn is_vec_u8(typ: &Type) -> bool {
     };
 
     matches!(
-        rust_to_arrow(&inner),
-        Some(NullableType {
+        rust_to_arrow(&inner, true),
+        Ok(NullableType {
             data_type: DataType::UInt8,
             nullable: false
         })
     )
 }
 
-fn rust_to_arrow(typ: &Type) -> Option<NullableType> {
+pub(crate) fn rust_to_arrow(typ: &Type, expect_owned: bool) -> anyhow::Result<NullableType> {
     match typ {
         Type::Path(pat) => {
             let last = pat.path.segments.last().unwrap();
             if last.ident == "Option" {
                 let AngleBracketed(args) = &last.arguments else {
-                    return None;
+                    bail!("invalid Rust type; Option must have arguments");
                 };
 
-                let GenericArgument::Type(inner) = args.args.first()? else {
-                    return None;
+                let Some(GenericArgument::Type(inner)) = args.args.first() else {
+                    bail!("invalid Rust type; Option must have an inner type parameter")
                 };
 
-                Some(rust_to_arrow(inner)?.with_nullability(true))
+                Ok(rust_to_arrow(inner, expect_owned)?.with_nullability(true))
             } else {
-                Some(NullableType::not_null(rust_primitive_to_arrow(typ)?))
+                let mut dt = rust_primitive_to_arrow(typ);
+
+                if dt.is_none() {
+                    dt = Some(
+                        match (
+                            render_path(typ)
+                                .ok_or_else(|| anyhow!("unsupported Rust type1"))?
+                                .as_str(),
+                            expect_owned,
+                        ) {
+                            ("String", true) => DataType::Utf8,
+                            ("String", false) => {
+                                bail!("expected reference type &str instead of String")
+                            }
+                            ("Vec<u8>", true) => DataType::Binary,
+                            ("Vec<u8>", false) => {
+                                bail!("expected reference type &[u8] instead of Vec<u8>")
+                            }
+                            (t, _) => bail!("unsupported Rust type {}", t),
+                        },
+                    );
+                }
+
+                Ok(NullableType::not_null(
+                    dt.ok_or_else(|| anyhow!("unsupported Rust type2"))?,
+                ))
             }
         }
-        _ => None,
+        Type::Reference(r) => {
+            let t = render_path(&r.elem).ok_or_else(|| anyhow!("unsupported Rust type3"))?;
+
+            let dt = match (t.as_str(), rust_primitive_to_arrow(&r.elem), expect_owned) {
+                ("String", _, false) => bail!("expected &str, not &String"),
+                ("String", _, true) => {
+                    bail!("expected owned String, not &String (hint: remove the &)")
+                }
+                ("Vec<u8>", _, false) => bail!("expected &[u8], not &Vec<u8>"),
+                ("Vec<u8>", _, true) => {
+                    bail!("expected owned Vec<u8>, not &Vec<u8> (hint: remove the &)")
+                }
+                ("str", _, false) => DataType::Utf8,
+                ("str", _, true) => bail!("expected owned String, not &str"),
+                ("[u8]", _, false) => DataType::Binary,
+                ("[u8]", _, true) => bail!("expected owned Vec<u8>, not &[u8]"),
+                (t, Some(_), _) => bail!(
+                    "unexpected &{}; primitives should be passed by value (hint: remove the &)",
+                    t
+                ),
+                _ => {
+                    bail!("unsupported Rust data type")
+                }
+            };
+
+            Ok(NullableType::not_null(dt))
+        }
+        _ => bail!("unsupported Rust data type"),
     }
 }
 
-fn rust_primitive_to_arrow(typ: &Type) -> Option<DataType> {
+fn render_path(typ: &Type) -> Option<String> {
     match typ {
         Type::Path(pat) => {
             let path: Vec<String> = pat
@@ -83,30 +135,31 @@ fn rust_primitive_to_arrow(typ: &Type) -> Option<DataType> {
                 .map(|s| s.to_token_stream().to_string().replace(' ', ""))
                 .collect();
 
-            match path.join("::").as_str() {
-                "bool" => Some(DataType::Boolean),
-                "i8" => Some(DataType::Int8),
-                "i16" => Some(DataType::Int16),
-                "i32" => Some(DataType::Int32),
-                "i64" => Some(DataType::Int64),
-                "u8" => Some(DataType::UInt8),
-                "u16" => Some(DataType::UInt16),
-                "u32" => Some(DataType::UInt32),
-                "u64" => Some(DataType::UInt64),
-                "f16" => Some(DataType::Float16),
-                "f32" => Some(DataType::Float32),
-                "f64" => Some(DataType::Float64),
-                "String" => Some(DataType::Utf8),
-                "Vec<u8>" => Some(DataType::Binary),
-                "SystemTime" | "std::time::SystemTime" => {
-                    Some(DataType::Timestamp(TimeUnit::Microsecond, None))
-                }
-                "Duration" | "std::time::Duration" => {
-                    Some(DataType::Duration(TimeUnit::Microsecond))
-                }
-                _ => None,
-            }
+            Some(path.join("::"))
         }
+        Type::Slice(t) => Some(format!("[{}]", render_path(&t.elem)?)),
+        _ => None,
+    }
+}
+
+fn rust_primitive_to_arrow(typ: &Type) -> Option<DataType> {
+    match render_path(typ)?.as_str() {
+        "bool" => Some(DataType::Boolean),
+        "i8" => Some(DataType::Int8),
+        "i16" => Some(DataType::Int16),
+        "i32" => Some(DataType::Int32),
+        "i64" => Some(DataType::Int64),
+        "u8" => Some(DataType::UInt8),
+        "u16" => Some(DataType::UInt16),
+        "u32" => Some(DataType::UInt32),
+        "u64" => Some(DataType::UInt64),
+        "f16" => Some(DataType::Float16),
+        "f32" => Some(DataType::Float32),
+        "f64" => Some(DataType::Float64),
+        "SystemTime" | "std::time::SystemTime" => {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, None))
+        }
+        "Duration" | "std::time::Duration" => Some(DataType::Duration(TimeUnit::Microsecond)),
         _ => None,
     }
 }
@@ -212,13 +265,11 @@ impl ParsedUdf {
                 }
                 FnArg::Typed(t) => {
                     let vec_type = Self::vec_inner_type(&t.ty);
-                    if vec_type.is_some() && !is_vec_u8(&t.ty) {
+                    if vec_type.is_some() {
                         vec_arguments += 1;
-                        let vec_type = rust_to_arrow(vec_type.as_ref().unwrap()).ok_or_else(|| {
+                        let vec_type = rust_to_arrow(vec_type.as_ref().unwrap(), false).map_err(|e| {
                             anyhow!(
-                                "Could not convert function {} inner vector arg {} into an Arrow data type",
-                                name,
-                                i
+                                "Could not convert function {name} inner vector arg {i} into an Arrow data type: {e}",
                             )
                         })?;
 
@@ -226,11 +277,9 @@ impl ParsedUdf {
                             Field::new("item", vec_type.data_type, vec_type.nullable),
                         ))));
                     } else {
-                        args.push(rust_to_arrow(&t.ty).ok_or_else(|| {
+                        args.push(rust_to_arrow(&t.ty, false).map_err(|e| {
                             anyhow!(
-                                "Could not convert function {} arg {} into a SQL data type",
-                                name,
-                                i
+                                "Could not convert function {name} arg {i} into a SQL data type: {e}",
                             )
                         })?);
                     }
@@ -240,11 +289,8 @@ impl ParsedUdf {
 
         let ret = match &function.sig.output {
             ReturnType::Default => bail!("Function {} return type must be specified", name),
-            ReturnType::Type(_, t) => rust_to_arrow(t).ok_or_else(|| {
-                anyhow!(
-                    "Could not convert function {} return type into a SQL data type",
-                    name
-                )
+            ReturnType::Type(_, t) => rust_to_arrow(t, true).map_err(|e| {
+                anyhow!("Could not convert function {name} return type into a SQL data type: {e}",)
             })?,
         };
 
@@ -310,8 +356,10 @@ pub fn inner_type(dt: &DataType) -> Option<DataType> {
 
 #[cfg(test)]
 mod tests {
-    use crate::parse::parse_duration;
+    use crate::parse::{parse_duration, rust_to_arrow, NullableType};
+    use arrow::datatypes::DataType;
     use std::time::Duration;
+    use syn::parse_quote;
 
     #[test]
     fn test_duration() {
@@ -328,5 +376,78 @@ mod tests {
         assert!(parse_duration("-10ms").is_err());
         assert!(parse_duration("10.0s").is_err());
         assert!(parse_duration("5s what").is_err());
+    }
+
+    #[test]
+    fn test_rust_to_arrow() {
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(i32), false).unwrap(),
+            NullableType::not_null(DataType::Int32)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Option<i32>), false).unwrap(),
+            NullableType::null(DataType::Int32)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Vec<u8>), true).unwrap(),
+            NullableType::not_null(DataType::Binary)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(&[u8]), false).unwrap(),
+            NullableType::not_null(DataType::Binary)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Vec<u8>), true).unwrap(),
+            NullableType::not_null(DataType::Binary)
+        );
+
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(u64), false).unwrap(),
+            NullableType::not_null(DataType::UInt64)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(f32), false).unwrap(),
+            NullableType::not_null(DataType::Float32)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(bool), false).unwrap(),
+            NullableType::not_null(DataType::Boolean)
+        );
+
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Option<f64>), false).unwrap(),
+            NullableType::null(DataType::Float64)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Option<bool>), false).unwrap(),
+            NullableType::null(DataType::Boolean)
+        );
+
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(String), true).unwrap(),
+            NullableType::not_null(DataType::Utf8)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(&str), false).unwrap(),
+            NullableType::not_null(DataType::Utf8)
+        );
+
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Option<String>), true).unwrap(),
+            NullableType::null(DataType::Utf8)
+        );
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(Option<&str>), false).unwrap(),
+            NullableType::null(DataType::Utf8)
+        );
+
+        assert_eq!(
+            rust_to_arrow(&parse_quote!(HashMap<String, i32>), false).ok(),
+            None
+        );
+        assert_eq!(rust_to_arrow(&parse_quote!(CustomStruct), false).ok(), None);
+
+        assert_eq!(rust_to_arrow(&parse_quote!(Vec<u8>), false).ok(), None);
+        assert_eq!(rust_to_arrow(&parse_quote!(&[u8]), true).ok(), None);
     }
 }

--- a/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
@@ -1,5 +1,5 @@
 use arrow_schema::DataType;
-use arroyo_udf_common::parse::ParsedUdf;
+use arroyo_udf_common::parse::{is_vec_u8, ParsedUdf};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
@@ -20,6 +20,7 @@ fn data_type_to_arrow_type_token(data_type: &DataType) -> TokenStream {
         DataType::UInt64 => quote!(UInt64Type),
         DataType::Float32 => quote!(Float32Type),
         DataType::Float64 => quote!(Float64Type),
+        DataType::Binary => quote!(GenericBinaryType<i32>),
         DataType::List(f) => data_type_to_arrow_type_token(f.data_type()),
         _ => panic!("Unsupported data type: {:?}", data_type),
     }
@@ -35,7 +36,7 @@ impl Parse for ParsedFunction {
             if let Some(vec) = function.sig.inputs.iter().find_map(|t| match t {
                 FnArg::Receiver(_) => None,
                 FnArg::Typed(t) => {
-                    if ParsedUdf::vec_inner_type(&t.ty).is_some() {
+                    if ParsedUdf::vec_inner_type(&t.ty).is_some() && !is_vec_u8(&t.ty) {
                         Some(t.ty.span())
                     } else {
                         None
@@ -149,6 +150,9 @@ fn arg_vars(parsed: &ParsedUdf) -> (Vec<TokenStream>, Vec<TokenStream>) {
                 DataType::Utf8 => {
                     quote!(let #id = arroyo_udf_plugin::arrow::array::StringArray::from(args.next().unwrap());)
                 }
+                DataType::Binary => {
+                    quote!(let #id = arroyo_udf_plugin::arrow::array::BinaryArray::from(args.next().unwrap());)
+                }
                 DataType::List(field) => {
                     let filter = if !field.is_nullable() {
                         quote!(.filter_map(|x| x))
@@ -175,11 +179,18 @@ fn sync_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream 
     let (parsed, item) = (parsed.0, parsed.1);
     let udf_name = format_ident!("{}", parsed.name);
 
-    let results_builder = if matches!(parsed.ret_type.data_type, DataType::Utf8) {
-        quote!(let mut results_builder = arroyo_udf_plugin::arrow::array::StringBuilder::with_capacity(batch_size, batch_size * 8);)
-    } else {
-        let return_type = data_type_to_arrow_type_token(&parsed.ret_type.data_type);
-        quote!(let mut results_builder = arroyo_udf_plugin::arrow::array::PrimitiveBuilder::<arroyo_udf_plugin::arrow::datatypes::#return_type>::with_capacity(batch_size);)
+    let results_builder = match parsed.ret_type.data_type {
+        DataType::Utf8 => {
+            quote!(let mut results_builder = arroyo_udf_plugin::arrow::array::StringBuilder::with_capacity(batch_size, batch_size * 8);)
+        }
+        DataType::Binary => {
+            quote!(let mut results_builder = arroyo_udf_plugin::arrow::array::GenericByteBuilder::<arroyo_udf_plugin::arrow::array::types::GenericBinaryType<i32>>
+                ::with_capacity(batch_size, batch_size * 8);)
+        }
+        _ => {
+            let return_type = data_type_to_arrow_type_token(&parsed.ret_type.data_type);
+            quote!(let mut results_builder = arroyo_udf_plugin::arrow::array::PrimitiveBuilder::<arroyo_udf_plugin::arrow::datatypes::#return_type>::with_capacity(batch_size);)
+        }
     };
 
     let (defs, args) = arg_vars(&parsed);
@@ -196,10 +207,14 @@ fn sync_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream 
         .map(|(i, arg_type)| {
             let id = format_ident!("arg_{}", i);
 
-            let append_none = if matches!(parsed.ret_type.data_type, DataType::Utf8) {
-                quote!(results_builder.append_option(None::<String>);)
-            } else {
-                quote!(results_builder.append_option(None);)
+            let append_none = match parsed.ret_type.data_type {
+                DataType::Utf8 => {
+                    quote!(results_builder.append_option(None::<String>);)
+                }
+                DataType::Binary => {
+                    quote!(results_builder.append_option(None::<Vec<u8>>);)
+                }
+                _ => quote!(results_builder.append_option(None);),
             };
 
             if arg_type.nullable {
@@ -215,24 +230,30 @@ fn sync_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream 
         })
         .collect();
 
-    let to_string: Vec<_> = parsed
+    let to_owned: Vec<_> = parsed
         .args
         .iter()
         .enumerate()
         .map(|(i, arg_type)| {
             let id = format_ident!("arg_{}", i);
-            if matches!(arg_type.data_type, DataType::Utf8) {
-                Some(quote!(let #id = #id.to_string()))
+            if matches!(arg_type.data_type, DataType::Utf8 | DataType::Binary) {
+                if arg_type.nullable {
+                    Some(quote!(let #id = #id.map(|t| t.to_owned())))
+                } else {
+                    Some(quote!(let #id = #id.to_owned()))
+                }
             } else {
                 None
             }
         })
         .collect();
 
+    let mut arg_destructure = quote!(arg_0);
     let mut arg_zip = quote!(arg_0.iter());
     for i in 1..args.len() {
         let next_arg = format_ident!("arg_{}", i);
         arg_zip = quote!(#arg_zip.zip(#next_arg.iter()));
+        arg_destructure = quote!((#arg_destructure, #next_arg))
     }
 
     let call = if parsed.ret_type.nullable {
@@ -247,9 +268,9 @@ fn sync_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream 
         }
     } else {
         quote! {
-            for (#(#args),*) in #arg_zip {
+            for #arg_destructure in #arg_zip {
                 #(#unwrapping;)*
-                #(#to_string;)*
+                #(#to_owned;)*
                 #call
             }
         }
@@ -297,11 +318,8 @@ fn async_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream
         .iter()
         .zip(parsed.args)
         .map(|(arg, dt)| match dt.data_type {
-            DataType::Utf8 => {
-                quote!(#arg.value(0).to_string())
-            }
-            DataType::Binary => {
-                quote!(#arg.value(0).clone())
+            DataType::Utf8 | DataType::Binary => {
+                quote!(#arg.value(0))
             }
             _ => {
                 quote!(#arg.value(0))
@@ -343,11 +361,15 @@ fn async_udf(parsed: ParsedFunction, mangle: Option<TokenStream>) -> TokenStream
         }
     };
 
-    let results_builder = if matches!(parsed.ret_type.data_type, DataType::Utf8) {
-        quote!(arroyo_udf_plugin::arrow::array::StringBuilder::new())
-    } else {
-        let return_type = data_type_to_arrow_type_token(&parsed.ret_type.data_type);
-        quote!(arroyo_udf_plugin::arrow::array::PrimitiveBuilder::<arroyo_udf_plugin::arrow::datatypes::#return_type>::new())
+    let results_builder = match parsed.ret_type.data_type {
+        DataType::Utf8 => quote!(arroyo_udf_plugin::arrow::array::StringBuilder::new()),
+        DataType::Binary => quote!(arroyo_udf_plugin::arrow::array::GenericByteBuilder::<
+            arroyo_udf_plugin::arrow::array::types::GenericBinaryType<i32>,
+        >::new()),
+        _ => {
+            let return_type = data_type_to_arrow_type_token(&parsed.ret_type.data_type);
+            quote!(arroyo_udf_plugin::arrow::array::PrimitiveBuilder::<arroyo_udf_plugin::arrow::datatypes::#return_type>::new())
+        }
     };
 
     let start = quote! {


### PR DESCRIPTION
This PR allows users to write UDFs that read from and produce binary data (via the raw_bytes format). This is generally useful for parsing custom/unsupported binary formats. For example, here's a UDF that transcodes from cbor to json

```rust
/*
[dependencies]
serde_cbor = "0.11"
serde_json = "1"
serde = {version = "1", features = ["derive"]}
serde-transcode = "1"
*/

use arroyo_udf_plugin::udf;


#[udf]
fn cbor_to_json(data: &[u8]) -> Option<String> {
    let mut deserializer = serde_cbor::Deserializer::from_slice(data);
    let mut buf = std::io::BufWriter::new(Vec::new());
    let mut serializer = serde_json::Serializer::new(&mut buf);
    serde_transcode::transcode(&mut deserializer, &mut serializer).ok()?;
    let bytes = buf.into_inner().unwrap();

    Some(String::from_utf8(bytes).ok()?)
}
```

There are also some unrelated fixes to UDF nullability handling as well as a breaking change: UDF String and byte arguments are now expected to be reference types (`&str` and `&[u8]`) rather than owned types so that we can avoid unnecessary copies. 