### PR TITLE
feat: make heap profiling as default

### DIFF
--- a/crates/arroyo/Cargo.toml
+++ b/crates/arroyo/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.13.0-dev"
 edition = "2021"
 
 [features]
-profiling = ["tikv-jemallocator/profiling"]
 python = ["arroyo-udf-python/python-enabled"]
 
 [dependencies]

--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -33,7 +33,6 @@ use uuid::Uuid;
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(all(
-    feature = "profiling",
     not(target_env = "msvc"),
     not(target_os = "macos"),
     any(target_arch = "x86_64", target_arch = "aarch64")


### PR DESCRIPTION
Sometimes, we need to analyze the memory usage of workers or controllers, and `pprof` is a very useful tool for this. I believe it should be included as a default feature rather than an optional compile-time setting. Additionally, it doesn't make much sense to expose an HTTP route if it can't be utilized effectively.