### PR TITLE
Bump udf version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-udf-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-udf-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arrow-schema",
  "arroyo-udf-common",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "arroyo-udf-plugin"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "arroyo-udf-common",

--- a/crates/arroyo-api/src/udfs.rs
+++ b/crates/arroyo-api/src/udfs.rs
@@ -19,7 +19,7 @@ use axum_extra::extract::WithRejection;
 use tonic::transport::Channel;
 use tracing::error;
 
-const PLUGIN_VERSION: &str = "0.1.1";
+const PLUGIN_VERSION: &str = "0.2.0";
 
 const LOCAL_UDF_LIB_CRATE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/crates/arroyo-api/src/udfs.rs
+++ b/crates/arroyo-api/src/udfs.rs
@@ -19,7 +19,7 @@ use axum_extra::extract::WithRejection;
 use tonic::transport::Channel;
 use tracing::error;
 
-const PLUGIN_VERSION: &str = "0.2.0";
+const PLUGIN_VERSION: &str = "=0.2.0";
 
 const LOCAL_UDF_LIB_CRATE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-udf-common"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Arroyo Systems <support@arroyo.systems>"]
 license = "MIT OR Apache-2.0"

--- a/crates/arroyo-udf/arroyo-udf-macros/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-udf-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Arroyo Systems <support@arroyo.systems>"]
 license = "MIT OR Apache-2.0"

--- a/crates/arroyo-udf/arroyo-udf-plugin/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-udf-plugin"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Arroyo Systems <support@arroyo.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The new UDF lib is incompatible with 0.1 and should have been given the version 0.2.0.