### PR TITLE
Unify worker and controller images in helm chart

### DIFF
--- a/k8s/arroyo/templates/configmap.yaml
+++ b/k8s/arroyo/templates/configmap.yaml
@@ -57,8 +57,8 @@ data:
           {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 10 }}
           {{- end }}    
-        image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
-        image-pull-policy: "{{ .Values.worker.image.pullPolicy }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image-pull-policy: "{{ .Values.imagePullPolicy }}"
         image-pull-secrets:
         {{- with .Values.imagePullSecrets }}
         {{- toYaml . | nindent 10 }}

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -46,8 +46,8 @@ spec:
       {{- end }}
       initContainers:
       - name: migrate-database
-        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
-        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: [ "/app/arroyo", "--config-dir", "/config", "migrate", "--wait", "300" ]
         volumeMounts:
           - name: arroyo-config
@@ -69,8 +69,8 @@ spec:
       - name: arroyo-controller
         securityContext:
         {{- toYaml .Values.securityContext | nindent 12 }}
-        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
-        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/app/arroyo", "--config-dir", "/config", "cluster"]
 
         env:

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -2,6 +2,11 @@
 
 nameOverride: ""
 fullnameOverride: ""
+
+image:
+  repository: ghcr.io/arroyosystems/arroyo
+  tag: "tip"
+imagePullPolicy: IfNotPresent
 imagePullSecrets: []
 
 controller:
@@ -10,10 +15,7 @@ controller:
     requests:
       memory: 256Mi
       cpu: 500m
-  image:
-    repository: ghcr.io/arroyosystems/arroyo
-    pullPolicy: IfNotPresent
-    tag: "tip"
+
   service:
     grpcPort: 9190
     compilerPort: 9000
@@ -27,10 +29,6 @@ worker:
       memory: 490Mi
       cpu: 900m
   slots: 16
-  image:
-    repository: ghcr.io/arroyosystems/arroyo
-    pullPolicy: IfNotPresent
-    tag: "tip"
 
 postgresql:
   # set to true to deploy a postgres instance in-cluster


### PR DESCRIPTION
Addresses #651 by using the same helm configuration for the controller and worker.

This is a backwards-incompatible change for users overriding the image for the controller or the worker.