### PR TITLE
Add timestamp metadata field to kafka connector

### DIFF
--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -159,7 +159,6 @@ async fn compile_sql<'a>(
                     .unwrap_or(json!({})),
                 &table.config,
                 Some(&table.schema),
-                None,
             )
             .map_err(log_and_map)?;
 

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -79,9 +79,8 @@ impl Connector for BlackholeConnector {
         _options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
-        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema, None)
+        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema)
     }
 
     fn from_config(
@@ -91,7 +90,6 @@ impl Connector for BlackholeConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         s: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let description = "Blackhole".to_string();
 
@@ -102,7 +100,7 @@ impl Connector for BlackholeConnector {
             format: None,
             bad_data: None,
             framing: None,
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -1,6 +1,5 @@
 use crate::blackhole::operator::BlackholeSinkFunc;
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;
 use arroyo_rpc::api_types::connections::{

--- a/crates/arroyo-connectors/src/confluent/mod.rs
+++ b/crates/arroyo-connectors/src/confluent/mod.rs
@@ -3,7 +3,6 @@ use crate::kafka::{
 };
 use crate::{kafka, pull_opt};
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;
 use arroyo_rpc::api_types::connections::{

--- a/crates/arroyo-connectors/src/confluent/mod.rs
+++ b/crates/arroyo-connectors/src/confluent/mod.rs
@@ -162,7 +162,6 @@ impl Connector for ConfluentConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let connection = profile
             .map(|p| {
@@ -174,7 +173,7 @@ impl Connector for ConfluentConnector {
 
         let table = KafkaConnector::table_from_options(options)?;
 
-        self.from_config(None, name, connection, table, schema, None)
+        self.from_config(None, name, connection, table, schema)
     }
 
     fn from_config(
@@ -184,12 +183,11 @@ impl Connector for ConfluentConnector {
         config: Self::ProfileT,
         mut table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         table
             .client_configs
             .insert("client.id".to_string(), CLIENT_ID.to_string());
-        KafkaConnector {}.from_config(id, name, config.into(), table, schema, None)
+        KafkaConnector {}.from_config(id, name, config.into(), table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_operator::connector::Connection;
 use arroyo_storage::BackendConfig;
 use std::collections::HashMap;

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -78,7 +78,6 @@ impl Connector for DeltaLakeConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let TableType::Sink {
             write_path,
@@ -125,7 +124,7 @@ impl Connector for DeltaLakeConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -145,11 +144,10 @@ impl Connector for DeltaLakeConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let table = file_system_sink_from_options(options, schema, CommitStyle::DeltaLake)?;
 
-        self.from_config(None, name, EmptyConfig {}, table, schema, None)
+        self.from_config(None, name, EmptyConfig {}, table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -3,7 +3,6 @@ mod sink;
 mod source;
 
 use anyhow::{anyhow, bail, Result};
-use arrow::datatypes::DataType;
 use arroyo_storage::BackendConfig;
 use regex::Regex;
 use std::collections::HashMap;

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -89,7 +89,6 @@ impl Connector for FluvioConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let endpoint = options.remove("endpoint");
         let topic = pull_opt("topic", options)?;
@@ -118,7 +117,7 @@ impl Connector for FluvioConnector {
             type_: table_type,
         };
 
-        Self::from_config(self, None, name, EmptyConfig {}, table, schema, None)
+        Self::from_config(self, None, name, EmptyConfig {}, table, schema)
     }
 
     fn from_config(
@@ -128,7 +127,6 @@ impl Connector for FluvioConnector {
         config: EmptyConfig,
         table: FluvioTable,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let (typ, desc) = match table.type_ {
             TableType::Source { .. } => (
@@ -157,7 +155,7 @@ impl Connector for FluvioConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -102,7 +102,6 @@ impl Connector for ImpulseConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;
@@ -136,7 +135,6 @@ impl Connector for ImpulseConnector {
                 message_count,
             },
             None,
-            None,
         )
     }
 
@@ -147,7 +145,6 @@ impl Connector for ImpulseConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         _: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let description = format!(
             "{}Impulse<{} eps{}>",
@@ -170,7 +167,7 @@ impl Connector for ImpulseConnector {
             format: None,
             bad_data: None,
             framing: None,
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -1,7 +1,6 @@
 mod operator;
 
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;
 use arroyo_rpc::api_types::connections::FieldType::Primitive;

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail};
-use arrow::datatypes::{DataType};
+use arrow::datatypes::DataType;
 use arroyo_formats::de::ArrowDeserializer;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, MetadataDef};
@@ -215,7 +215,7 @@ impl Connector for KafkaConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            metadata_fields: schema.metadata_fields()
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -325,7 +325,7 @@ impl Connector for KafkaConnector {
             MetadataDef {
                 name: "timestamp",
                 data_type: DataType::Int64,
-            }
+            },
         ]
     }
 

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -2,7 +2,7 @@ use arroyo_formats::de::FieldValueType;
 use arroyo_rpc::formats::{BadData, Format, Framing};
 use arroyo_rpc::grpc::rpc::TableConfig;
 use arroyo_rpc::schema_resolver::SchemaResolver;
-use arroyo_rpc::{grpc::rpc::StopMode, ControlMessage, ControlResp};
+use arroyo_rpc::{grpc::rpc::StopMode, ControlMessage, ControlResp, MetadataField};
 
 use arroyo_operator::context::ArrowContext;
 use arroyo_operator::operator::SourceOperator;
@@ -36,7 +36,7 @@ pub struct KafkaSourceFunc {
     pub schema_resolver: Option<Arc<dyn SchemaResolver + Sync>>,
     pub client_configs: HashMap<String, String>,
     pub messages_per_second: NonZeroU32,
-    pub metadata_fields: Option<HashMap<String, String>>,
+    pub metadata_fields: Vec<MetadataField>,
 }
 
 #[derive(Copy, Clone, Debug, Encode, Decode, PartialEq, PartialOrd)]
@@ -169,7 +169,7 @@ impl KafkaSourceFunc {
 
         let mut flush_ticker = tokio::time::interval(Duration::from_millis(50));
         flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
+        
         loop {
             select! {
                 message = consumer.recv() => {
@@ -179,30 +179,26 @@ impl KafkaSourceFunc {
                                 let timestamp = msg.timestamp().to_millis()
                                     .ok_or_else(|| UserError::new("Failed to read timestamp from Kafka record",
                                         "The message read from Kafka did not contain a message timestamp"))?;
+                                
+                                let topic = msg.topic();
 
-                                let connector_metadata = if let Some(metadata_fields) = &self.metadata_fields {
+                                let connector_metadata = if !self.metadata_fields.is_empty() {
                                     let mut connector_metadata = HashMap::new();
-                                    for (key, value) in metadata_fields {
-                                        match value.as_str() {
-                                            "offset_id" => {
-                                                connector_metadata.insert(key, FieldValueType::Int64(msg.offset()));
-                                            }
-                                            "partition" => {
-                                                connector_metadata.insert(key, FieldValueType::Int32(msg.partition()));
-                                            }
-                                            "topic" => {
-                                                connector_metadata.insert(key, FieldValueType::String(&self.topic));
-                                            }
-                                            _ => {}
-                                        }
+                                    for f in &self.metadata_fields {
+                                        connector_metadata.insert(&f.field_name, match f.key.as_str() {
+                                            "offset_id" => FieldValueType::Int64(msg.offset()),
+                                            "partition" => FieldValueType::Int32(msg.partition()),
+                                            "topic" => FieldValueType::String(topic),
+                                            "timestamp" => FieldValueType::Int64(timestamp),
+                                            k => unreachable!("Invalid metadata key '{}'", k),
+                                        });
                                     }
                                     Some(connector_metadata)
                                 } else {
                                     None
                                 };
 
-
-                                ctx.deserialize_slice(v, from_millis(timestamp as u64), connector_metadata).await?;
+                                ctx.deserialize_slice(v, from_millis(timestamp.max(0) as u64), connector_metadata.as_ref()).await?;
 
 
                                 if ctx.should_flush() {

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -169,7 +169,7 @@ impl KafkaSourceFunc {
 
         let mut flush_ticker = tokio::time::interval(Duration::from_millis(50));
         flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        
+
         loop {
             select! {
                 message = consumer.recv() => {
@@ -179,7 +179,7 @@ impl KafkaSourceFunc {
                                 let timestamp = msg.timestamp().to_millis()
                                     .ok_or_else(|| UserError::new("Failed to read timestamp from Kafka record",
                                         "The message read from Kafka did not contain a message timestamp"))?;
-                                
+
                                 let topic = msg.topic();
 
                                 let connector_metadata = if !self.metadata_fields.is_empty() {

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -18,7 +18,7 @@ use arroyo_operator::operator::SourceOperator;
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::formats::{Format, RawStringFormat};
 use arroyo_rpc::grpc::rpc::{CheckpointMetadata, OperatorCheckpointMetadata, OperatorMetadata};
-use arroyo_rpc::{CheckpointCompleted, ControlMessage, ControlResp};
+use arroyo_rpc::{CheckpointCompleted, ControlMessage, ControlResp, MetadataField};
 use arroyo_types::{
     single_item_hash_map, to_micros, ArrowMessage, CheckpointBarrier, SignalMessage, TaskInfo,
 };
@@ -87,7 +87,7 @@ impl KafkaTopicTester {
             schema_resolver: None,
             client_configs: HashMap::new(),
             messages_per_second: NonZeroU32::new(100).unwrap(),
-            metadata_fields: None,
+            metadata_fields: vec![],
         });
 
         let (to_control_tx, control_rx) = channel(128);
@@ -358,10 +358,10 @@ async fn test_kafka_with_metadata_fields() {
     kafka_topic_tester.create_topic().await;
 
     // Prepare metadata fields
-    let metadata_fields = Some(HashMap::from([(
-        "offset".to_string(),
-        "offset_id".to_string(),
-    )]));
+    let metadata_fields = vec![MetadataField {
+        field_name: "offset".to_string(),
+        key: "offset_id".to_string(),
+    }];
 
     // Set metadata fields in KafkaSourceFunc
     let mut kafka = KafkaSourceFunc {

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -84,7 +84,6 @@ impl Connector for KinesisConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let (connection_type, description) = match table.type_ {
             TableType::Source { .. } => (
@@ -113,7 +112,7 @@ impl Connector for KinesisConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -133,7 +132,6 @@ impl Connector for KinesisConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let typ = pull_opt("type", options)?;
         let table_type = match typ.as_str() {
@@ -170,7 +168,7 @@ impl Connector for KinesisConnector {
             aws_region: options.remove("aws_region").map(|s| s.to_string()),
         };
 
-        Self::from_config(self, None, name, EmptyConfig {}, table, schema, None)
+        Self::from_config(self, None, name, EmptyConfig {}, table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail, Result};
-use arrow::datatypes::DataType;
 use std::collections::HashMap;
 use typify::import_types;
 

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -138,6 +138,7 @@ pub(crate) fn source_field(name: &str, field_type: FieldType) -> SourceField {
             r#type: field_type,
         },
         nullable: false,
+        metadata_key: None,
     }
 }
 

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -240,14 +240,12 @@ impl Connector for MqttConnector {
     }
 
     fn metadata_defs(&self) -> &'static [MetadataDef] {
-        &[
-            MetadataDef {
-                name: "topic",
-                data_type: DataType::Utf8,
-            }
-        ]
+        &[MetadataDef {
+            name: "topic",
+            data_type: DataType::Utf8,
+        }]
     }
-    
+
     fn from_options(
         &self,
         name: &str,

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -10,7 +10,7 @@ use crate::pull_opt;
 use anyhow::{anyhow, bail};
 use arrow::datatypes::DataType;
 use arroyo_formats::ser::ArrowSerializer;
-use arroyo_operator::connector::{Connection, Connector};
+use arroyo_operator::connector::{Connection, Connector, MetadataDef};
 use arroyo_operator::operator::OperatorNode;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
@@ -158,7 +158,6 @@ impl Connector for MqttConnector {
         config: MqttConfig,
         table: MqttTable,
         schema: Option<&ConnectionSchema>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let (typ, desc) = match table.type_ {
             TableType::Source { .. } => (
@@ -178,13 +177,6 @@ impl Connector for MqttConnector {
             .map(|t| t.to_owned())
             .ok_or_else(|| anyhow!("'format' must be set for Mqtt connection"))?;
 
-        let metadata_fields = metadata_fields.map(|fields| {
-            fields
-                .into_iter()
-                .map(|(k, (v, _))| (k, v))
-                .collect::<HashMap<String, String>>()
-        });
-
         let config = OperatorConfig {
             connection: serde_json::to_value(config).unwrap(),
             table: serde_json::to_value(table).unwrap(),
@@ -192,7 +184,7 @@ impl Connector for MqttConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: metadata_fields,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -247,13 +239,21 @@ impl Connector for MqttConnector {
         }
     }
 
+    fn metadata_defs(&self) -> &'static [MetadataDef] {
+        &[
+            MetadataDef {
+                name: "topic",
+                data_type: DataType::Utf8,
+            }
+        ]
+    }
+    
     fn from_options(
         &self,
         name: &str,
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let connection = profile
             .map(|p| {
@@ -265,25 +265,7 @@ impl Connector for MqttConnector {
 
         let table = Self::table_from_options(options)?;
 
-        if let Some(fields) = &metadata_fields {
-            for (k, (v, t)) in fields {
-                if v != "topic" {
-                    return Err(anyhow!(
-                        "Invalid metadata field name for mqtt connector: {}",
-                        k
-                    ));
-                }
-                if *t != DataType::Utf8 {
-                    return Err(anyhow!(
-                        "Invalid datatype: {} for metadata field: {} for mqtt connector",
-                        k,
-                        v
-                    ));
-                }
-            }
-        }
-
-        Self::from_config(self, None, name, connection, table, schema, metadata_fields)
+        Self::from_config(self, None, name, connection, table, schema)
     }
 
     fn make_operator(
@@ -311,7 +293,7 @@ impl Connector for MqttConnector {
                 )
                 .unwrap(),
                 subscribed: Arc::new(AtomicBool::new(false)),
-                metadata_fields: config.additional_fields,
+                metadata_fields: config.metadata_fields,
             })),
             TableType::Sink { retain } => OperatorNode::from_operator(Box::new(MqttSinkFunc {
                 config: profile,

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -142,14 +142,14 @@ impl MqttSourceFunc {
         let qos = self.qos;
         let mut flush_ticker = tokio::time::interval(Duration::from_millis(50));
         flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        
+
         loop {
             select! {
                 event = eventloop.poll() => {
                     match event {
                         Ok(MqttEvent::Incoming(Incoming::Publish(p))) => {
                             let topic = String::from_utf8_lossy(&p.topic).to_string();
-                            
+
                             let connector_metadata = if !self.metadata_fields.is_empty() {
                                 let mut connector_metadata = HashMap::new();
                                 for mf in &self.metadata_fields {
@@ -162,7 +162,7 @@ impl MqttSourceFunc {
                             } else {
                                 None
                             };
-                            
+
                             ctx.deserialize_slice(&p.payload, SystemTime::now(), connector_metadata.as_ref()).await?;
                             rate_limiter.until_ready().await;
                         }

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use arroyo_rpc::formats::{BadData, Format, Framing};
-use arroyo_rpc::{grpc::rpc::StopMode, ControlMessage, ControlResp};
+use arroyo_rpc::{grpc::rpc::StopMode, ControlMessage, ControlResp, MetadataField};
 use arroyo_types::{ArrowMessage, SignalMessage, UserError, Watermark};
 use governor::{Quota, RateLimiter as GovernorRateLimiter};
 use rumqttc::v5::mqttbytes::QoS;
@@ -34,7 +34,7 @@ pub struct MqttSourceFunc {
     pub bad_data: Option<BadData>,
     pub messages_per_second: NonZeroU32,
     pub subscribed: Arc<AtomicBool>,
-    pub metadata_fields: Option<HashMap<String, String>>,
+    pub metadata_fields: Vec<MetadataField>,
 }
 
 #[async_trait]
@@ -77,7 +77,7 @@ impl MqttSourceFunc {
         framing: Option<Framing>,
         bad_data: Option<BadData>,
         messages_per_second: u32,
-        metadata_fields: Option<HashMap<String, String>>,
+        metadata_fields: Vec<MetadataField>,
     ) -> Self {
         Self {
             config,
@@ -142,26 +142,28 @@ impl MqttSourceFunc {
         let qos = self.qos;
         let mut flush_ticker = tokio::time::interval(Duration::from_millis(50));
         flush_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
+        
         loop {
             select! {
                 event = eventloop.poll() => {
                     match event {
                         Ok(MqttEvent::Incoming(Incoming::Publish(p))) => {
                             let topic = String::from_utf8_lossy(&p.topic).to_string();
-                            let connector_metadata: Option<HashMap<&String, FieldValueType<'_>>> =
-                            self.metadata_fields.as_ref().map(|fields| {
-                                fields.iter()
-                                    .filter_map(|(k, v)| {
-                                        if v == "topic" {
-                                            Some((k, FieldValueType::String(&topic)))
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect()
-                            });
-                            ctx.deserialize_slice(&p.payload, SystemTime::now(), connector_metadata).await?;
+                            
+                            let connector_metadata = if !self.metadata_fields.is_empty() {
+                                let mut connector_metadata = HashMap::new();
+                                for mf in &self.metadata_fields {
+                                    connector_metadata.insert(&mf.field_name, match mf.key.as_str() {
+                                        "topic" => FieldValueType::String(&topic),
+                                        k => unreachable!("invalid metadata key '{}' for mqtt", k)
+                                    });
+                                }
+                                Some(connector_metadata)
+                            } else {
+                                None
+                            };
+                            
+                            ctx.deserialize_slice(&p.payload, SystemTime::now(), connector_metadata.as_ref()).await?;
                             rate_limiter.until_ready().await;
                         }
                         Ok(MqttEvent::Outgoing(Outgoing::Subscribe(_))) => {

--- a/crates/arroyo-connectors/src/mqtt/source/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/test.rs
@@ -125,7 +125,7 @@ impl MqttTopicTester {
             None,
             None,
             10,
-            None,
+            vec![],
         );
 
         let (to_control_tx, control_rx) = channel(128);

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -3,7 +3,6 @@ use crate::nats::source::NatsSourceFunc;
 use crate::pull_opt;
 use anyhow::anyhow;
 use anyhow::bail;
-use arrow::datatypes::DataType;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -247,7 +247,6 @@ impl Connector for NatsConnector {
         config: NatsConfig,
         table: NatsTable,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let stream_or_subject = match &table.connector_type {
             ConnectorType::Source { source_type, .. } => {
@@ -297,7 +296,7 @@ impl Connector for NatsConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -317,7 +316,6 @@ impl Connector for NatsConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let connection = profile
             .map(|p| {
@@ -329,7 +327,7 @@ impl Connector for NatsConnector {
 
         let table = Self::table_from_options(options)?;
 
-        Self::from_config(self, None, name, connection, table, schema, None)
+        Self::from_config(self, None, name, connection, table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -3,7 +3,7 @@ mod operator;
 mod test;
 
 use anyhow::{anyhow, bail};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::datatypes::{Field, Schema, TimeUnit};
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;
 use arroyo_rpc::api_types::connections::{

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -158,7 +158,6 @@ impl Connector for NexmarkConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;
@@ -184,7 +183,6 @@ impl Connector for NexmarkConnector {
                 runtime,
             },
             None,
-            None,
         )
     }
 
@@ -195,7 +193,6 @@ impl Connector for NexmarkConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         _: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let description = format!(
             "{}Nexmark<{} eps>",
@@ -214,7 +211,7 @@ impl Connector for NexmarkConnector {
             format: None,
             bad_data: None,
             framing: None,
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_rpc::{var_str::VarStr, OperatorConfig};
 use arroyo_types::string_to_map;
 use reqwest::{Client, Request};

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -153,7 +153,6 @@ impl Connector for PollingHTTPConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");
@@ -185,7 +184,6 @@ impl Connector for PollingHTTPConnector {
                 emit_behavior,
             },
             schema,
-            None,
         )
     }
 
@@ -196,7 +194,6 @@ impl Connector for PollingHTTPConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let description = format!("PollingHTTPSource<{}>", table.endpoint);
 
@@ -226,7 +223,7 @@ impl Connector for PollingHTTPConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -3,7 +3,6 @@ mod operator;
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_rpc::OperatorConfig;
 
 use arroyo_operator::connector::Connection;

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -72,7 +72,6 @@ impl Connector for PreviewConnector {
         _: &mut HashMap<String, String>,
         _: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         bail!("Preview connector cannot be created in SQL");
     }
@@ -84,7 +83,6 @@ impl Connector for PreviewConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let description = "PreviewSink".to_string();
 
@@ -99,7 +97,7 @@ impl Connector for PreviewConnector {
             format: None,
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -228,7 +228,6 @@ impl Connector for RedisConnector {
         options: &mut HashMap<String, String>,
         s: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let connection_config = match profile {
             Some(connection_profile) => {
@@ -350,7 +349,6 @@ impl Connector for RedisConnector {
                 connector_type: sink,
             },
             s,
-            None,
         )
     }
 
@@ -361,7 +359,6 @@ impl Connector for RedisConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let schema = schema
             .map(|s| s.to_owned())
@@ -382,7 +379,7 @@ impl Connector for RedisConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -1,7 +1,6 @@
 mod operator;
 
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::OperatorNode;

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail, Result};
-use arrow::datatypes::DataType;
 use arroyo_formats::ser::ArrowSerializer;
 use std::collections::HashMap;
 use typify::import_types;

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -85,7 +85,6 @@ impl Connector for SingleFileConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let schema = schema
             .map(|s| s.to_owned())
@@ -105,7 +104,7 @@ impl Connector for SingleFileConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {
@@ -125,7 +124,6 @@ impl Connector for SingleFileConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let path = pull_opt("path", options)?;
         let Ok(table_type) = pull_opt("type", options)?.try_into() else {
@@ -150,7 +148,6 @@ impl Connector for SingleFileConnector {
                 wait_for_control,
             },
             schema,
-            None,
         )
     }
 

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
-use arrow::datatypes::DataType;
 use arroyo_rpc::{var_str::VarStr, OperatorConfig};
 use arroyo_types::string_to_map;
 use eventsource_client::Client;

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -79,7 +79,6 @@ impl Connector for SSEConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let description = format!("SSESource<{}>", table.endpoint);
 
@@ -109,7 +108,7 @@ impl Connector for SSEConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -129,7 +128,6 @@ impl Connector for SSEConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");
@@ -145,7 +143,6 @@ impl Connector for SSEConnector {
                 headers: headers.map(VarStr::new),
             },
             schema,
-            None,
         )
     }
 

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -77,9 +77,8 @@ impl Connector for StdoutConnector {
         _options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
-        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema, None)
+        self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema)
     }
 
     fn from_config(
@@ -89,7 +88,6 @@ impl Connector for StdoutConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let description = "StdoutSink".to_string();
 
@@ -110,7 +108,7 @@ impl Connector for StdoutConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: vec![],
         };
 
         Ok(Connection {

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -3,7 +3,6 @@ mod operator;
 use std::collections::HashMap;
 
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_rpc::OperatorConfig;
 use tokio::io::BufWriter;
 

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -143,7 +143,6 @@ impl Connector for WebhookConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let description = format!("WebhookSink<{}>", table.endpoint.sub_env_vars()?);
 
@@ -164,7 +163,7 @@ impl Connector for WebhookConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -184,7 +183,6 @@ impl Connector for WebhookConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
 
@@ -205,7 +203,7 @@ impl Connector for WebhookConnector {
         )?;
         let _ = Self::construct_test_request(&client, &table)?;
 
-        self.from_config(None, name, EmptyConfig {}, table, schema, None)
+        self.from_config(None, name, EmptyConfig {}, table, schema)
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_rpc::OperatorConfig;
 
 use arroyo_formats::ser::ArrowSerializer;

--- a/crates/arroyo-connectors/src/websocket/mod.rs
+++ b/crates/arroyo-connectors/src/websocket/mod.rs
@@ -221,7 +221,6 @@ impl Connector for WebsocketConnector {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<arroyo_operator::connector::Connection> {
         let description = format!("WebsocketSource<{}>", table.endpoint);
 
@@ -251,7 +250,7 @@ impl Connector for WebsocketConnector {
             format: Some(format),
             bad_data: schema.bad_data.clone(),
             framing: schema.framing.clone(),
-            additional_fields: None,
+            metadata_fields: schema.metadata_fields(),
         };
 
         Ok(Connection {
@@ -271,7 +270,6 @@ impl Connector for WebsocketConnector {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
-        _metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");
@@ -308,7 +306,6 @@ impl Connector for WebsocketConnector {
                 subscription_messages,
             },
             schema,
-            None,
         )
     }
 

--- a/crates/arroyo-connectors/src/websocket/mod.rs
+++ b/crates/arroyo-connectors/src/websocket/mod.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use arrow::datatypes::DataType;
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -500,7 +500,7 @@ pub(crate) fn add_additional_fields(
 }
 
 pub(crate) fn add_additional_fields_using_builder(
-    additional_fields: Option<&HashMap<&String , FieldValueType<'_>>>,
+    additional_fields: Option<&HashMap<&String, FieldValueType<'_>>>,
     additional_fields_builder: &mut Option<HashMap<String, Box<dyn ArrayBuilder>>>,
 ) {
     if let Some(fields) = additional_fields {

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -4,9 +4,8 @@ use arrow::datatypes::{DataType, Field};
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::{primitive_to_sql, OperatorConfig};
+use arroyo_rpc::OperatorConfig;
 use arroyo_types::DisplayAsSql;
-use datafusion::sql::unparser::expr_to_sql;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::value::Value;

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -1,16 +1,18 @@
 use crate::operator::OperatorNode;
-use anyhow::anyhow;
-use arrow::datatypes::DataType;
+use anyhow::{anyhow, bail};
+use arrow::datatypes::{DataType, Field};
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{primitive_to_sql, OperatorConfig};
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::value::Value;
 use std::collections::HashMap;
+use datafusion::sql::unparser::expr_to_sql;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
+use arroyo_types::DisplayAsSql;
 
 #[derive(Debug, Clone)]
 pub struct Connection {
@@ -21,6 +23,11 @@ pub struct Connection {
     pub schema: ConnectionSchema,
     pub config: String,
     pub description: String,
+}
+
+pub struct MetadataDef {
+    pub name: &'static str,
+    pub data_type: DataType,
 }
 
 #[allow(clippy::wrong_self_convention)]
@@ -44,6 +51,10 @@ pub trait Connector: Send {
     }
 
     fn metadata(&self) -> arroyo_rpc::api_types::connections::Connector;
+    
+    fn metadata_defs(&self) -> &'static [MetadataDef] {
+        &[]
+    }
 
     fn table_type(&self, config: Self::ProfileT, table: Self::TableT) -> ConnectionType;
 
@@ -90,7 +101,6 @@ pub trait Connector: Send {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection>;
 
     fn from_config(
@@ -100,7 +110,6 @@ pub trait Connector: Send {
         config: Self::ProfileT,
         table: Self::TableT,
         schema: Option<&ConnectionSchema>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection>;
 
     #[allow(unused)]
@@ -117,6 +126,8 @@ pub trait ErasedConnector: Send {
     fn name(&self) -> &'static str;
 
     fn metadata(&self) -> arroyo_rpc::api_types::connections::Connector;
+
+    fn metadata_defs(&self) -> &'static [MetadataDef];
 
     fn validate_config(&self, s: &serde_json::Value) -> Result<(), serde_json::Error>;
 
@@ -165,7 +176,6 @@ pub trait ErasedConnector: Send {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection>;
 
     fn from_config(
@@ -175,7 +185,6 @@ pub trait ErasedConnector: Send {
         config: &serde_json::Value,
         table: &serde_json::Value,
         schema: Option<&ConnectionSchema>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection>;
 
     fn make_operator(&self, config: OperatorConfig) -> anyhow::Result<OperatorNode>;
@@ -188,6 +197,10 @@ impl<C: Connector> ErasedConnector for C {
 
     fn metadata(&self) -> arroyo_rpc::api_types::connections::Connector {
         self.metadata()
+    }
+
+    fn metadata_defs(&self) -> &'static [MetadataDef] {
+        self.metadata_defs()
     }
 
     fn config_description(&self, s: &serde_json::Value) -> Result<String, serde_json::Error> {
@@ -261,9 +274,26 @@ impl<C: Connector> ErasedConnector for C {
         options: &mut HashMap<String, String>,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
-        self.from_options(name, options, schema, profile, metadata_fields)
+        if let Some(schema) = schema {
+            for sf in schema.fields.iter() {
+                if let Some(key) = &sf.metadata_key {
+                    let field = self.metadata_defs()
+                        .iter()
+                        .find(|f| f.name == key)
+                        .ok_or_else(|| anyhow!("unknown metadata field '{}' for {} connector '{}'", key, self.name(), name))?;
+
+                    let arrow_field: Field = sf.clone().into();
+                    
+                    if !field.data_type.equals_datatype(arrow_field.data_type()) {
+                        bail!("incorrect data type for metadata field '{}'; expected {}, but found {}",
+                        arrow_field.name(), DisplayAsSql(&field.data_type), DisplayAsSql(arrow_field.data_type()));
+                    }
+                }
+            }
+        }
+        
+        self.from_options(name, options, schema, profile)
     }
 
     fn from_config(
@@ -273,7 +303,6 @@ impl<C: Connector> ErasedConnector for C {
         config: &serde_json::Value,
         table: &serde_json::Value,
         schema: Option<&ConnectionSchema>,
-        metadata_fields: Option<HashMap<String, (String, DataType)>>,
     ) -> anyhow::Result<Connection> {
         self.from_config(
             id,
@@ -281,7 +310,6 @@ impl<C: Connector> ErasedConnector for C {
             self.parse_config(config)?,
             self.parse_table(table)?,
             schema,
-            metadata_fields,
         )
     }
 

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -670,7 +670,7 @@ impl ArrowContext {
         &mut self,
         msg: &[u8],
         time: SystemTime,
-        additional_fields: Option<HashMap<&String, FieldValueType<'_>>>,
+        additional_fields: Option<&HashMap<&String, FieldValueType<'_>>>,
     ) -> Result<(), UserError> {
         let deserializer = self
             .deserializer

--- a/crates/arroyo-planner/src/extension/table_source.rs
+++ b/crates/arroyo-planner/src/extension/table_source.rs
@@ -14,7 +14,7 @@ use crate::{
     schemas::add_timestamp_field,
     tables::ConnectorTable,
 };
-
+use crate::tables::FieldSpec;
 use super::{ArroyoExtension, DebeziumUnrollingExtension, NodeWithIncomingEdges};
 pub(crate) const TABLE_SOURCE_NAME: &str = "TableSourceExtension";
 
@@ -31,10 +31,10 @@ impl TableSourceExtension {
             .fields
             .iter()
             .filter_map(|field| match field {
-                crate::tables::FieldSpec::StructField(field) => {
+                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => {
                     Some((Some(name.clone()), Arc::new(field.clone())).into())
                 }
-                crate::tables::FieldSpec::VirtualField { .. } => None,
+                FieldSpec::VirtualField { .. } => None,
             })
             .collect::<Vec<_>>();
         let base_schema = Arc::new(schema_from_df_fields(&physical_fields).unwrap());

--- a/crates/arroyo-planner/src/extension/table_source.rs
+++ b/crates/arroyo-planner/src/extension/table_source.rs
@@ -31,10 +31,10 @@ impl TableSourceExtension {
             .fields
             .iter()
             .filter_map(|field| match field {
-                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, .. } => {
+                FieldSpec::Struct(field) | FieldSpec::Metadata { field, .. } => {
                     Some((Some(name.clone()), Arc::new(field.clone())).into())
                 }
-                FieldSpec::VirtualField { .. } => None,
+                FieldSpec::Virtual { .. } => None,
             })
             .collect::<Vec<_>>();
         let base_schema = Arc::new(schema_from_df_fields(&physical_fields).unwrap());

--- a/crates/arroyo-planner/src/extension/table_source.rs
+++ b/crates/arroyo-planner/src/extension/table_source.rs
@@ -8,14 +8,14 @@ use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 
 use prost::Message;
 
+use super::{ArroyoExtension, DebeziumUnrollingExtension, NodeWithIncomingEdges};
+use crate::tables::FieldSpec;
 use crate::{
     builder::{NamedNode, Planner},
     schema_from_df_fields,
     schemas::add_timestamp_field,
     tables::ConnectorTable,
 };
-use crate::tables::FieldSpec;
-use super::{ArroyoExtension, DebeziumUnrollingExtension, NodeWithIncomingEdges};
 pub(crate) const TABLE_SOURCE_NAME: &str = "TableSourceExtension";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -31,7 +31,7 @@ impl TableSourceExtension {
             .fields
             .iter()
             .filter_map(|field| match field {
-                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => {
+                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, .. } => {
                     Some((Some(name.clone()), Arc::new(field.clone())).into())
                 }
                 FieldSpec::VirtualField { .. } => None,

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -49,14 +49,13 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &watermark_field {
                         return match f {
-                            FieldSpec::StructField(field)
-                            | FieldSpec::MetadataField { field, .. } => {
+                            FieldSpec::Struct(field) | FieldSpec::Metadata { field, .. } => {
                                 Some(Expr::Column(Column {
                                     relation: None,
                                     name: field.name().to_string(),
                                 }))
                             }
-                            FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
+                            FieldSpec::Virtual { expression, .. } => Some(expression.clone()),
                         };
                     }
                     None
@@ -87,13 +86,13 @@ impl<'a> SourceRewriter<'a> {
             .fields
             .iter()
             .map(|field| match field {
-                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, .. } => {
+                FieldSpec::Struct(field) | FieldSpec::Metadata { field, .. } => {
                     Expr::Column(Column {
                         relation: Some(qualifier.clone()),
                         name: field.name().to_string(),
                     })
                 }
-                FieldSpec::VirtualField { field, expression } => expression
+                FieldSpec::Virtual { field, expression } => expression
                     .clone()
                     .alias_qualified(Some(qualifier.clone()), field.name().to_string()),
             })
@@ -111,14 +110,13 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &event_time_field {
                         return match f {
-                            FieldSpec::StructField(field)
-                            | FieldSpec::MetadataField { field, .. } => {
+                            FieldSpec::Struct(field) | FieldSpec::Metadata { field, .. } => {
                                 Some(Expr::Column(Column {
                                     relation: Some(qualifier.clone()),
                                     name: field.name().to_string(),
                                 }))
                             }
-                            FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
+                            FieldSpec::Virtual { expression, .. } => Some(expression.clone()),
                         };
                     }
                     None

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -49,10 +49,13 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &watermark_field {
                         return match f {
-                            FieldSpec::StructField(field) | FieldSpec::MetadataField {field, ..} => Some(Expr::Column(Column {
-                                relation: None,
-                                name: field.name().to_string(),
-                            })),
+                            FieldSpec::StructField(field)
+                            | FieldSpec::MetadataField { field, .. } => {
+                                Some(Expr::Column(Column {
+                                    relation: None,
+                                    name: field.name().to_string(),
+                                }))
+                            }
                             FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
                         };
                     }
@@ -84,10 +87,12 @@ impl<'a> SourceRewriter<'a> {
             .fields
             .iter()
             .map(|field| match field {
-                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => Expr::Column(Column {
-                    relation: Some(qualifier.clone()),
-                    name: field.name().to_string(),
-                }),
+                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, .. } => {
+                    Expr::Column(Column {
+                        relation: Some(qualifier.clone()),
+                        name: field.name().to_string(),
+                    })
+                }
                 FieldSpec::VirtualField { field, expression } => expression
                     .clone()
                     .alias_qualified(Some(qualifier.clone()), field.name().to_string()),
@@ -106,10 +111,13 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &event_time_field {
                         return match f {
-                            FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => Some(Expr::Column(Column {
-                                relation: Some(qualifier.clone()),
-                                name: field.name().to_string(),
-                            })),
+                            FieldSpec::StructField(field)
+                            | FieldSpec::MetadataField { field, .. } => {
+                                Some(Expr::Column(Column {
+                                    relation: Some(qualifier.clone()),
+                                    name: field.name().to_string(),
+                                }))
+                            }
                             FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
                         };
                     }

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -49,9 +49,9 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &watermark_field {
                         return match f {
-                            FieldSpec::StructField(f) => Some(Expr::Column(Column {
+                            FieldSpec::StructField(field) | FieldSpec::MetadataField {field, ..} => Some(Expr::Column(Column {
                                 relation: None,
-                                name: f.name().to_string(),
+                                name: field.name().to_string(),
                             })),
                             FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
                         };
@@ -84,9 +84,9 @@ impl<'a> SourceRewriter<'a> {
             .fields
             .iter()
             .map(|field| match field {
-                FieldSpec::StructField(f) => Expr::Column(Column {
+                FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => Expr::Column(Column {
                     relation: Some(qualifier.clone()),
-                    name: f.name().to_string(),
+                    name: field.name().to_string(),
                 }),
                 FieldSpec::VirtualField { field, expression } => expression
                     .clone()
@@ -106,9 +106,9 @@ impl<'a> SourceRewriter<'a> {
                 .find_map(|f| {
                     if f.field().name() == &event_time_field {
                         return match f {
-                            FieldSpec::StructField(f) => Some(Expr::Column(Column {
+                            FieldSpec::StructField(field) | FieldSpec::MetadataField { field, ..} => Some(Expr::Column(Column {
                                 relation: Some(qualifier.clone()),
-                                name: f.name().to_string(),
+                                name: field.name().to_string(),
                             })),
                             FieldSpec::VirtualField { expression, .. } => Some(expression.clone()),
                         };

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, time::Duration};
 
 use arrow_schema::{DataType, Field, FieldRef, Schema};
 use arroyo_connectors::connector_for_type;
-use datafusion::logical_expr::expr::ScalarFunction;
 
 use crate::extension::remote_table::RemoteTableExtension;
 use crate::types::convert_data_type;
@@ -54,7 +53,7 @@ use datafusion::optimizer::unwrap_cast_in_comparison::UnwrapCastInComparison;
 use datafusion::optimizer::OptimizerRule;
 use datafusion::sql::planner::PlannerContext;
 use datafusion::sql::sqlparser;
-use datafusion::sql::sqlparser::ast::{FunctionArg, FunctionArguments, Query};
+use datafusion::sql::sqlparser::ast::Query;
 use datafusion::{
     optimizer::{optimizer::Optimizer, OptimizerContext},
     sql::{
@@ -62,7 +61,6 @@ use datafusion::{
         sqlparser::ast::{ColumnDef, ColumnOption, Statement, Value},
     },
 };
-use syn::Meta;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConnectorTable {
@@ -280,8 +278,6 @@ impl ConnectorTable {
                         struct_field.data_type()
                     ))
                 })?;
-
-                println!("setting metadata field for {} {:?}", struct_field.name(), f);
 
                 if let Some(key) = f.metadata_key() {
                     sf.metadata_key = Some(key.to_string());

--- a/crates/arroyo-planner/src/test/mod.rs
+++ b/crates/arroyo-planner/src/test/mod.rs
@@ -24,7 +24,6 @@ fn get_test_schema_provider() -> ArroyoSchemaProvider {
                 runtime: Some(10.0 * 1_000_000.0),
             },
             None,
-            None,
         )
         .unwrap();
 

--- a/crates/arroyo-planner/src/test/queries/metadata_error.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_error.sql
@@ -1,0 +1,14 @@
+--fail=Failed to create table mqtt caused by Error during planning: incorrect data type for metadata field 'topic'; expected TEXT, but found INT
+create table mqtt (
+    name TEXT,
+    value INT,
+    topic INT GENERATED ALWAYS AS (metadata('topic')) STORED
+) with (
+    connector = 'mqtt',
+    url = 'tcp://localhost:1883',
+    topic = 'plant/#',
+    type = 'source',
+    format = 'json'
+);
+
+select topic from mqtt;

--- a/crates/arroyo-planner/src/test/queries/metadata_fields.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_fields.sql
@@ -1,0 +1,13 @@
+create table mqtt (
+    name TEXT,
+    value INT,
+    my_topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED
+) with (
+    connector = 'mqtt',
+    url = 'tcp://localhost:1883',
+    topic = 'plant/#',
+    type = 'source',
+    format = 'json'
+);
+
+select my_topic from mqtt;

--- a/crates/arroyo-planner/src/test/queries/metadata_raw_string.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_raw_string.sql
@@ -1,0 +1,12 @@
+create table mqtt (
+    value TEXT,
+    my_topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED
+) with (
+    connector = 'mqtt',
+    url = 'tcp://localhost:1883',
+    topic = 'plant/#',
+    type = 'source',
+    format = 'raw_string'
+);
+
+select my_topic from mqtt;

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -1,5 +1,5 @@
 use crate::formats::{BadData, Format, Framing};
-use crate::primitive_to_sql;
+use crate::{primitive_to_sql, MetadataField};
 use anyhow::bail;
 use arrow_schema::{DataType, Field, Fields, TimeUnit};
 use serde::{Deserialize, Serialize};
@@ -120,6 +120,8 @@ pub struct SourceField {
     pub field_name: String,
     pub field_type: SourceFieldType,
     pub nullable: bool,
+    #[serde(default)]
+    pub metadata_key: Option<String>,
 }
 
 impl From<SourceField> for Field {
@@ -220,6 +222,7 @@ impl TryFrom<Field> for SourceField {
                 sql_name,
             },
             nullable: f.is_nullable(),
+            metadata_key: None,
         })
     }
 }
@@ -273,22 +276,25 @@ impl ConnectionSchema {
     }
 
     pub fn validate(self) -> anyhow::Result<Self> {
+        let non_metadata_fields: Vec<_> = self.fields.iter().filter(|f| f.metadata_key.is_none()).collect();
+        println!("non metadata fields = {:?}", non_metadata_fields);
+        
         match &self.format {
             Some(Format::RawString(_)) => {
-                if self.fields.len() != 1
-                    || self.fields.first().unwrap().field_type.r#type
+                if non_metadata_fields.len() != 1
+                    || non_metadata_fields.first().unwrap().field_type.r#type
                         != FieldType::Primitive(PrimitiveType::String)
-                    || self.fields.first().unwrap().field_name != "value"
+                    || non_metadata_fields.first().unwrap().field_name != "value"
                 {
                     bail!("raw_string format requires a schema with a single field called `value` of type TEXT");
                 }
             }
             Some(Format::Json(json_format)) => {
                 if json_format.unstructured
-                    && (self.fields.len() != 1
-                        || self.fields.first().unwrap().field_type.r#type
+                    && (non_metadata_fields.len() != 1
+                        || non_metadata_fields.first().unwrap().field_type.r#type
                             != FieldType::Primitive(PrimitiveType::Json)
-                        || self.fields.first().unwrap().field_name != "value")
+                        || non_metadata_fields.first().unwrap().field_name != "value")
                 {
                     bail!("json format with unstructured flag enabled requires a schema with a single field called `value` of type JSON");
                 }
@@ -303,6 +309,15 @@ impl ConnectionSchema {
     pub fn arroyo_schema(&self) -> ArroyoSchemaRef {
         let fields: Vec<Field> = self.fields.iter().map(|f| f.clone().into()).collect();
         Arc::new(ArroyoSchema::from_fields(fields))
+    }
+    
+    pub fn metadata_fields(&self) -> Vec<MetadataField> {
+        self.fields.iter()
+            .filter_map(|f| Some(MetadataField {
+                field_name: f.field_name.clone(),
+                key: f.metadata_key.clone()? 
+            }))
+            .collect()
     }
 }
 

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -276,9 +276,13 @@ impl ConnectionSchema {
     }
 
     pub fn validate(self) -> anyhow::Result<Self> {
-        let non_metadata_fields: Vec<_> = self.fields.iter().filter(|f| f.metadata_key.is_none()).collect();
+        let non_metadata_fields: Vec<_> = self
+            .fields
+            .iter()
+            .filter(|f| f.metadata_key.is_none())
+            .collect();
         println!("non metadata fields = {:?}", non_metadata_fields);
-        
+
         match &self.format {
             Some(Format::RawString(_)) => {
                 if non_metadata_fields.len() != 1
@@ -310,13 +314,16 @@ impl ConnectionSchema {
         let fields: Vec<Field> = self.fields.iter().map(|f| f.clone().into()).collect();
         Arc::new(ArroyoSchema::from_fields(fields))
     }
-    
+
     pub fn metadata_fields(&self) -> Vec<MetadataField> {
-        self.fields.iter()
-            .filter_map(|f| Some(MetadataField {
-                field_name: f.field_name.clone(),
-                key: f.metadata_key.clone()? 
-            }))
+        self.fields
+            .iter()
+            .filter_map(|f| {
+                Some(MetadataField {
+                    field_name: f.field_name.clone(),
+                    key: f.metadata_key.clone()?,
+                })
+            })
             .collect()
     }
 }

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -281,7 +281,6 @@ impl ConnectionSchema {
             .iter()
             .filter(|f| f.metadata_key.is_none())
             .collect();
-        println!("non metadata fields = {:?}", non_metadata_fields);
 
         match &self.format {
             Some(Format::RawString(_)) => {

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -210,7 +210,7 @@ impl Default for OperatorConfig {
             bad_data: None,
             framing: None,
             rate_limit: None,
-            metadata_fields: vec![]
+            metadata_fields: vec![],
         }
     }
 }

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -184,6 +184,12 @@ pub struct RateLimit {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MetadataField {
+    pub field_name: String,
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OperatorConfig {
     pub connection: Value,
     pub table: Value,
@@ -191,7 +197,8 @@ pub struct OperatorConfig {
     pub bad_data: Option<BadData>,
     pub framing: Option<Framing>,
     pub rate_limit: Option<RateLimit>,
-    pub additional_fields: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub metadata_fields: Vec<MetadataField>,
 }
 
 impl Default for OperatorConfig {
@@ -203,7 +210,7 @@ impl Default for OperatorConfig {
             bad_data: None,
             framing: None,
             rate_limit: None,
-            additional_fields: None,
+            metadata_fields: vec![]
         }
     }
 }

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -5,7 +5,7 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::{Range, RangeInclusive};
 use std::sync::Arc;
@@ -456,6 +456,35 @@ pub struct CheckpointBarrier {
     pub then_stop: bool,
 }
 
+pub struct DisplayAsSql<'a>(pub &'a DataType);
+
+impl <'a> Display for DisplayAsSql<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            DataType::Boolean => write!(f, "BOOLEAN"),
+            DataType::Int8 | DataType::Int16 | DataType::Int32 => write!(f, "INT"),
+            DataType::Int64 => write!(f, "BIGINT"),
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 => write!(f, "INT UNSIGNED"),
+            DataType::UInt64 => write!(f, "BIGINT UNSIGNED"),
+            DataType::Float16 | DataType::Float32 => write!(f, "FLOAT"),
+            DataType::Float64 => write!(f, "DOUBLE"),
+            DataType::Timestamp(_, _) => write!(f, "TIMESTAMP"),
+            DataType::Date32 => write!(f, "DATE"),
+            DataType::Date64 => write!(f, "DATETIME"),
+            DataType::Time32(_) => write!(f, "TIME"),
+            DataType::Time64(_) => write!(f, "TIME"),
+            DataType::Duration(_) => write!(f, "INTERVAL"),
+            DataType::Interval(_) => write!(f, "INTERVAL"),
+            DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => write!(f, "BYTEA"),
+            DataType::Utf8 | DataType::LargeUtf8 => write!(f, "TEXT"),
+            DataType::List(inner) => {
+                write!(f, "{}[]", DisplayAsSql(&inner.data_type()))
+            },
+            dt => write!(f, "{}", dt)
+        }
+    }
+}
+    
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Hash, Serialize)]
 pub enum DatePart {
     Year,

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -480,7 +480,7 @@ impl<'a> Display for DisplayAsSql<'a> {
             }
             DataType::Utf8 | DataType::LargeUtf8 => write!(f, "TEXT"),
             DataType::List(inner) => {
-                write!(f, "{}[]", DisplayAsSql(&inner.data_type()))
+                write!(f, "{}[]", DisplayAsSql(inner.data_type()))
             }
             dt => write!(f, "{}", dt),
         }

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -458,7 +458,7 @@ pub struct CheckpointBarrier {
 
 pub struct DisplayAsSql<'a>(pub &'a DataType);
 
-impl <'a> Display for DisplayAsSql<'a> {
+impl<'a> Display for DisplayAsSql<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.0 {
             DataType::Boolean => write!(f, "BOOLEAN"),
@@ -475,16 +475,18 @@ impl <'a> Display for DisplayAsSql<'a> {
             DataType::Time64(_) => write!(f, "TIME"),
             DataType::Duration(_) => write!(f, "INTERVAL"),
             DataType::Interval(_) => write!(f, "INTERVAL"),
-            DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => write!(f, "BYTEA"),
+            DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => {
+                write!(f, "BYTEA")
+            }
             DataType::Utf8 | DataType::LargeUtf8 => write!(f, "TEXT"),
             DataType::List(inner) => {
                 write!(f, "{}[]", DisplayAsSql(&inner.data_type()))
-            },
-            dt => write!(f, "{}", dt)
+            }
+            dt => write!(f, "{}", dt),
         }
     }
 }
-    
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Hash, Serialize)]
 pub enum DatePart {
     Year,


### PR DESCRIPTION
This PR adds a metadata field for the timestamp to the Kafka source, such that this now works:

```sql
create table workflow (
    id TEXT,
    topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED,
    timestamp BIGINT GENERATED ALWAYS AS (metadata('timestamp')) STORED
) with (
    connector = 'kafka',
    bootstrap_servers = 'localhost:9092',
    topic = 'workflow-events',
    type = 'source',
    format = 'json'
);
```

This closes #631.

Also addresses an issue where metadata fields could not be added to sources with raw_string/raw_bytes/unstructured json formats.