### PR TITLE
Feature add pgcrypto ext

### DIFF
--- a/crates/arroyo-api/migrations/V6__add_cluster_table.sql
+++ b/crates/arroyo-api/migrations/V6__add_cluster_table.sql
@@ -1,4 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE cluster_info (
     id UUID PRIMARY KEY,
     name VARCHAR(255) NOT NULL,

--- a/crates/arroyo-api/migrations/V6__add_cluster_table.sql
+++ b/crates/arroyo-api/migrations/V6__add_cluster_table.sql
@@ -1,3 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE cluster_info (
     id UUID PRIMARY KEY,
     name VARCHAR(255) NOT NULL,


### PR DESCRIPTION
Sometime, we want to use external PG. However, However lower version PG (i.g. 12.16) may not support `gen_random_uuid` function by default and get following error in migration stage.
```text
{"timestamp":"2024-11-27T10:22:03.165300Z","level":"ERROR","fields":{"message":"Failed to run migrations on PostgresConfig { database_name: \"postgres\", host: \"10.252.176.141\", port: 25432, user: \"postgres\", password: Sensitive(\"JvVQknYlPYhJe2.P_ZAa1\") }: Error { kind: Connection(\"error applying migration V6__add_cluster_table\", Error { kind: Db, cause: Some(DbError { severity: \"ERROR\", parsed_severity: Some(Error), code: SqlState(E42883), message: \"function gen_random_uuid() does not exist\", detail: None, hint: Some(\"No function matches the given name and argument types. You might need to add explicit type casts.\"), position: Some(Original(264)), where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some(\"parse_func.c\"), line: Some(631), routine: Some(\"ParseFuncOrColumn\") }) }), report: Some(Report { applied_migrations: [] }) }"},"target":"arroyo"}
```
Here, we must enable `pgcrypto` extension. So I add below SQL for this case.
```SQL
CREATE EXTENSION IF NOT EXISTS pgcrypto;
```