### PR TITLE
Plan hop(x, x) to tumble(x)

### DIFF
--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -588,7 +588,12 @@ fn find_window(expression: &Expr) -> Result<Option<WindowType>> {
                         slide
                     );
                 }
-                Ok(Some(WindowType::Sliding { width, slide }))
+                if slide == width {
+                    // a hop window with slide == width is a tumble window
+                    Ok(Some(WindowType::Tumbling { width }))
+                } else {
+                    Ok(Some(WindowType::Sliding { width, slide }))
+                }
             }
             "tumble" => {
                 if args.len() != 1 {

--- a/crates/arroyo-planner/src/test/queries/hop_to_tumble.sql
+++ b/crates/arroyo-planner/src/test/queries/hop_to_tumble.sql
@@ -1,0 +1,7 @@
+create table impulse with (
+     connector = 'impulse',
+     event_rate = '10'
+);
+
+select count(*) from impulse
+group by hop(interval '10 seconds', interval '10 seconds');


### PR DESCRIPTION
Currently queries involving sliding windows with the same slide and width (like `hop(interval '10 seconds', interval '10 seconds)`) produce unexpected behavior in the operator. But logically this is just a tumbling window which are more efficient. This PR recognizes this patterns and plans a tumbling window instead of a sliding window.