### PR TITLE
minor: change ouput_schema

### DIFF
--- a/crates/arroyo-planner/src/extension/key_calculation.rs
+++ b/crates/arroyo-planner/src/extension/key_calculation.rs
@@ -110,7 +110,7 @@ impl ArroyoExtension for KeyCalculationExtension {
     }
 
     fn output_schema(&self) -> ArroyoSchema {
-        let arrow_schema = Arc::new(self.input.schema().as_ref().into());
+        let arrow_schema = Arc::new(self.schema().as_ref().into());
         ArroyoSchema::from_schema_keys(arrow_schema, self.keys.clone()).unwrap()
     }
 }


### PR DESCRIPTION
It's may be not right for `KeyCalculationExtension`.output_schema. I notice that output_schema is depend on `self.input.schema`
https://github.com/ArroyoSystems/arroyo/blob/68fb412bfd15e706e59cbaac8295942d30badfee/crates/arroyo-planner/src/extension/key_calculation.rs#L112-L115
But according to func `new_named_and_trimmed`, the schema of `KeyCaclculationExtension` may not equal to `self.input.schema`
https://github.com/ArroyoSystems/arroyo/blob/68fb412bfd15e706e59cbaac8295942d30badfee/crates/arroyo-planner/src/extension/key_calculation.rs#L39-L57  