### PR TITLE
RabbitMQ connection testing

### DIFF
--- a/crates/arroyo-connectors/src/rabbitmq/mod.rs
+++ b/crates/arroyo-connectors/src/rabbitmq/mod.rs
@@ -59,7 +59,7 @@ impl Connector for RabbitmqConnector {
         _: &str,
         config: Self::ProfileT,
         table: Self::TableT,
-        schema: Option<&arroyo_rpc::api_types::connections::ConnectionSchema>,
+        _schema: Option<&arroyo_rpc::api_types::connections::ConnectionSchema>,
         tx: tokio::sync::mpsc::Sender<arroyo_rpc::api_types::connections::TestSourceMessage>,
     ) {
         tokio::task::spawn(async move {


### PR DESCRIPTION
Update the RabbitmqConnector::test method to validate the connection parameters. If there is an error during the connection process, the method creates a `TestSourceMessage` that shows the error. If everything is fine, it confirms that the connection is successfully validated.

This pull request resolves a TODO that I left in the code in a previous PR.