### PR TITLE
State restoration in pipeline clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "arroyo-openapi",
  "arroyo-rpc",
  "arroyo-server-common",
+ "arroyo-storage",
  "arroyo-types",
  "arroyo-worker",
  "async-trait",

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -158,10 +158,7 @@ async fn compile_sql<'a>(
         },
     )
     .await
-    .map_err(|err| {
-        warn!("{:?}", err);
-        bad_request(err.to_string())
-    })
+    .map_err(|err| bad_request(err.to_string()))
 }
 
 fn set_parallelism(program: &mut LogicalProgram, parallelism: usize) {

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -241,9 +241,9 @@ pub struct Config {
     /// process with a non-standard port.
     compiler_endpoint: Option<Url>,
 
-    /// Supplies the default query for `arroyo run`; otherwise the query is read from the command
-    /// line or from stdin
-    pub query: Option<String>,
+    /// Run options
+    #[serde(default)]
+    pub run: RunConfig,
 
     /// Telemetry config
     #[serde(default)]
@@ -630,6 +630,17 @@ pub enum LogFormat {
     Plaintext,
     Json,
     Logfmt,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct RunConfig {
+    /// Supplies the default query for `arroyo run`; otherwise the query is read from the command
+    /// line or from stdin
+    pub query: Option<String>,
+
+    /// Sets the state directory, where state will be read from and written to
+    pub state_dir: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/arroyo/Cargo.toml
+++ b/crates/arroyo/Cargo.toml
@@ -17,6 +17,7 @@ arroyo-compiler-service = { path = "../arroyo-compiler-service" }
 arroyo-node = { path = "../arroyo-node" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-openapi = { path ="../arroyo-openapi" }
+arroyo-storage = { path = "../arroyo-storage" }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
@@ -29,7 +30,7 @@ postgres-types = { version = "*", features = ["derive"] }
 tokio-postgres = { version = "*", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
 deadpool-postgres = { workspace = true }
 cornucopia_async = { workspace = true }
-rusqlite = "0.31.0"
+rusqlite = {  version = "0.31.0", features = ["backup"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 refinery = { version = "0.8.14" , features = ["tokio-postgres", "rusqlite"] }
 anyhow = { version = "1.0.79"}


### PR DESCRIPTION
This PR reworks the CLI interface for pipeline clusters and adds better support for running stateful pipelines using sqlite on runtimes like fargate.