### PR TITLE
fix: fix recursion limit reached decode error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ deltalake = { version = "0.18.2" }
 cornucopia = { version = "0.9.0" }
 cornucopia_async = {version = "0.6.0"}
 deadpool-postgres = "0.12"
-prost = "0.12"
+prost = { version = "0.12", features = ["no-recursion-limit"] }
 prost-reflect = "0.12.0"
 prost-build = {version = "0.12" }
 prost-types = "0.12"


### PR DESCRIPTION
I meeting a decode error (in arroyo-worker), when I input sql with very long predicate expr in When clause. (in our case, we have converted filter node to another extension node).
```text
2024-08-09T10:46:29.901975Z ERROR arroyo_server_common: crates/arroyo-server-common/src/lib.rs:133: panicked at crates/arroyo-worker/src/arrow/express
ion_match.rs:105:88:
called `Result::unwrap()` on an `Err` value: DecodeError { description: "recursion limit reached", stack: [("PhysicalExprNode", "expr_type"), ("Physic
alBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNo
de", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("P
hysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNod
e", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type
"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("Physical
BinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode
", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("Phy
sicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode"
, "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type")
, ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBi
naryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode",
"l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("Physi
calExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode",
"expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"),
("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBina
ryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "
l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("Physica
lExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "e
xpr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("
PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinary
ExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"
), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type"), ("PhysicalBinaryExprNode", "r"), ("PhysicalE
xprNode", "expr_type"), ("PhysicalBinaryExprNode", "l"), ("PhysicalExprNode", "expr_type")] } panic.file="crates/arroyo-worker/src/arrow/expression_ma
tch.rs" panic.line=105 panic.column=88
```
I dig out that the error is throwed from `prost` crate (see below code). and this limit is only available when missing `no-recursion-limit` feature in `Cargo.toml`.

https://github.com/tokio-rs/prost/blob/d38072f5962e29b0cb1ebef6038510c54fa13ca7/prost/src/encoding.rs#L82-L90

Whether add `no-recursion-limit` feature to handle this case?
