### PR TITLE
Allow setting worker environment variables in kubernetes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shlex",
  "syn 2.0.72",
  "thiserror",
  "time",
@@ -8252,6 +8253,12 @@ checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/arroyo-controller/Cargo.toml
+++ b/crates/arroyo-controller/Cargo.toml
@@ -44,6 +44,7 @@ anyhow = "1.0.70"
 kube = { version = "0.91", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.22.0", features = ["v1_30"] }
 serde_yaml = {version = "0.9"}
+shlex = "1.3"
 
 # json-schema support
 serde_json = "1.0"

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -116,6 +116,12 @@ impl KubernetesScheduler {
             }));
         }
 
+        for var in &config().kubernetes_scheduler.worker.env {
+            env.as_array_mut()
+                .unwrap()
+                .push(serde_json::to_value(var).unwrap());
+        }
+
         let owner: Vec<_> = config()
             .kubernetes_scheduler
             .controller
@@ -123,11 +129,7 @@ impl KubernetesScheduler {
             .cloned()
             .collect();
 
-        let command: Vec<_> = c
-            .worker
-            .command
-            .split(|w: char| w.is_whitespace())
-            .collect();
+        let command: Vec<_> = shlex::split(&c.worker.command).expect("cannot split command");
 
         serde_json::from_value(json!({
             "apiVersion": "v1",


### PR DESCRIPTION
Adds support for setting env vars on the kubernetes workers via config, for example:

configmap.yaml
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-arroyo-config
data:
  config.yaml: |
    kubernetes-scheduler:
      worker:
        env:
          - name: AWS_DEFAULT_REGION
            value: us-east-1
          - name: AWS_ACCESS_KEY_ID
            value: "AJKSDJLAKJSDALKSJD"
          - name: AWS_SECRET_ACCESS_KEY
            value: "214124jHJhkjh1212aasd"
```

values.yaml
```yaml
existingConfigMap: "my-arroyo-config"
```
