### PR TITLE
Change default ports to avoid clashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           killall arroyo
           ARROYO__DISABLE_TELEMETRY=true ARROYO__CHECKPOINT_URL=file:///tmp/arroyo-integ ARROYO__COMPILER__ARTIFACT_URL=file:///tmp/artifacts ARROYO__DATABASE__TYPE=sqlite target/debug/arroyo cluster &
-          timeout=10; while ! nc -z localhost 8000 && [ $timeout -gt 0 ]; do sleep 1; timeout=$((timeout - 1)); done; [ $timeout -gt 0 ]
+          timeout=10; while ! nc -z localhost 5115 && [ $timeout -gt 0 ]; do sleep 1; timeout=$((timeout - 1)); done; [ $timeout -gt 0 ]
           cargo nextest run --package integ -E 'kind(test)'
           
   build-console:

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -19,16 +19,16 @@ checkpoints-to-compact = 4
 
 [api]
 bind-address = "0.0.0.0"
-http-port = 8000
+http-port = 5115
 
 [controller]
 bind-address = "0.0.0.0"
-rpc-port = 9190
+rpc-port = 5116
 scheduler = "process"
 
 [compiler]
 bind-address = "0.0.0.0"
-rpc-port = 9191
+rpc-port = 5117
 install-clang = true
 install-rustc = true
 artifact-url = "/tmp/arroyo/artifacts"
@@ -43,12 +43,12 @@ queue-size = 8192
 
 [node]
 bind-address = "0.0.0.0"
-rpc-port = 9192
+rpc-port = 5118
 task-slots = 16
 
 [admin]
 bind-address = "0.0.0.0"
-http-port = 8001
+http-port = 5114
 
 
 # Schedulers

--- a/crates/integ/tests/api_tests.rs
+++ b/crates/integ/tests/api_tests.rs
@@ -58,7 +58,7 @@ fn get_client() -> Arc<Client> {
                 &format!(
                     "{}/api",
                     env::var("API_ENDPOINT")
-                        .unwrap_or_else(|_| "http://localhost:8000".to_string())
+                        .unwrap_or_else(|_| "http://localhost:5115".to_string())
                 ),
                 client,
             ))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,19 +58,21 @@ COPY --from=builder /arroyo ./
 
 ENV INSTALL_RUSTC=true \
     INSTALL_CLANG=true \
-    ARROYO__API__RUN_HTTP_PORT=8000
+    ARROYO__API__RUN_HTTP_PORT=5115
 
-EXPOSE 8000
+EXPOSE 5115
 ENTRYPOINT [ "/app/arroyo" ]
+CMD ["cluster"]
 
 FROM rust:slim-bookworm AS arroyo-full
 WORKDIR /app
 RUN apt-get update && \
     apt-get -y install libsasl2-2 ca-certificates curl pkg-config
 
-ENV ARROYO__API__RUN_HTTP_PORT=8000
+ENV ARROYO__API__RUN_HTTP_PORT=5115
 
 COPY --from=builder /arroyo ./
 
-EXPOSE 8000
+EXPOSE 5115
 ENTRYPOINT [ "/app/arroyo" ]
+CMD ["cluster"]

--- a/k8s/arroyo/README.md
+++ b/k8s/arroyo/README.md
@@ -53,10 +53,10 @@ $ open "http://$(kubectl get service/arroyo-api -o jsonpath='{.spec.clusterIP}')
 or if that doesn't work, by proxying the service:
 
 ```
-$ kubectl port-forward service/arroyo-api 8000:80 8001:8001
+$ kubectl port-forward service/arroyo-api 5115:80
 ```
 
-and opening http://localhost:8000.
+and opening http://localhost:5115.
 
 
 ## Configuration

--- a/k8s/arroyo/templates/NOTES.txt
+++ b/k8s/arroyo/templates/NOTES.txt
@@ -10,8 +10,8 @@ Once the release is fully deployed, you can navigate to the web ui by running
 
 If that doesn't work (for example on MacOS or a remote Kubernetes cluster), you can also try
 
-  $ kubectl port-forward service/{{ .Release.Name }} 8000:80
+  $ kubectl port-forward service/{{ .Release.Name }} 5115:80
 
-And opening http://localhost:8000 in your browser.
+And opening http://localhost:5115 in your browser.
 
 See the documentation at https://doc.arroyo.dev, and ask questions on our discord: https://discord.gg/cjCr5rVmyR

--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -149,11 +149,11 @@ spec:
     - name: grpc
       protocol: TCP
       port: {{ .Values.controller.service.grpcPort }}
-      targetPort: 9190
+      targetPort: 5116
     - name: admin
       protocol: TCP
       port: {{ .Values.controller.service.adminPort }}
-      targetPort: 9191
+      targetPort: 5114
     - name: http
       protocol: TCP
       port: {{ .Values.controller.service.httpPort }}

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -17,9 +17,9 @@ controller:
       cpu: 500m
 
   service:
-    grpcPort: 9190
-    compilerPort: 9000
-    adminPort: 8001
+    grpcPort: 5116
+    compilerPort: 5117
+    adminPort: 5114
     httpPort: 80
 
 worker:

--- a/webui/src/routes/pipelines/CreatePipeline.tsx
+++ b/webui/src/routes/pipelines/CreatePipeline.tsx
@@ -80,7 +80,7 @@ export function CreatePipeline() {
   const [queryInput, setQueryInput] = useState<string>('');
   const [queryInputToCheck, setQueryInputToCheck] = useState<string | undefined>(undefined);
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [options, setOptions] = useState<SqlOptions>({ parallelism: 4, checkpointMS: 5000 });
+  const [options, setOptions] = useState<SqlOptions>({ parallelism: 1, checkpointMS: 10000 });
   const navigate = useNavigate();
   const [startError, setStartError] = useState<string | null>(null);
   const [tabIndex, setTabIndex] = useState<number>(0);

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: process.env.API_ROOT || 'http://localhost:8000',
+        target: process.env.API_ROOT || 'http://localhost:5115',
       },
     },
   },


### PR DESCRIPTION
Changes the default ports for the Arroyo services to avoid commonly-used ports, in preparation for shipping native packages.

New defaults:
* API HTTP: 5115
* Controller gRPC: 5116
* Compiler gRPC: 5117
* Node gRPC: 5118
* Admin HTTP: 5114