### PR TITLE
feat: support record cpu profile

### DIFF
--- a/crates/arroyo-server-common/Cargo.toml
+++ b/crates/arroyo-server-common/Cargo.toml
@@ -36,5 +36,10 @@ toml = "0.8.13"
 dirs = "5.0.1"
 uuid = { version = "1.8.0", features = ["v4"] }
 
+# profile
+flate2 = "1.0.30"
+pprof = { version = "0.13.0", features = ["flamegraph", "protobuf-codec"] }
+serde = { version = "1.0.96", features = ["derive"] }
+
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 
+mod profile;
 pub mod shutdown;
 
 use anyhow::anyhow;
@@ -13,6 +14,7 @@ use axum::Router;
 use hyper::Body;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
+use profile::handle_get_profile;
 use prometheus::{register_int_counter, Encoder, IntCounter, ProtobufEncoder, TextEncoder};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -292,6 +294,7 @@ pub async fn start_admin_server(service: &str) -> anyhow::Result<()> {
         .route("/details", get(details))
         .route("/config", get(config_route))
         .route("/debug/pprof/heap", get(handle_get_heap))
+        .route("/debug/pprof/profile", get(handle_get_profile))
         .with_state(state);
 
     let addr = SocketAddr::new(addr, port);

--- a/crates/arroyo-server-common/src/profile.rs
+++ b/crates/arroyo-server-common/src/profile.rs
@@ -1,0 +1,59 @@
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use pprof::{protos::Message, ProfilerGuardBuilder};
+use std::time::Duration;
+use tokio::time::sleep;
+
+pub async fn handle_get_profile(
+    Query(params): Query<ProfileParams>,
+) -> Result<Response, StatusCode> {
+    let frequency = params.frequency.unwrap_or(3000);
+    let duration = params.duration.unwrap_or(30);
+    match generate_profile(frequency, duration).await {
+        Ok(body) => Ok((
+            StatusCode::OK,
+            [("Content-Type", "application/octet-stream")],
+            [(
+                "Content-Disposition",
+                "attachment; filename=\"profile.pb.gz\"",
+            )],
+            body,
+        )
+            .into_response()),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+#[derive(serde::Deserialize)]
+pub struct ProfileParams {
+    /// CPU profile collecting frequency, unit: Hz
+    pub frequency: Option<i32>,
+    /// CPU profile collecting duration, unit: second
+    pub duration: Option<u64>,
+}
+
+async fn generate_profile(
+    frequency: i32,
+    duration: u64,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let guard = ProfilerGuardBuilder::default()
+        .frequency(frequency)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()?;
+
+    sleep(Duration::from_secs(duration)).await;
+
+    let profile = guard.report().build()?.pprof()?;
+
+    let mut body = Vec::new();
+    let mut encoder = GzEncoder::new(&mut body, Compression::default());
+
+    profile.write_to_writer(&mut encoder)?;
+    encoder.finish()?;
+    Ok(body)
+}


### PR DESCRIPTION
This PR can help us analyze CPU performance through pprof, I have written a new route `/debug/pprof/profile` to bind to the original admin HTTP service. We can use the following method to obtain the profile file.

```shell
root@arroyo-worker-job-fuybkun7nu-15-0:/app# curl -v http://127.0.0.1:6901/debug/pprof/profile?duration=60 --output profile.pb.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:6901...
* Connected to 127.0.0.1 (127.0.0.1) port 6901 (#0)
> GET /debug/pprof/profile?duration=60 HTTP/1.1
> Host: 127.0.0.1:6901
> User-Agent: curl/7.88.1
> Accept: */*
>
  0     0    0     0    0     0      0      0 --:--:--  0:01:03 --:--:--     0< HTTP/1.1 200 OK
< content-type: application/octet-stream
< content-disposition: attachment; filename="profile.pb.gz"
< content-length: 174913
< date: Mon, 21 Oct 2024 07:10:20 GMT
<
{ [43853 bytes data]
100  170k  100  170k    0     0   2726      0  0:01:04  0:01:04 --:--:-- 44987
* Connection #0 to host 127.0.0.1 left intact
```
Then, you can use below command to visualize `profile.pb.gz` 

```shell
go tool pprof -http=:8080 .\profile.pb.gz
```
![image](https://github.com/user-attachments/assets/b8e9a5de-a36a-432f-98d7-1bea7e0e1c0f)
