### PR TITLE
Add support for setting the key and timestamp for messages written to kafka

### DIFF
--- a/crates/arroyo-connectors/src/kafka/sink/test.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/test.rs
@@ -75,9 +75,13 @@ impl KafkaTopicTester {
             bootstrap_servers: self.server.to_string(),
             producer: None,
             consistency_mode: ConsistencyMode::AtLeastOnce,
+            timestamp_field: None,
+            timestamp_col: None,
+            key_field: None,
             write_futures: vec![],
             client_config: HashMap::new(),
             serializer: ArrowSerializer::new(Format::Json(JsonFormat::default())),
+            key_col: None,
         };
 
         let (_, control_rx) = channel(128);

--- a/crates/arroyo-connectors/src/kafka/table.json
+++ b/crates/arroyo-connectors/src/kafka/table.json
@@ -61,6 +61,16 @@
                                 "at_least_once",
                                 "exactly_once"
                             ]
+                        },
+                        "key_field": {
+                            "type": "string",
+                            "title": "key field",
+                            "description": "Field to use to set the key of the message written to Kafka"
+                        },
+                        "timestamp_field": {
+                            "type": "string",
+                            "title": "timestamp field",
+                            "description": "Field to use to set the timestamp of the message written to Kafka; defaults to the event time"
                         }
                     },
                     "additionalProperties": false,

--- a/crates/arroyo-state/src/tables/table_manager.rs
+++ b/crates/arroyo-state/src/tables/table_manager.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use arroyo_rpc::CompactionResult;
 use arroyo_rpc::{
     grpc::rpc::{
@@ -11,14 +11,13 @@ use arroyo_rpc::{
     },
     CheckpointCompleted, ControlResp,
 };
-use arroyo_storage::{StorageProvider, StorageProviderRef};
+use arroyo_storage::StorageProviderRef;
 use arroyo_types::{to_micros, CheckpointBarrier, Data, Key, TaskInfoRef};
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     oneshot,
 };
 
-use arroyo_rpc::config::config;
 use tracing::{debug, error, info, warn};
 
 use crate::{get_storage_provider, tables::global_keyed_map::GlobalKeyedTable, StateMessage};


### PR DESCRIPTION
Addresses #696

This PR allows users to set the key and timestamp of messages written to Kafka, based on a field in the data. This is similar to how the output is controlled for the redis sink. This is accomplished by adding two new optional configs for the kafka sink, `sink.timestamp_field` and `sink.key_field`.

A (somewhat silly) example of what this looks like in SQL:

```sql
create table impulse with (
    connector = 'impulse',
    event_rate = '10'
);

create table sink (
    i BIGINT,
    k TEXT,
    ts TIMESTAMP NOT NULL
) with (
    connector = 'kafka',
    bootstrap_servers = 'localhost:9092',
    format = 'json',
    'sink.timestamp_field' = 'ts',
    'sink.key_field' = 'k',
    type = 'sink',
    topic = 'timestamped'
);


insert into sink
select counter, concat('k', counter), from_unixtime(counter + 1722300386)
from impulse;
```