### PR TITLE
feat: using NodePort export svc in k8s

### DIFF
--- a/k8s/arroyo/templates/controller.yaml
+++ b/k8s/arroyo/templates/controller.yaml
@@ -143,6 +143,7 @@ kind: Service
 metadata:
   name: {{ include "arroyo.fullname" . }}
 spec:
+  type: NodePort
   selector:
     app: {{ include "arroyo.fullname" . }}-controller
   ports:
@@ -150,11 +151,14 @@ spec:
       protocol: TCP
       port: {{ .Values.controller.service.grpcPort }}
       targetPort: grpc
+      nodePort: {{ .Values.controller.service.grpcNodePort }}
     - name: admin
       protocol: TCP
       port: {{ .Values.controller.service.adminPort }}
       targetPort: admin
+      nodePort: {{ .Values.controller.service.adminNodePort }}
     - name: http
       protocol: TCP
       port: {{ .Values.controller.service.httpPort }}
       targetPort: http
+      nodePort: {{ .Values.controller.service.httpNodePort }}

--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -22,6 +22,10 @@ controller:
     compilerPort: 5117
     adminPort: 5114
     httpPort: 80
+    # node port export to used by users outside the cluster
+    grpcNodePort: 31116
+    adminNodePort: 31114
+    httpNodePort: 31115
 
 worker:
   resources:


### PR DESCRIPTION
original arroyo-controller, I can't access service outsize of k8s cluster. I think can using NodePort to export arroyo service. I notice that print NOTE using `kubectl port-forward service/arroyo 5115:80` It's hard to use, because `kubectl port-forward` won't return and not daemon cmd. 