### PR TITLE
Correctly handle AWS token refreshes for Delta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=public_token_cache#8b0175855610c7e895546afc8df966a4aeabee88"
+source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#4cfe48061503161e43cd3cd7960e74ce789bd3b9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ source = "git+https://github.com/delta-io/delta-rs?rev=25ce38956e25722ba7a6cbc0f
 dependencies = [
  "deltalake-aws",
  "deltalake-core",
+ "deltalake-gcp",
 ]
 
 [[package]]
@@ -3452,6 +3453,24 @@ dependencies = [
  "urlencoding",
  "uuid",
  "z85",
+]
+
+[[package]]
+name = "deltalake-gcp"
+version = "0.6.0"
+source = "git+https://github.com/delta-io/delta-rs?rev=25ce38956e25722ba7a6cbc0f5a7dba6b3361554#25ce38956e25722ba7a6cbc0f5a7dba6b3361554"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "deltalake-core",
+ "futures",
+ "lazy_static",
+ "object_store",
+ "regex",
+ "thiserror 2.0.3",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=public_token_cache#8b0175855610c7e895546afc8df966a4aeabee88"
+source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#4cfe48061503161e43cd3cd7960e74ce789bd3b9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,9 +1509,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.10"
+version = "1.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1520,7 +1520,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1602,7 +1602,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1625,7 +1625,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1647,7 +1647,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1661,15 +1661,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.49.0"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1683,15 +1683,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.50.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1705,15 +1705,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.49.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53dcf5e7d9bd1517b8b998e170e650047cea8a2b85fe1835abe3210713e541b7"
+checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1728,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1790,6 +1790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1845,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.9"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10060,9 +10069,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#4cfe48061503161e43cd3cd7960e74ce789bd3b9"
+source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#3eb9c26755e935892b8dfadd7acdb376ea52cc95"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7253,8 +7253,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -7300,7 +7300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -7390,7 +7390,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -8775,7 +8775,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -10404,7 +10404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#4cfe48061503161e43cd3cd7960e74ce789bd3b9"
+source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=public_token_cache#8b0175855610c7e895546afc8df966a4aeabee88"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=object_store_0.11.1%2Farroyo#4cfe48061503161e43cd3cd7960e74ce789bd3b9"
+source = "git+http://github.com/ArroyoSystems/arrow-rs?branch=public_token_cache#8b0175855610c7e895546afc8df966a4aeabee88"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,8 @@ datafusion-functions-window = {git = 'https://github.com/ArroyoSystems/arrow-dat
 
 datafusion-functions-json = {git = 'https://github.com/ArroyoSystems/datafusion-functions-json', branch = 'datafusion_43'}
 
-object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }
+# object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }
+object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'public_token_cache' }
 
 cornucopia_async = { git = "https://github.com/ArroyoSystems/cornucopia", branch = "sqlite" }
 cornucopia = { git = "https://github.com/ArroyoSystems/cornucopia", branch = "sqlite" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,7 @@ datafusion-functions-window = {git = 'https://github.com/ArroyoSystems/arrow-dat
 
 datafusion-functions-json = {git = 'https://github.com/ArroyoSystems/datafusion-functions-json', branch = 'datafusion_43'}
 
-# object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }
-object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'public_token_cache' }
+object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }
 
 cornucopia_async = { git = "https://github.com/ArroyoSystems/cornucopia", branch = "sqlite" }
 cornucopia = { git = "https://github.com/ArroyoSystems/cornucopia", branch = "sqlite" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ prost = { version = "0.13", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.0"
 prost-build = {version = "0.13" }
 prost-types = "0.13"
-aws-config = "1.5.6"
+aws-config = "1.5.13"
 reqwest = "0.12"
 
 [profile.release]

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -83,7 +83,7 @@ uuid = { version = "1.7.0", features = ["v4"] }
 # Filesystem
 parquet = { workspace = true, features = ["async"]}
 object_store = { workspace = true }
-deltalake = { workspace = true, features = ["s3"] }
+deltalake = { workspace = true, features = ["s3", "gcs"] }
 async-compression = { version = "0.4.3", features = ["tokio", "zstd", "gzip"] }
 
 # MQTT

--- a/crates/arroyo-connectors/src/filesystem/sink/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/delta.rs
@@ -1,52 +1,40 @@
 use super::FinishedFile;
 use anyhow::{Context, Result};
-use arrow::datatypes::{Schema, SchemaRef};
-use arroyo_storage::{get_current_credentials, StorageProvider};
+use arrow::datatypes::Schema;
+use arroyo_storage::{BackendConfig, StorageProvider};
 use arroyo_types::to_millis;
+use deltalake::aws::storage::S3StorageBackend;
 use deltalake::TableProperty::{MinReaderVersion, MinWriterVersion};
 use deltalake::{
-    aws::storage::s3_constants::AWS_S3_ALLOW_UNSAFE_RENAME,
     kernel::{Action, Add},
     operations::create::CreateBuilder,
     protocol::SaveMode,
     table::PeekCommit,
-    DeltaTableBuilder,
+    DeltaTable, DeltaTableBuilder,
 };
-use object_store::{aws::AmazonS3ConfigKey, path::Path};
-use once_cell::sync::Lazy;
+use object_store::{path::Path, ObjectStore};
+use std::sync::Arc;
 use std::{
     collections::{HashMap, HashSet},
     time::SystemTime,
 };
 use tracing::debug;
-
-static INIT: Lazy<()> = Lazy::new(|| {
-    deltalake::aws::register_handlers(None);
-});
+use url::Url;
 
 pub(crate) async fn commit_files_to_delta(
     finished_files: &[FinishedFile],
     relative_table_path: &Path,
-    storage_provider: &StorageProvider,
+    table: &mut DeltaTable,
     last_version: i64,
-    schema: SchemaRef,
 ) -> Result<Option<i64>> {
     if finished_files.is_empty() {
         return Ok(None);
     }
 
     let add_actions = create_add_actions(finished_files, relative_table_path)?;
-    let table_path = build_table_path(storage_provider, relative_table_path);
-    let storage_options = configure_storage_options(&table_path, storage_provider).await?;
-    let mut table = load_or_create_table(&table_path, storage_options, &schema).await?;
 
-    if let Some(new_version) = check_existing_files(
-        &mut table,
-        last_version,
-        finished_files,
-        relative_table_path,
-    )
-    .await?
+    if let Some(new_version) =
+        check_existing_files(table, last_version, finished_files, relative_table_path).await?
     {
         return Ok(Some(new_version));
     }
@@ -55,72 +43,50 @@ pub(crate) async fn commit_files_to_delta(
     Ok(Some(new_version))
 }
 
-async fn load_or_create_table(
-    table_path: &str,
-    storage_options: HashMap<String, String>,
-    schema: &Schema,
-) -> Result<deltalake::DeltaTable> {
-    Lazy::force(&INIT);
-    deltalake::aws::register_handlers(None);
-    match DeltaTableBuilder::from_uri(table_path)
-        .with_storage_options(storage_options.clone())
-        .load()
-        .await
-    {
-        Ok(table) => Ok(table),
-        Err(deltalake::DeltaTableError::NotATable(_)) => {
-            create_new_table(table_path, storage_options, schema).await
-        }
-        Err(err) => Err(err.into()),
-    }
-}
-
-async fn create_new_table(
-    table_path: &str,
-    storage_options: HashMap<String, String>,
-    schema: &Schema,
-) -> Result<deltalake::DeltaTable> {
-    let delta_object_store = DeltaTableBuilder::from_uri(table_path)
-        .with_storage_options(storage_options)
-        .build_storage()?;
-    let delta_schema: deltalake::kernel::Schema = (schema).try_into()?;
-    CreateBuilder::new()
-        .with_log_store(delta_object_store)
-        .with_columns(delta_schema.fields().cloned())
-        .with_configuration_property(MinReaderVersion, Some("3"))
-        .with_configuration_property(MinWriterVersion, Some("7"))
-        .await
-        .map_err(Into::into)
-}
-
-async fn configure_storage_options(
-    table_path: &str,
+pub(crate) async fn load_or_create_table(
+    table_path: &Path,
     storage_provider: &StorageProvider,
-) -> Result<HashMap<String, String>> {
-    let mut options = storage_provider.storage_options().clone();
-    if table_path.starts_with("s3://") {
-        update_s3_credentials(&mut options).await?;
-    }
-    Ok(options)
-}
+    schema: &Schema,
+) -> Result<DeltaTable> {
+    deltalake::aws::register_handlers(None);
+    deltalake::gcp::register_handlers(None);
 
-async fn update_s3_credentials(options: &mut HashMap<String, String>) -> Result<()> {
-    if !options.contains_key(AmazonS3ConfigKey::SecretAccessKey.as_ref()) {
-        let tmp_credentials = get_current_credentials().await?;
-        options.insert(
-            AmazonS3ConfigKey::AccessKeyId.as_ref().to_string(),
-            tmp_credentials.key_id.clone(),
-        );
-        options.insert(
-            AmazonS3ConfigKey::SecretAccessKey.as_ref().to_string(),
-            tmp_credentials.secret_key.clone(),
-        );
-        if let Some(token) = tmp_credentials.token.as_ref() {
-            options.insert(AmazonS3ConfigKey::Token.as_ref().to_string(), token.clone());
-        }
+    let (backing_store, url): (Arc<dyn ObjectStore>, _) = match storage_provider.config() {
+        BackendConfig::S3(_) => (
+            Arc::new(S3StorageBackend::try_new(
+                storage_provider.get_backing_store(),
+                true,
+            )?),
+            format!("s3://{}", storage_provider.qualify_path(table_path)),
+        ),
+        BackendConfig::GCS(_) => (
+            storage_provider.get_backing_store(),
+            format!("gs://{}", storage_provider.qualify_path(table_path)),
+        ),
+        BackendConfig::Local(_) => (storage_provider.get_backing_store(), table_path.to_string()),
+    };
+
+    let mut delta = DeltaTableBuilder::from_uri(&url)
+        .with_storage_backend(
+            backing_store,
+            Url::parse(&storage_provider.canonical_url())?,
+        )
+        .build()?;
+
+    println!("Table uri = {}", delta.table_uri());
+
+    if delta.verify_deltatable_existence().await? {
+        delta.load().await?;
+        Ok(delta)
+    } else {
+        let delta_schema: deltalake::kernel::Schema = schema.try_into()?;
+        Ok(CreateBuilder::new()
+            .with_log_store(delta.log_store())
+            .with_columns(delta_schema.fields().cloned())
+            .with_configuration_property(MinReaderVersion, Some("3"))
+            .with_configuration_property(MinWriterVersion, Some("7"))
+            .await?)
     }
-    options.insert(AWS_S3_ALLOW_UNSAFE_RENAME.to_string(), "true".to_string());
-    Ok(())
 }
 
 fn create_add_actions(
@@ -158,7 +124,7 @@ fn create_add_action(file: &FinishedFile, relative_table_path: &Path) -> Result<
 }
 
 async fn check_existing_files(
-    table: &mut deltalake::DeltaTable,
+    table: &mut DeltaTable,
     last_version: i64,
     finished_files: &[FinishedFile],
     relative_table_path: &Path,
@@ -191,7 +157,7 @@ async fn check_existing_files(
     Ok(None)
 }
 
-async fn commit_to_delta(table: deltalake::DeltaTable, add_actions: Vec<Action>) -> Result<i64> {
+async fn commit_to_delta(table: &mut DeltaTable, add_actions: Vec<Action>) -> Result<i64> {
     Ok(deltalake::operations::transaction::CommitBuilder::default()
         .with_actions(add_actions)
         .build(
@@ -205,12 +171,4 @@ async fn commit_to_delta(table: deltalake::DeltaTable, add_actions: Vec<Action>)
         )
         .await?
         .version)
-}
-
-fn build_table_path(storage_provider: &StorageProvider, relative_table_path: &Path) -> String {
-    format!(
-        "{}/{}",
-        storage_provider.object_store_base_url(),
-        relative_table_path
-    )
 }

--- a/crates/arroyo-connectors/src/filesystem/sink/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/delta.rs
@@ -67,13 +67,8 @@ pub(crate) async fn load_or_create_table(
     };
 
     let mut delta = DeltaTableBuilder::from_uri(&url)
-        .with_storage_backend(
-            backing_store,
-            Url::parse(&storage_provider.canonical_url())?,
-        )
+        .with_storage_backend(backing_store, Url::parse(storage_provider.canonical_url())?)
         .build()?;
-
-    println!("Table uri = {}", delta.table_uri());
 
     if delta.verify_deltatable_existence().await? {
         delta.load().await?;

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -37,7 +37,7 @@ use futures::{stream::FuturesUnordered, Future};
 use futures::{stream::StreamExt, TryStreamExt};
 use object_store::{multipart::PartId, path::Path, MultipartId};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use arroyo_types::*;
@@ -507,7 +507,7 @@ async fn from_checkpoint(
             parts_to_add,
             trailing_bytes,
         } => {
-            info!("finishing file for path {:?}", path);
+            debug!("finishing file for path {:?}", path);
             let multipart_id = object_store
                 .start_multipart(path)
                 .await
@@ -527,7 +527,7 @@ async fn from_checkpoint(
                     .await?;
                 parts.push(upload_part);
             }
-            info!(
+            debug!(
                 "parts: {:?}, pushed_size: {:?}, multipart id: {:?}",
                 parts, pushed_size, multipart_id
             );

--- a/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
@@ -13,7 +13,7 @@ use bincode::config;
 use prost::Message;
 use std::fmt::Debug;
 use std::{collections::HashMap, time::SystemTime};
-use tracing::info;
+use tracing::debug;
 
 pub struct TwoPhaseCommitterOperator<TPC: TwoPhaseCommitter> {
     committer: TPC,
@@ -86,7 +86,7 @@ impl<TPC: TwoPhaseCommitter> TwoPhaseCommitterOperator<TPC> {
         mut commit_data: HashMap<String, HashMap<u32, Vec<u8>>>,
         ctx: &mut OperatorContext,
     ) {
-        info!("received commit message");
+        debug!("received commit message");
         let pre_commits = match self.committer.commit_strategy() {
             CommitStrategy::PerSubtask => std::mem::take(&mut self.pre_commits),
             CommitStrategy::PerOperator => {

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -180,13 +180,6 @@ impl Scheduler for KubernetesScheduler {
         let replicas = (req.slots as f32 / config().kubernetes_scheduler.worker.task_slots as f32)
             .ceil() as usize;
 
-        info!(
-            job_id = *req.job_id,
-            message = "starting workers on k8s",
-            replicas,
-            task_slots = req.slots
-        );
-
         let max_slots_per_pod = config().kubernetes_scheduler.worker.task_slots as usize;
         let mut slots_scheduled = 0;
         let mut pods = vec![];

--- a/crates/arroyo-state/src/tables/global_keyed_map.rs
+++ b/crates/arroyo-state/src/tables/global_keyed_map.rs
@@ -17,7 +17,7 @@ use parquet::{
     basic::ZstdLevel,
     file::properties::{EnabledStatistics, WriterProperties},
 };
-use tracing::info;
+use tracing::debug;
 
 use std::iter::Zip;
 
@@ -244,7 +244,7 @@ impl TableEpochCheckpointer for GlobalKeyedCheckpointer {
                 bail!("global keyed data expects KeyedData, not record batches")
             }
             TableData::CommitData { data } => {
-                info!("received commit data");
+                debug!("received commit data");
                 // set commit data, failing if it was already set
                 if self.commit_data.is_some() {
                     bail!("commit data already set for this epoch")

--- a/crates/arroyo-storage/src/aws.rs
+++ b/crates/arroyo-storage/src/aws.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::OnceCell;
+use tracing::info;
 
 pub struct ArroyoCredentialProvider {
     cache: TokenCache<Arc<AwsCredential>>,
@@ -66,6 +67,7 @@ impl ArroyoCredentialProvider {
 async fn get_token(
     provider: &SharedCredentialsProvider,
 ) -> Result<TemporaryToken<Arc<AwsCredential>>, Box<dyn Error + Send + Sync>> {
+    info!("Getting credentials");
     let creds = provider
         .provide_credentials()
         .await
@@ -73,6 +75,7 @@ async fn get_token(
             store: "S3",
             source: Box::new(e),
         })?;
+    info!("Got credentials = {:?}", creds);
     let expiry = creds
         .expiry()
         .map(|exp| Instant::now() + exp.elapsed().unwrap_or_default());


### PR DESCRIPTION
Previously we were allowing delta-rs to create it own object stores with its own authentication handling. In order to get parity with our existing auth strategy for AWS (which relies on the official aws-config library to get consistency with aws-cli and other AWS tools), we were fetching a token at delta-rs creation time and passing that to the library.

This works for static, long-lived credentials, but fails for dynamically-refreshed credentials like those from IRSA. This PR reworks our use of delta-rs such that we use our own object_store structs, which properly handle credential refreshing.

While debugging this issue, I also discovered that because object_store uses its own HTTP client to make S3 requests (rather than using AWS smithy), there was no token caching being performed, leading to a huge volume of requests to Amazon STS and some additional latency for S3 operations. This PR also introduces our own sophisticated token cache for AWS, with support for lazy and asynchronous token refreshes.