### PR TITLE
Upgrade kinesis dependency to avoid multiple AWS client versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
  "async-compression",
  "async-nats",
  "async-trait",
- "aws-config 0.51.0",
+ "aws-config",
  "aws-sdk-kinesis",
  "axum",
  "base64 0.13.1",
@@ -1003,7 +1003,7 @@ dependencies = [
  "arroyo-rpc",
  "arroyo-types",
  "async-trait",
- "aws-config 1.5.5",
+ "aws-config",
  "aws-credential-types",
  "bytes",
  "futures",
@@ -1342,7 +1342,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "regex",
- "ring 0.17.8",
+ "ring",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
@@ -1515,55 +1515,27 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "0.51.0"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a636c44c77fa18bdba56126a34d30cfe5538fe88f7d34988fa731fee143ddd"
-dependencies = [
- "aws-http",
- "aws-sdk-sso 0.21.0",
- "aws-sdk-sts 0.21.0",
- "aws-smithy-async 0.51.0",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-types 0.51.0",
- "bytes",
- "hex",
- "http 0.2.12",
- "hyper 0.14.28",
- "ring 0.16.20",
- "time",
- "tokio",
- "tower",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-config"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+checksum = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso 1.39.0",
+ "aws-sdk-sso",
  "aws-sdk-ssooidc",
- "aws-sdk-sts 1.39.0",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
- "aws-smithy-json 0.60.7",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
- "ring 0.17.8",
+ "ring",
  "time",
  "tokio",
  "tracing",
@@ -1573,61 +1545,30 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
- "aws-smithy-async 1.2.1",
+ "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "zeroize",
 ]
 
 [[package]]
-name = "aws-endpoint"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca8f374874f6459aaa88dc861d7f5d834ca1ff97668eae190e97266b5f6c3fb"
-dependencies = [
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-types 0.51.0",
- "http 0.2.12",
- "regex",
- "tracing",
-]
-
-[[package]]
-name = "aws-http"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d41e19e779b73463f5f0c21b3aacc995f4ba783ab13a7ae9f5dfb159a551b4"
-dependencies = [
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-types 0.51.0",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "lazy_static",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-runtime"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
 dependencies = [
  "aws-credential-types",
- "aws-sigv4 1.2.3",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "fastrand 2.1.0",
  "http 0.2.12",
@@ -1647,13 +1588,13 @@ checksum = "281c887364ff494a6ce0b492b03da5fa7729da004dbb875e2c81aceb24debe89"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "fastrand 2.1.0",
  "http 0.2.12",
@@ -1664,63 +1605,41 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.21.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37766fdf50feab317b4f939b1c9ee58a2a1c51785974328ce84cff1eea7a1bb8"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async 0.51.0",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-types 0.51.0",
- "bytes",
- "http 0.2.12",
- "tokio-stream",
- "tower",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dcb1cb71aa8763b327542ead410424515cff0cde5b753eedd2917e09c63734"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async 0.51.0",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-types 0.51.0",
- "bytes",
- "http 0.2.12",
- "tokio-stream",
- "tower",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11822090cf501c316c6f75711d77b96fba30658e3867a7762e5e2f5d32d31e81"
+checksum = "e4cb8ebae55e016a5404398bb5f83e8124fc3bfc0dba1fe6022d3221e8f2548c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1730,19 +1649,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.40.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a2a06ff89176123945d1bbe865603c4d7101bea216a550bb4d2e4e9ba74d74"
+checksum = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1752,43 +1671,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.21.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfcf584297c666f6b472d5368a78de3bc714b6e0a53d7fbf76c3e347c292ab1"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async 0.51.0",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower",
- "aws-smithy-query 0.51.0",
- "aws-smithy-types 0.51.0",
- "aws-smithy-xml 0.51.0",
- "aws-types 0.51.0",
- "bytes",
- "http 0.2.12",
- "tower",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20a91795850826a6f456f4a48eff1dfa59a0e69bdbf5b8c50518fd372106574"
+checksum = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
- "aws-smithy-json 0.60.7",
- "aws-smithy-query 0.60.7",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
- "aws-smithy-xml 0.60.8",
- "aws-types 1.3.3",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1796,46 +1693,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sig-auth"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
-dependencies = [
- "aws-sigv4 0.51.1",
- "aws-smithy-http 0.51.0",
- "aws-types 0.51.0",
- "http 0.2.12",
- "tracing",
-]
-
-[[package]]
 name = "aws-sigv4"
-version = "0.51.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0b2658d2cb66dbf02f0e8dee80810ef1e0ca3530ede463e0ef994c301087d1"
-dependencies = [
- "aws-smithy-http 0.51.0",
- "form_urlencoded",
- "hex",
- "http 0.2.12",
- "once_cell",
- "percent-encoding",
- "regex",
- "ring 0.16.20",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.60.11",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -1851,18 +1717,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "aws-smithy-async"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
@@ -1873,57 +1727,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-client"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
-dependencies = [
- "aws-smithy-async 0.51.0",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower",
- "aws-smithy-types 0.51.0",
- "bytes",
- "fastrand 1.9.0",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-tls",
- "pin-project-lite",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
-dependencies = [
- "aws-smithy-types 0.51.0",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http"
 version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1934,30 +1744,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
-dependencies = [
- "aws-smithy-http 0.51.0",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "pin-project-lite",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8324ba98c8a94187723cc16c37aefa09504646ee65c3d2c3af495bab5ea701b"
-dependencies = [
- "aws-smithy-types 0.51.0",
 ]
 
 [[package]]
@@ -1966,17 +1752,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.2.6",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
-dependencies = [
- "aws-smithy-types 0.51.0",
- "urlencoding",
+ "aws-smithy-types",
 ]
 
 [[package]]
@@ -1985,7 +1761,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "urlencoding",
 ]
 
@@ -1995,10 +1771,10 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
- "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.11",
+ "aws-smithy-async",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "bytes",
  "fastrand 2.1.0",
  "h2 0.3.26",
@@ -2022,8 +1798,8 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
- "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -2031,18 +1807,6 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
-dependencies = [
- "itoa",
- "num-integer",
- "ryu",
- "time",
 ]
 
 [[package]]
@@ -2073,36 +1837,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.51.0"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f83dd1fdf5d347fa30ae4ad30a9d1d42ce4cd74a93d94afa874646f94cd"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
 dependencies = [
  "xmlparser",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
-dependencies = [
- "aws-smithy-async 0.51.0",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
- "http 0.2.12",
- "rustc_version",
- "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -2112,9 +1851,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-async 1.2.1",
+ "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.6",
+ "aws-smithy-types",
  "rustc_version",
  "tracing",
 ]
@@ -3516,10 +3255,10 @@ version = "0.1.2"
 source = "git+https://github.com/delta-io/delta-rs?rev=e75a0b49b40f35ed361444bbea0e5720f359d732#e75a0b49b40f35ed361444bbea0e5720f359d732"
 dependencies = [
  "async-trait",
- "aws-config 1.5.5",
+ "aws-config",
  "aws-credential-types",
  "aws-sdk-dynamodb",
- "aws-sdk-sts 1.39.0",
+ "aws-sdk-sts",
  "aws-smithy-runtime-api",
  "backoff",
  "bytes",
@@ -6147,7 +5886,7 @@ dependencies = [
  "quick-xml",
  "rand 0.8.5",
  "reqwest 0.12.5",
- "ring 0.17.8",
+ "ring",
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
@@ -7227,7 +6966,7 @@ checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring",
  "rustc-hash",
  "rustls 0.23.8",
  "slab",
@@ -7679,21 +7418,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -7703,7 +7427,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -7933,7 +7657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -7946,7 +7670,7 @@ checksum = "79adb16721f56eb2d843e67676896a61ce7a0fa622dc18d3e372477a029d2740"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
  "subtle",
@@ -8009,8 +7733,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -8019,9 +7743,9 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -8104,8 +7828,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -9684,12 +9408,6 @@ checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -10000,8 +9718,8 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ prost = { version = "0.12", features = ["no-recursion-limit"] }
 prost-reflect = "0.12.0"
 prost-build = {version = "0.12" }
 prost-types = "0.12"
+aws-config = "1.5.6"
 
 [profile.release]
 debug = 1

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -71,8 +71,8 @@ fluvio = {version = "0.23", features = ["openssl"]}
 fluvio-future = "0.7"
 
 # Kinesis
-aws-sdk-kinesis = { version = "0.21", default-features = false, features = ["rt-tokio", "native-tls"] }
-aws-config = { version = "0.51", default-features = false, features = ["rt-tokio", "native-tls"] }
+aws-sdk-kinesis = { version = "1.44" }
+aws-config = { workspace = true }
 uuid = { version = "1.7.0", features = ["v4"] }
 
 # Filesystem

--- a/crates/arroyo-connectors/src/kinesis/sink.rs
+++ b/crates/arroyo-connectors/src/kinesis/sink.rs
@@ -1,22 +1,24 @@
-use std::time::{Duration, SystemTime};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use arrow::array::RecordBatch;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::context::ArrowContext;
 use arroyo_operator::operator::ArrowOperator;
+use arroyo_rpc::retry;
 use arroyo_types::CheckpointBarrier;
 use async_trait::async_trait;
-use aws_config::from_env;
-use aws_sdk_kinesis::{
-    client::fluent_builders::PutRecords, model::PutRecordsRequestEntry, types::Blob,
-    Client as KinesisClient, Region,
-};
+use aws_config::{from_env, Region};
+use aws_sdk_kinesis::primitives::Blob;
+use aws_sdk_kinesis::types::PutRecordsRequestEntry;
+use aws_sdk_kinesis::Client as KinesisClient;
 use tracing::warn;
 use uuid::Uuid;
 
 pub struct KinesisSinkFunc {
-    pub client: Option<KinesisClient>,
+    pub client: Option<Arc<KinesisClient>>,
     pub aws_region: Option<String>,
     pub in_progress_batch: Option<BatchRecordPreparer>,
     pub flush_config: FlushConfig,
@@ -35,103 +37,72 @@ impl ArrowOperator for KinesisSinkFunc {
         if let Some(region) = &self.aws_region {
             loader = loader.region(Region::new(region.clone()));
         }
-        self.client = Some(KinesisClient::new(&loader.load().await));
+
+        let client = Arc::new(KinesisClient::new(&loader.load().await));
+        self.client = Some(client.clone());
+
+        self.in_progress_batch = Some(BatchRecordPreparer::new(client, self.name.clone()));
     }
 
-    async fn process_batch(&mut self, batch: RecordBatch, _ctx: &mut ArrowContext) {
-        let mut batch_preparer = match self.in_progress_batch.take() {
-            None => BatchRecordPreparer::new(
-                self.client
-                    .as_ref()
-                    .unwrap()
-                    .put_records()
-                    .stream_name(self.name.clone()),
-            ),
-            Some(batch_preparer) => batch_preparer,
-        };
-
+    async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut ArrowContext) {
         for v in self.serializer.serialize(&batch) {
-            batch_preparer.add_record(Uuid::new_v4().to_string(), v);
-        }
-
-        if self.flush_config.should_flush(&batch_preparer) {
-            self.flush_with_retries(batch_preparer)
+            self.in_progress_batch
+                .as_mut()
+                .unwrap()
+                .add_record(Uuid::new_v4().to_string(), v);
+            self.maybe_flush_with_retries(ctx)
                 .await
                 .expect("failed to flush batch during processing");
-        } else {
-            self.in_progress_batch = Some(batch_preparer);
         }
     }
 
     async fn handle_checkpoint(&mut self, _: CheckpointBarrier, _: &mut ArrowContext) {
-        if let Some(batch_preparer) = self.in_progress_batch.take() {
-            batch_preparer
-                .flush()
-                .await
-                .expect("failed to flush batch during checkpoint");
-        }
+        retry!(
+            self.in_progress_batch.as_mut().unwrap().flush().await,
+            30,
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+            |e| warn!("{}", e)
+        )
+        .expect("could not flush to Kinesis during checkpointing");
     }
 
-    async fn handle_tick(&mut self, _: u64, _ctx: &mut ArrowContext) {
-        let Some(batch_preparer) = &self.in_progress_batch else {
-            return;
-        };
-
-        if !self.flush_config.should_flush(batch_preparer) {
-            return;
-        }
-        let in_progress_batch = self.in_progress_batch.take().unwrap();
-
-        self.flush_with_retries(in_progress_batch)
+    async fn handle_tick(&mut self, _: u64, ctx: &mut ArrowContext) {
+        self.maybe_flush_with_retries(ctx)
             .await
             .expect("failed to flush batch during tick");
     }
 }
 
 impl KinesisSinkFunc {
-    async fn flush_with_retries(
-        &mut self,
-        mut record_batch_preparer: BatchRecordPreparer,
-    ) -> Result<()> {
-        let mut retries = 0;
-        loop {
-            let vectors_to_retry = record_batch_preparer.flush().await?;
-            if vectors_to_retry.is_empty() {
-                return Ok(());
-            } else {
-                retries += 1;
-                warn!("failed to flush batch, retry attempt: {}", retries);
-                tokio::time::sleep(std::time::Duration::from_millis(2000.min(100 << retries)))
-                    .await;
-                record_batch_preparer = self.take_or_create_batch_preparer().await;
-                for (k, v) in vectors_to_retry {
-                    record_batch_preparer.add_record(k, v);
-                }
-            }
+    async fn maybe_flush_with_retries(&mut self, ctx: &mut ArrowContext) -> Result<()> {
+        if !self
+            .flush_config
+            .should_flush(self.in_progress_batch.as_ref().unwrap())
+        {
+            return Ok(());
         }
-    }
 
-    async fn take_or_create_batch_preparer(&mut self) -> BatchRecordPreparer {
-        match self.in_progress_batch.take() {
-            None => BatchRecordPreparer::new(
-                self.client
-                    .as_ref()
-                    .unwrap()
-                    .put_records()
-                    .stream_name(self.name.clone()),
-            ),
-            Some(batch_preparer) => batch_preparer,
-        }
+        retry!(
+            self.in_progress_batch.as_mut().unwrap().flush().await,
+            20,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+            |e| ctx
+                .report_error("failed to write to Kinesis", format!("{:?}", e))
+                .await
+        )?;
+
+        Ok(())
     }
 }
 
 pub struct BatchRecordPreparer {
-    // TODO: figure out how to not need an option
-    put_records_call: Option<PutRecords>,
+    client: Arc<KinesisClient>,
+    stream: String,
     buffered_records: Vec<(String, Vec<u8>)>,
-    record_count: usize,
     data_size: usize,
-    creation_time: SystemTime,
+    last_flush_time: Instant,
 }
 
 pub struct FlushConfig {
@@ -148,70 +119,98 @@ impl FlushConfig {
     ) -> Self {
         Self {
             max_record_count: records_per_batch.unwrap_or(500) as usize,
-            max_data_size: max_buffer_size.unwrap_or(4_500_000) as usize,
+            max_data_size: max_buffer_size.unwrap_or(4_000_000) as usize,
             max_age: Duration::from_millis(flush_interval_millis.unwrap_or(1000) as u64),
         }
     }
 
     fn should_flush(&self, batch_preparer: &BatchRecordPreparer) -> bool {
-        batch_preparer.record_count >= self.max_record_count
+        batch_preparer.buffered_records.len() >= self.max_record_count
             || batch_preparer.data_size >= self.max_data_size
-            || batch_preparer.creation_time.elapsed().unwrap_or_default() >= self.max_age
+            || batch_preparer.last_flush_time.elapsed() >= self.max_age
     }
 }
 
 impl BatchRecordPreparer {
-    fn new(put_records_call: PutRecords) -> Self {
+    fn new(client: Arc<KinesisClient>, name: String) -> Self {
         Self {
-            put_records_call: Some(put_records_call),
+            client,
+            stream: name,
             buffered_records: Vec::new(),
-            record_count: 0,
             data_size: 0,
-            creation_time: SystemTime::now(),
+            last_flush_time: Instant::now(),
         }
     }
     fn add_record(&mut self, key: String, value: Vec<u8>) {
-        self.buffered_records.push((key.clone(), value.clone()));
-        let blob = Blob::new(value);
-        self.data_size += blob.as_ref().len();
-        let put_record_request = PutRecordsRequestEntry::builder()
-            .data(blob)
-            .partition_key(key)
-            .build();
-        self.put_records_call = self
-            .put_records_call
-            .take()
-            .map(|call| call.records(put_record_request));
-        self.record_count += 1;
+        self.data_size += value.len() + key.len();
+        self.buffered_records.push((key, value));
     }
 
-    async fn flush(mut self) -> Result<Vec<(String, Vec<u8>)>> {
-        if self.record_count == 0 {
-            return Ok(Vec::new());
+    async fn flush(&mut self) -> Result<()> {
+        if self.buffered_records.is_empty() {
+            return Ok(());
         }
-        let response = self.put_records_call.take().unwrap().send().await?;
+
+        let response = self
+            .client
+            .put_records()
+            .stream_name(self.stream.clone())
+            .set_records(Some(
+                self.buffered_records
+                    .iter()
+                    .map(|(k, v)| {
+                        PutRecordsRequestEntry::builder()
+                            .partition_key(k)
+                            .data(Blob::new(v.clone()))
+                            .build()
+                            // cannot occur when partition key and data are supplied
+                            .unwrap()
+                    })
+                    .collect(),
+            ))
+            .send()
+            .await?;
+
+        self.last_flush_time = Instant::now();
+
         let failed_record_count = response.failed_record_count().unwrap_or(0);
-        if failed_record_count > 0 {
-            warn!(
-                "batch write had {} failed responses out of {}",
-                failed_record_count, self.record_count
-            );
-            let records_to_retry = response
-                .records()
-                .unwrap()
-                .iter()
-                .enumerate()
-                .filter_map(|(i, record)| {
-                    if record.error_code().is_some() {
-                        Some(self.buffered_records[i].clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            Ok(records_to_retry)
-        } else {
-            Ok(Vec::new())
+        if failed_record_count == 0 {
+            self.buffered_records.clear();
+            self.data_size = 0;
+            return Ok(());
         }
+
+        let records_to_retry: HashSet<_> = response
+            .records()
+            .iter()
+            .enumerate()
+            .filter_map(|(i, record)| {
+                if record.error_code().is_some() {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        self.buffered_records = self
+            .buffered_records
+            .drain(..)
+            .enumerate()
+            .filter(|(i, _)| records_to_retry.contains(i))
+            .map(|(_, v)| v)
+            .collect();
+
+        self.data_size = self
+            .buffered_records
+            .iter()
+            .map(|(k, v)| k.len() + v.len())
+            .sum();
+
+        bail!(
+            "batch write had {} failed responses out of {}",
+            failed_record_count,
+            self.buffered_records.len()
+        )
     }
 }

--- a/crates/arroyo-connectors/src/kinesis/table.json
+++ b/crates/arroyo-connectors/src/kinesis/table.json
@@ -48,7 +48,7 @@
                             "type": "integer",
                             "title": "Batch Max Size (bytes)",
                             "description": "The maximum size of a batch of records to write to Kinesis",
-                            "maximum": 5000000
+                            "maximum": 4000000
                         },
                         "batch_flush_interval_millis": {
                             "type": "integer",

--- a/crates/arroyo-storage/Cargo.toml
+++ b/crates/arroyo-storage/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.4.0"
 tracing = "0.1"
 
 aws-credential-types = "1.2.0"
-aws-config = { version = "1.5.4" }
+aws-config = { workspace = true }
 rand = "0.8"
 object_store = {workspace = true, features = ["aws", "gcp"]}
 regex = "1.9.5"


### PR DESCRIPTION
This should speed up compilation and reduce binary size (as aws-client is one of our slowest to compile and biggest dependencies).

Also refactors the flushing logic a bit to use our new `retry!` macro, and fixes a regression from 0.10 that could cause failed flushes if a batch was too big.