### PR TITLE
Use specific python version binary

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Create output directory
         run: mkdir artifacts
       - name: Build Arroyo with Python
-        run: PYO3_PYTHON=$(brew --prefix python@3.12)/Frameworks/Python.framework/Versions/3.12/bin/python3 cargo build --features python --release --package arroyo && strip target/release/arroyo && mv target/release/arroyo artifacts/arroyo-python
+        run: PYO3_PYTHON=$(brew --prefix python@3.12)/Frameworks/Python.framework/Versions/3.12/bin/python3.12 cargo build --features python --release --package arroyo && strip target/release/arroyo && mv target/release/arroyo artifacts/arroyo-python
       - name: Build Arroyo without Python
         run: cargo build --release --package arroyo && strip target/release/arroyo && mv target/release/arroyo artifacts/arroyo
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The Mac OS vm now includes python 3.13, which has changed the path of the Python 3.12 binary.