### PR TITLE
Fix race condition that could stall scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7093,9 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7106,19 +7106,20 @@ dependencies = [
  "futures-util",
  "itoa",
  "log",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
+ "rustls 0.23.12",
+ "rustls-native-certs 0.7.1",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tokio-retry",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "url",
 ]

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -61,7 +61,7 @@ tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 reqwest = { version = "0.11.20", features = ["stream"] }
 
 # Redis
-redis = { version = "0.24.0", features = ["default", "tokio-rustls-comp", "cluster-async", "connection-manager"] }
+redis = { version = "0.26.0", features = ["default", "tokio-rustls-comp", "cluster-async", "connection-manager"] }
 
 # Fluvio
 fluvio = {version = "0.23", features = ["openssl"]}

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -1,7 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
-
 use anyhow::{anyhow, bail};
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector};
@@ -11,6 +9,7 @@ use redis::aio::ConnectionManager;
 use redis::cluster::ClusterClient;
 use redis::{Client, ConnectionInfo, IntoConnectionInfo};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tokio::sync::oneshot::Receiver;
 use typify::import_types;
 
@@ -113,7 +112,7 @@ async fn test_inner(
     match &client {
         RedisClient::Standard(client) => {
             let mut connection = client
-                .get_async_connection()
+                .get_multiplexed_async_connection()
                 .await
                 .map_err(|e| anyhow!("Failed to connect to to Redis Cluster: {:?}", e))?;
             tx.send(TestSourceMessage::info(

--- a/crates/arroyo-connectors/src/redis/operator/sink.rs
+++ b/crates/arroyo-connectors/src/redis/operator/sink.rs
@@ -197,11 +197,7 @@ impl RedisWriter {
         }
 
         while attempts < 20 {
-            match self
-                .pipeline
-                .query_async::<_, ()>(&mut self.connection)
-                .await
-            {
+            match self.pipeline.query_async::<()>(&mut self.connection).await {
                 Ok(_) => {
                     self.pipeline.clear();
                     self.size_estimate = 0;
@@ -219,7 +215,7 @@ impl RedisWriter {
             }
 
             tokio::time::sleep(Duration::from_millis((50 * (1 << attempts)).min(5_000))).await;
-            attempts -= 1;
+            attempts += 1;
         }
 
         panic!("Exhausted retries writing to Redis");
@@ -319,7 +315,7 @@ impl ArrowOperator for RedisSinkFunc {
             }
 
             tokio::time::sleep(Duration::from_millis((50 * (1 << attempts)).min(5_000))).await;
-            attempts -= 1;
+            attempts += 1;
         }
 
         panic!("Failed to establish connection to redis after 20 retries");

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -438,8 +438,16 @@ impl ControllerGrpc for ControllerServer {
         &self,
         request: Request<WorkerErrorReq>,
     ) -> Result<Response<WorkerErrorRes>, Status> {
-        info!("Got worker error.");
         let req = request.into_inner();
+
+        info!(
+            job_id = req.job_id,
+            operator_id = req.operator_id,
+            message = "operator error",
+            error_message = req.message,
+            error_details = req.details
+        );
+
         let client = self.db.client().await.unwrap();
         match queries::controller_queries::execute_create_job_log_message(
             &client,

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -89,6 +89,16 @@ impl OperatorNode {
                     "Running source {}-{}",
                     ctx.task_info.operator_name, ctx.task_info.task_index
                 );
+
+                ctx.control_tx
+                    .send(ControlResp::TaskStarted {
+                        operator_id: ctx.task_info.operator_id.clone(),
+                        task_index: ctx.task_info.task_index,
+                        start_time: SystemTime::now(),
+                    })
+                    .await
+                    .unwrap();
+
                 let result = s.run(ctx).await;
 
                 s.on_close(ctx).await;
@@ -193,6 +203,15 @@ async fn operator_run_behavior(
         "Running operator {}-{}",
         ctx.task_info.operator_name, ctx.task_info.task_index
     );
+
+    ctx.control_tx
+        .send(ControlResp::TaskStarted {
+            operator_id: ctx.task_info.operator_id.clone(),
+            task_index: ctx.task_info.task_index,
+            start_time: SystemTime::now(),
+        })
+        .await
+        .unwrap();
 
     let task_info = ctx.task_info.clone();
     let name = this.name();

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -738,14 +738,6 @@ impl Engine {
 
         let send_copy = control_tx.clone();
         tokio::spawn(async move {
-            send_copy
-                .send(ControlResp::TaskStarted {
-                    operator_id: operator_id.clone(),
-                    task_index,
-                    start_time: SystemTime::now(),
-                })
-                .await
-                .unwrap();
             if let Err(error) = join_task.await {
                 send_copy
                     .send(ControlResp::TaskFailed {


### PR DESCRIPTION
During scheduling, the controller sends the task assignments to the workers then waits for the tasks to start up. Each worker engine then constructs its graph and starts of the "local nodes"—i.e., the ones that it is responsible for running.

Each operator on startup follows these steps:

1. Notify the controller of task startup
2. Call `on_start`
3. Wait for all other operators to have started
4. Call `run`

If any of these steps panic, a TaskFailed message is sent to the controller.

However, if an operator panicked in step 2 at the wrong time, the pipeline could end up stuck while the controller thought it was healthy in the running state.

Why?

* The controller determined that the pipeline was ready when it received all of the task start notifications, but those are sent upfront
* A failed operator will close its queues, which should cause a cascade of panics that shuts down the pipeline cleanly. However, if it panics during on_start, no other operator will be started up because they are waiting for all operators to wait on the barrier (step 3) so they will never try to produce messages to the closed queue
* The failed task will send a TaskFailed message to the controller, but because this is a "RunningMessage," it's ignored in scheduling

For the problem to occur, all three three issues are required.

This PR fixes the first and third issue, and ensures that a pipeline will either get into a true running state or fail and get restarted by the controller:

* We now send TaskStarted notifications after `on_start`, once the operators are actually running; this means that we won't transition to running until the operators are actually running
* The scheduling state now handles TaskFailed notifications and will restart scheduling on receiving one

Fixing the second issue—for example by allowing the barrier to be canceled on panic—is left as a future improvement.