### PR TITLE
allow cluster-domain for services to be configured in values.yaml

### DIFF
--- a/k8s/arroyo/templates/_helpers.tpl
+++ b/k8s/arroyo/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Prometheus endpoint
 {{- if .Values.prometheus.endpoint }}
 {{- .Values.prometheus.endpoint }}
 {{- else if .Values.prometheus.deploy -}}
-http://{{- template "prometheus.fullname" . }}-prometheus-server.{{- default .Release.Namespace }}.svc.cluster.local
+http://{{- template "prometheus.fullname" . }}-prometheus-server.{{- default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
 {{- end }}
 

--- a/k8s/arroyo/templates/configmap.yaml
+++ b/k8s/arroyo/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
       type: "postgres"
       postgres:
     {{- if .Values.postgresql.deploy }}
-        host: "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.cluster.local"
+        host: "{{- include "arroyo.fullname" . }}-postgresql.{{- default .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
         port: {{ default "5432" .Values.postgresql.auth.port }}
         database-name: "arroyo"
         user: "arroyo"

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -2,6 +2,7 @@
 
 nameOverride: ""
 fullnameOverride: ""
+clusterDomain: cluster.local
 
 image:
   repository: ghcr.io/arroyosystems/arroyo


### PR DESCRIPTION
the cluster domain is often overridden when multiple clusters are being managed. small patch to allow configuration of this field in the generated manifests.