### PR TITLE
Lookup joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "local-ip-address",
  "md-5",
  "memchr",
+ "mini-moka",
  "object_store",
  "once_cell",
  "ordered-float 3.9.2",
@@ -2203,6 +2204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "bytemuck"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2286,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3782,6 +3802,15 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -5964,6 +5993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7253,8 +7297,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -7300,7 +7344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -7381,6 +7425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.6.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7390,7 +7445,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -8740,6 +8795,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8775,7 +8845,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -9073,6 +9143,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -9812,6 +9888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10186,7 +10268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "cfg-if",
  "regex",
  "rustversion",
@@ -10404,7 +10486,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/arroyo-api/src/connection_tables.rs
+++ b/crates/arroyo-api/src/connection_tables.rs
@@ -509,6 +509,9 @@ async fn expand_avro_schema(
             ConnectionType::Sink => {
                 // don't fetch schemas for sinks for now
             }
+            ConnectionType::Lookup => {
+                todo!("lookup tables cannot be created via the UI")
+            }
         }
     }
 
@@ -520,6 +523,9 @@ async fn expand_avro_schema(
             ConnectionType::Sink => {
                 schema.inferred = Some(true);
                 Ok(schema)
+            }
+            ConnectionType::Lookup => {
+                todo!("lookup tables cannot be created via the UI")
             }
         };
     };
@@ -595,6 +601,9 @@ async fn expand_proto_schema(
             }
             ConnectionType::Sink => {
                 // don't fetch schemas for sinks for now
+            }
+            ConnectionType::Lookup => {
+                todo!("lookup tables cannot be created via the UI")
             }
         }
     }
@@ -696,6 +705,9 @@ async fn expand_json_schema(
             ConnectionType::Sink => {
                 // don't fetch schemas for sinks for now until we're better able to conform our output to the schema
                 schema.inferred = Some(true);
+            }
+            ConnectionType::Lookup => {
+                todo!("lookup tables cannot be created via the UI")
             }
         }
     }

--- a/crates/arroyo-connectors/src/filesystem/sink/local.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/local.rs
@@ -233,7 +233,7 @@ impl<V: LocalWriter + Send + 'static> TwoPhaseCommitter for LocalFileSystemWrite
 
         let storage_provider = StorageProvider::for_url(&self.final_dir).await?;
 
-        let schema = Arc::new(ctx.in_schemas[0].clone());
+        let schema = ctx.in_schemas[0].clone();
 
         self.commit_state = Some(match self.file_settings.commit_style.unwrap() {
             CommitStyle::DeltaLake => CommitState::DeltaLake {

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -1564,8 +1564,7 @@ impl<R: MultiPartWriter + Send + 'static> TwoPhaseCommitter for FileSystemSink<R
         ctx: &mut OperatorContext,
         data_recovery: Vec<Self::DataRecovery>,
     ) -> Result<()> {
-        self.start(Arc::new(ctx.in_schemas.first().unwrap().clone()))
-            .await?;
+        self.start(Arc::new(ctx.in_schemas.first().unwrap().clone()))?;
 
         let mut max_file_index = 0;
         let mut recovered_files = Vec::new();

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -1564,7 +1564,7 @@ impl<R: MultiPartWriter + Send + 'static> TwoPhaseCommitter for FileSystemSink<R
         ctx: &mut OperatorContext,
         data_recovery: Vec<Self::DataRecovery>,
     ) -> Result<()> {
-        self.start(Arc::new(ctx.in_schemas.first().unwrap().clone()))?;
+        self.start(ctx.in_schemas.first().unwrap().clone()).await?;
 
         let mut max_file_index = 0;
         let mut recovered_files = Vec::new();

--- a/crates/arroyo-connectors/src/filesystem/source.rs
+++ b/crates/arroyo-connectors/src/filesystem/source.rs
@@ -128,6 +128,7 @@ impl FileSystemSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
         let parallelism = ctx.task_info.parallelism;
         let task_index = ctx.task_info.task_index;

--- a/crates/arroyo-connectors/src/fluvio/source.rs
+++ b/crates/arroyo-connectors/src/fluvio/source.rs
@@ -57,6 +57,7 @@ impl SourceOperator for FluvioSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         match self.run_int(ctx, collector).await {

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -34,6 +34,7 @@ pub fn impulse_schema() -> ConnectionSchema {
         ],
         definition: None,
         inferred: None,
+        primary_keys: Default::default(),
     }
 }
 

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -642,6 +642,7 @@ impl KafkaTester {
                         format.clone(),
                         None,
                         Arc::new(aschema),
+                        &schema.metadata_fields(),
                         BadData::Fail {},
                         Arc::new(schema_resolver),
                     );

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -664,6 +664,7 @@ impl KafkaTester {
                     let mut deserializer = ArrowDeserializer::new(
                         format.clone(),
                         Arc::new(aschema),
+                        &schema.metadata_fields(),
                         None,
                         BadData::Fail {},
                     );
@@ -701,6 +702,7 @@ impl KafkaTester {
                 let mut deserializer = ArrowDeserializer::new(
                     format.clone(),
                     Arc::new(aschema),
+                    &schema.metadata_fields(),
                     None,
                     BadData::Fail {},
                 );

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -645,10 +645,9 @@ impl KafkaTester {
                         BadData::Fail {},
                         Arc::new(schema_resolver),
                     );
-                    let mut builders = aschema.builders();
 
                     let mut error = deserializer
-                        .deserialize_slice(&mut builders, &msg, SystemTime::now(), None)
+                        .deserialize_slice(&msg, SystemTime::now(), None)
                         .await
                         .into_iter()
                         .next();
@@ -667,10 +666,9 @@ impl KafkaTester {
                         None,
                         BadData::Fail {},
                     );
-                    let mut builders = aschema.builders();
 
                     let mut error = deserializer
-                        .deserialize_slice(&mut builders, &msg, SystemTime::now(), None)
+                        .deserialize_slice(&msg, SystemTime::now(), None)
                         .await
                         .into_iter()
                         .next();
@@ -701,10 +699,9 @@ impl KafkaTester {
                 let aschema: ArroyoSchema = schema.clone().into();
                 let mut deserializer =
                     ArrowDeserializer::new(format.clone(), aschema.clone(), None, BadData::Fail {});
-                let mut builders = aschema.builders();
 
                 let mut error = deserializer
-                    .deserialize_slice(&mut builders, &msg, SystemTime::now(), None)
+                    .deserialize_slice(&msg, SystemTime::now(), None)
                     .await
                     .into_iter()
                     .next();

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -641,7 +641,7 @@ impl KafkaTester {
                     let mut deserializer = ArrowDeserializer::with_schema_resolver(
                         format.clone(),
                         None,
-                        aschema.clone(),
+                        Arc::new(aschema),
                         BadData::Fail {},
                         Arc::new(schema_resolver),
                     );
@@ -662,7 +662,7 @@ impl KafkaTester {
                     let aschema: ArroyoSchema = schema.clone().into();
                     let mut deserializer = ArrowDeserializer::new(
                         format.clone(),
-                        aschema.clone(),
+                        Arc::new(aschema),
                         None,
                         BadData::Fail {},
                     );
@@ -697,8 +697,12 @@ impl KafkaTester {
             }
             Format::Protobuf(_) => {
                 let aschema: ArroyoSchema = schema.clone().into();
-                let mut deserializer =
-                    ArrowDeserializer::new(format.clone(), aschema.clone(), None, BadData::Fail {});
+                let mut deserializer = ArrowDeserializer::new(
+                    format.clone(),
+                    Arc::new(aschema),
+                    None,
+                    BadData::Fail {},
+                );
 
                 let mut error = deserializer
                     .deserialize_slice(&msg, SystemTime::now(), None)

--- a/crates/arroyo-connectors/src/kafka/sink/test.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/test.rs
@@ -96,7 +96,7 @@ impl KafkaTopicTester {
             None,
             command_tx,
             1,
-            vec![ArroyoSchema::new_unkeyed(schema(), 0)],
+            vec![Arc::new(ArroyoSchema::new_unkeyed(schema(), 0))],
             None,
             HashMap::new(),
         )

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -181,6 +181,7 @@ impl KafkaSourceFunc {
                 self.format.clone(),
                 self.framing.clone(),
                 self.bad_data.clone(),
+                &self.metadata_fields,
             );
         }
 

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -173,6 +173,7 @@ impl KafkaSourceFunc {
                 self.format.clone(),
                 self.framing.clone(),
                 self.bad_data.clone(),
+                &self.metadata_fields,
                 schema_resolver.clone(),
             );
         } else {
@@ -201,7 +202,7 @@ impl KafkaSourceFunc {
                                 let connector_metadata = if !self.metadata_fields.is_empty() {
                                     let mut connector_metadata = HashMap::new();
                                     for f in &self.metadata_fields {
-                                        connector_metadata.insert(&f.field_name, match f.key.as_str() {
+                                        connector_metadata.insert(f.field_name.as_str(), match f.key.as_str() {
                                             "offset_id" => FieldValueType::Int64(msg.offset()),
                                             "partition" => FieldValueType::Int32(msg.partition()),
                                             "topic" => FieldValueType::String(topic),

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -5,14 +5,10 @@ use arroyo_state::tables::ErasedTable;
 use arroyo_state::{BackingStore, StateBackend};
 use rand::random;
 
-use arrow::array::{Array, StringArray};
-use arrow::datatypes::TimeUnit;
-use std::collections::{HashMap, VecDeque};
-use std::num::NonZeroU32;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime};
-use arrow::datatypes::DataType::UInt64;
 use crate::kafka::SourceOffset;
+use arrow::array::{Array, StringArray};
+use arrow::datatypes::DataType::UInt64;
+use arrow::datatypes::TimeUnit;
 use arroyo_operator::context::{
     batch_bounded, ArrowCollector, BatchReceiver, OperatorContext, SourceCollector, SourceContext,
 };
@@ -29,6 +25,10 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
 use rdkafka::producer::{BaseProducer, BaseRecord};
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use super::KafkaSourceFunc;

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -108,7 +108,7 @@ impl KafkaTopicTester {
             operator_ids: vec![task_info.operator_id.clone()],
         });
 
-        let out_schema = Some(ArroyoSchema::new_unkeyed(
+        let out_schema = Some(Arc::new(ArroyoSchema::new_unkeyed(
             Arc::new(Schema::new(vec![
                 Field::new(
                     "_timestamp",
@@ -118,7 +118,7 @@ impl KafkaTopicTester {
                 Field::new("value", DataType::Utf8, false),
             ])),
             0,
-        ));
+        )));
 
         let task_info = Arc::new(task_info);
 

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-
+use arrow::datatypes::DataType::UInt64;
 use crate::kafka::SourceOffset;
 use arroyo_operator::context::{
     batch_bounded, ArrowCollector, BatchReceiver, OperatorContext, SourceCollector, SourceContext,
@@ -389,6 +389,7 @@ async fn test_kafka_with_metadata_fields() {
     let metadata_fields = vec![MetadataField {
         field_name: "offset".to_string(),
         key: "offset_id".to_string(),
+        data_type: Some(UInt64),
     }];
 
     // Set metadata fields in KafkaSourceFunc
@@ -420,7 +421,7 @@ async fn test_kafka_with_metadata_fields() {
         command_tx.clone(),
         1,
         vec![],
-        Some(ArroyoSchema::new_unkeyed(
+        Some(Arc::new(ArroyoSchema::new_unkeyed(
             Arc::new(Schema::new(vec![
                 Field::new(
                     "_timestamp",
@@ -431,7 +432,7 @@ async fn test_kafka_with_metadata_fields() {
                 Field::new("offset", DataType::Int64, false),
             ])),
             0,
-        )),
+        ))),
         kafka.tables(),
     )
     .await;

--- a/crates/arroyo-connectors/src/kinesis/source.rs
+++ b/crates/arroyo-connectors/src/kinesis/source.rs
@@ -173,6 +173,7 @@ impl SourceOperator for KinesisSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         match self.run_int(ctx, collector).await {

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -11,6 +11,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+use arrow::array::{ArrayRef, RecordBatch};
+use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 use tracing::warn;
 
@@ -63,6 +65,14 @@ pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
 
 #[derive(Serialize, Deserialize)]
 pub struct EmptyConfig {}
+
+#[async_trait]
+pub trait LookupConnector {
+    fn name(&self) -> String;
+
+    async fn lookup(&mut self, keys: &[ArrayRef]) -> RecordBatch;
+}
+
 
 pub(crate) async fn send(tx: &mut Sender<TestSourceMessage>, msg: TestSourceMessage) {
     if tx.send(msg).await.is_err() {

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -5,7 +5,7 @@ use arroyo_rpc::api_types::connections::{
 };
 use arroyo_rpc::primitive_to_sql;
 use arroyo_rpc::var_str::VarStr;
-use arroyo_types::string_to_map;
+use arroyo_types::{string_to_map, SourceError};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -70,7 +70,7 @@ pub struct EmptyConfig {}
 pub trait LookupConnector {
     fn name(&self) -> String;
 
-    async fn lookup(&mut self, keys: &[ArrayRef]) -> RecordBatch;
+    async fn lookup(&mut self, keys: &[ArrayRef]) -> Option<Result<RecordBatch, SourceError>>;
 }
 
 

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -1,13 +1,11 @@
 use anyhow::{anyhow, bail, Context};
-use arrow::array::{ArrayRef, RecordBatch};
 use arroyo_operator::connector::ErasedConnector;
 use arroyo_rpc::api_types::connections::{
     ConnectionSchema, ConnectionType, FieldType, SourceField, SourceFieldType, TestSourceMessage,
 };
 use arroyo_rpc::primitive_to_sql;
 use arroyo_rpc::var_str::VarStr;
-use arroyo_types::{string_to_map, SourceError};
-use async_trait::async_trait;
+use arroyo_types::string_to_map;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};

--- a/crates/arroyo-connectors/src/mqtt/sink/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/test.rs
@@ -84,7 +84,7 @@ impl MqttTopicTester {
             None,
             command_tx,
             1,
-            vec![ArroyoSchema::new_unkeyed(schema(), 0)],
+            vec![Arc::new(ArroyoSchema::new_unkeyed(schema(), 0))],
             None,
             HashMap::new(),
         )

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -101,6 +101,7 @@ impl MqttSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &self.metadata_fields,
         );
 
         if ctx.task_info.task_index > 0 {

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -152,7 +152,7 @@ impl MqttSourceFunc {
                             let connector_metadata = if !self.metadata_fields.is_empty() {
                                 let mut connector_metadata = HashMap::new();
                                 for mf in &self.metadata_fields {
-                                    connector_metadata.insert(&mf.field_name, match mf.key.as_str() {
+                                    connector_metadata.insert(mf.field_name.as_str(), match mf.key.as_str() {
                                         "topic" => FieldValueType::String(&topic),
                                         k => unreachable!("invalid metadata key '{}' for mqtt", k)
                                     });

--- a/crates/arroyo-connectors/src/mqtt/source/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/test.rs
@@ -141,7 +141,7 @@ impl MqttTopicTester {
             command_tx.clone(),
             1,
             vec![],
-            Some(ArroyoSchema::new_unkeyed(
+            Some(Arc::new(ArroyoSchema::new_unkeyed(
                 Arc::new(Schema::new(vec![
                     Field::new(
                         "_timestamp",
@@ -151,7 +151,7 @@ impl MqttTopicTester {
                     Field::new("value", DataType::UInt64, false),
                 ])),
                 0,
-            )),
+            ))),
             mqtt.tables(),
         )
         .await;

--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -333,6 +333,7 @@ impl NatsSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         let nats_client = get_nats_client(&self.connection)

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -91,6 +91,7 @@ pub fn nexmark_schema() -> ConnectionSchema {
             .collect(),
         definition: None,
         inferred: None,
+        primary_keys: Default::default(),
     }
 }
 

--- a/crates/arroyo-connectors/src/polling_http/operator.rs
+++ b/crates/arroyo-connectors/src/polling_http/operator.rs
@@ -208,6 +208,7 @@ impl PollingHttpSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         // since there's no way to partition across an http source, only read on the first task

--- a/crates/arroyo-connectors/src/rabbitmq/source.rs
+++ b/crates/arroyo-connectors/src/rabbitmq/source.rs
@@ -50,6 +50,7 @@ impl SourceOperator for RabbitmqStreamSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         match self.run_int(ctx, collector).await {

--- a/crates/arroyo-connectors/src/redis/lookup.rs
+++ b/crates/arroyo-connectors/src/redis/lookup.rs
@@ -1,0 +1,75 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use arrow::array::{ArrayRef, AsArray, RecordBatch};
+use arrow::compute::StringArrayType;
+use arrow::datatypes::DataType;
+use async_trait::async_trait;
+use futures::future::OptionFuture;
+use futures::stream::FuturesOrdered;
+use futures::StreamExt;
+use redis::{AsyncCommands, RedisFuture, RedisResult};
+use arroyo_formats::de::ArrowDeserializer;
+use crate::LookupConnector;
+use crate::redis::{RedisClient, RedisConnector};
+use crate::redis::sink::GeneralConnection;
+
+pub struct RedisLookup {
+    deserializer: ArrowDeserializer,
+    client: RedisClient,
+    connection: Option<GeneralConnection>,
+}
+
+// pub enum RedisFutureOrNull<'a> {
+//     RedisFuture(RedisFuture<'a, String>),
+//     Null
+// }
+// 
+// impl <'a> Future for RedisFutureOrNull<'a> {
+//     type Output = RedisResult<Option<String>>;
+// 
+//     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//         match self {
+//             RedisFutureOrNull::RedisFuture(f) => (**f).poll().map(|t| Some(t)),
+//             RedisFutureOrNull::Null => Poll::Ready(None),
+//         }
+//     }
+// }
+
+#[async_trait]
+impl LookupConnector for RedisLookup {
+    fn name(&self) -> String {
+        "RedisLookup".to_string()
+    }
+
+    async fn lookup(&mut self, keys: &[ArrayRef]) -> RecordBatch {
+        if self.connection.is_none() {
+            self.connection = Some(self.client.get_connection().await.unwrap());
+        }
+
+        assert_eq!(keys.len(), 1, "redis lookup can only have a single key");
+        assert_eq!(*keys[0].data_type(), DataType::Utf8, "redis lookup key must be a string");
+
+        let key = keys[0].as_string();
+
+        let connection = self.connection.as_mut().unwrap();
+        
+        let result = connection.mget::<_, Vec<String>>(&key.iter().filter_map(|k| k).collect::<Vec<_>>())
+            .await
+            .unwrap();
+        
+        let mut result_iter = result.iter();
+        
+        for k in key.iter() {
+            if k.is_some() {
+                self.deserializer.deserialize_slice()result_iter.next()
+            }
+        } 
+    
+        while let Some(t) = futures.next().await {
+            
+        };
+        
+        Ok(())
+    }
+}

--- a/crates/arroyo-connectors/src/redis/lookup.rs
+++ b/crates/arroyo-connectors/src/redis/lookup.rs
@@ -1,19 +1,19 @@
-use std::time::SystemTime;
+use crate::redis::sink::GeneralConnection;
+use crate::redis::RedisClient;
 use arrow::array::{ArrayRef, AsArray, RecordBatch};
 use arrow::datatypes::DataType;
-use async_trait::async_trait;
-use redis::{cmd, Value};
-use redis::aio::ConnectionLike;
 use arroyo_formats::de::ArrowDeserializer;
+use arroyo_operator::connector::LookupConnector;
 use arroyo_types::SourceError;
-use crate::LookupConnector;
-use crate::redis::{RedisClient};
-use crate::redis::sink::GeneralConnection;
+use async_trait::async_trait;
+use redis::aio::ConnectionLike;
+use redis::{cmd, Value};
+use std::time::SystemTime;
 
 pub struct RedisLookup {
-    deserializer: ArrowDeserializer,
-    client: RedisClient,
-    connection: Option<GeneralConnection>,
+    pub(crate) deserializer: ArrowDeserializer,
+    pub(crate) client: RedisClient,
+    pub(crate) connection: Option<GeneralConnection>,
 }
 
 #[async_trait]
@@ -28,13 +28,16 @@ impl LookupConnector for RedisLookup {
         }
 
         assert_eq!(keys.len(), 1, "redis lookup can only have a single key");
-        assert_eq!(*keys[0].data_type(), DataType::Utf8, "redis lookup key must be a string");
-
+        assert_eq!(
+            *keys[0].data_type(),
+            DataType::Utf8,
+            "redis lookup key must be a string"
+        );
 
         let connection = self.connection.as_mut().unwrap();
-        
+
         let mut mget = cmd("mget");
-        
+
         for k in keys[0].as_string::<i32>() {
             mget.arg(k.unwrap());
         }
@@ -42,22 +45,24 @@ impl LookupConnector for RedisLookup {
         let Value::Array(vs) = connection.req_packed_command(&mget).await.unwrap() else {
             panic!("value was not an array");
         };
-        
+
         for v in vs {
             match v {
                 Value::Nil => {
-                    todo!("handle missing values")
+                    self.deserializer.deserialize_slice("null".as_bytes(), SystemTime::now(), None)
+                        .await;
                 }
                 Value::SimpleString(s) => {
-                    self.deserializer.deserialize_slice(s.as_bytes(), SystemTime::now(), None).await;
+                    self.deserializer
+                        .deserialize_slice(s.as_bytes(), SystemTime::now(), None)
+                        .await;
                 }
                 v => {
                     panic!("unexpected type {:?}", v);
                 }
             }
         }
-        
-        
+
         self.deserializer.flush_buffer()
     }
 }

--- a/crates/arroyo-connectors/src/redis/lookup.rs
+++ b/crates/arroyo-connectors/src/redis/lookup.rs
@@ -82,7 +82,7 @@ impl LookupConnector for RedisLookup {
                 }
                 Value::BulkString(v) => {
                     self.deserializer
-                        .deserialize_without_timestamp(&v, Some(&additional))
+                        .deserialize_without_timestamp(v, Some(&additional))
                         .await
                 }
                 v => {

--- a/crates/arroyo-connectors/src/redis/lookup.rs
+++ b/crates/arroyo-connectors/src/redis/lookup.rs
@@ -49,7 +49,8 @@ impl LookupConnector for RedisLookup {
         for v in vs {
             match v {
                 Value::Nil => {
-                    self.deserializer.deserialize_slice("null".as_bytes(), SystemTime::now(), None)
+                    self.deserializer
+                        .deserialize_slice("null".as_bytes(), SystemTime::now(), None)
                         .await;
                 }
                 Value::SimpleString(s) => {

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -1,7 +1,11 @@
 pub mod lookup;
 pub mod sink;
 
+use crate::redis::lookup::RedisLookup;
+use crate::redis::sink::{GeneralConnection, RedisSinkFunc};
+use crate::{pull_opt, pull_option_to_u64};
 use anyhow::{anyhow, bail};
+use arrow::datatypes::{DataType, Schema};
 use arroyo_formats::de::ArrowDeserializer;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector, LookupConnector, MetadataDef};
@@ -11,6 +15,7 @@ use arroyo_rpc::api_types::connections::{
     TestSourceMessage,
 };
 use arroyo_rpc::df::ArroyoSchema;
+use arroyo_rpc::schema_resolver::FailingSchemaResolver;
 use arroyo_rpc::var_str::VarStr;
 use arroyo_rpc::OperatorConfig;
 use redis::aio::ConnectionManager;
@@ -19,13 +24,8 @@ use redis::{Client, ConnectionInfo, IntoConnectionInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use arrow::datatypes::{DataType, Schema};
 use tokio::sync::oneshot::Receiver;
 use typify::import_types;
-use arroyo_rpc::schema_resolver::FailingSchemaResolver;
-use crate::redis::lookup::RedisLookup;
-use crate::redis::sink::{GeneralConnection, RedisSinkFunc};
-use crate::{pull_opt, pull_option_to_u64};
 
 pub struct RedisConnector {}
 
@@ -463,7 +463,7 @@ impl Connector for RedisConnector {
                     .format
                     .ok_or_else(|| anyhow!("Redis table must have a format"))?,
                 schema,
-                &config.metadata_fields,                
+                &config.metadata_fields,
                 config.bad_data.unwrap_or_default(),
                 Arc::new(FailingSchemaResolver::new()),
             ),

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -303,13 +303,13 @@ impl Connector for RedisConnector {
             "lookup" => {
                 // for look-up tables, we require that there's a primary key metadata field
                 for f in &schema.fields {
-                    if schema.primary_keys.contains(&f.field_name) {
-                        if f.metadata_key.as_ref().map(|k| k != "key").unwrap_or(true) {
-                            bail!(
-                                "Redis lookup tables must have a PRIMARY KEY field defined as \
-                            `field_name TEXT GENERATED ALWAYS AS (metadata('key')) STORED`"
-                            );
-                        }
+                    if schema.primary_keys.contains(&f.field_name)
+                        && f.metadata_key.as_ref().map(|k| k != "key").unwrap_or(true)
+                    {
+                        bail!(
+                            "Redis lookup tables must have a PRIMARY KEY field defined as \
+                        `field_name TEXT GENERATED ALWAYS AS (metadata('key')) STORED`"
+                        );
                     }
                 }
 

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -14,7 +14,6 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, FieldType, PrimitiveType,
     TestSourceMessage,
 };
-use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::schema_resolver::FailingSchemaResolver;
 use arroyo_rpc::var_str::VarStr;
 use arroyo_rpc::OperatorConfig;
@@ -453,7 +452,7 @@ impl Connector for RedisConnector {
     fn make_lookup(
         &self,
         profile: Self::ProfileT,
-        table: Self::TableT,
+        _: Self::TableT,
         config: OperatorConfig,
         schema: Arc<Schema>,
     ) -> anyhow::Result<Box<dyn LookupConnector + Send>> {

--- a/crates/arroyo-connectors/src/redis/operator/mod.rs
+++ b/crates/arroyo-connectors/src/redis/operator/mod.rs
@@ -1,1 +1,0 @@
-pub mod sink;

--- a/crates/arroyo-connectors/src/redis/sink.rs
+++ b/crates/arroyo-connectors/src/redis/sink.rs
@@ -1,4 +1,4 @@
-use crate::redis::{ListOperation, RedisClient, RedisTable, TableType, Target};
+use crate::redis::{ListOperation, RedisClient, Target};
 use arrow::array::{AsArray, RecordBatch};
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::context::{Collector, ErrorReporter, OperatorContext};
@@ -20,7 +20,7 @@ const FLUSH_BYTES: usize = 10 * 1024 * 1024;
 pub struct RedisSinkFunc {
     pub serializer: ArrowSerializer,
     pub target: Target,
-    pub client: RedisClient,
+    pub(crate) client: RedisClient,
     pub cmd_q: Option<(Sender<u32>, Receiver<RedisCmd>)>,
 
     pub rx: Receiver<u32>,

--- a/crates/arroyo-connectors/src/redis/sink.rs
+++ b/crates/arroyo-connectors/src/redis/sink.rs
@@ -283,11 +283,9 @@ impl ArrowOperator for RedisSinkFunc {
                         last_flushed: Instant::now(),
                         max_push_keys: HashSet::new(),
                         behavior: match &self.target {
-                            Target::StringTable { ttl_secs, .. } => {
-                                RedisBehavior::Set {
-                                    ttl: ttl_secs.map(|t| t.get() as usize),
-                                }
-                            }
+                            Target::StringTable { ttl_secs, .. } => RedisBehavior::Set {
+                                ttl: ttl_secs.map(|t| t.get() as usize),
+                            },
                             Target::ListTable {
                                 max_length,
                                 operation,

--- a/crates/arroyo-connectors/src/redis/sink.rs
+++ b/crates/arroyo-connectors/src/redis/sink.rs
@@ -19,7 +19,7 @@ const FLUSH_BYTES: usize = 10 * 1024 * 1024;
 
 pub struct RedisSinkFunc {
     pub serializer: ArrowSerializer,
-    pub table: RedisTable,
+    pub target: Target,
     pub client: RedisClient,
     pub cmd_q: Option<(Sender<u32>, Receiver<RedisCmd>)>,
 
@@ -229,19 +229,19 @@ impl ArrowOperator for RedisSinkFunc {
     }
 
     async fn on_start(&mut self, ctx: &mut OperatorContext) {
-        match &self.table.connector_type {
-            TableType::Target(Target::ListTable {
+        match &self.target {
+            Target::ListTable {
                 list_key_column: Some(key),
                 ..
-            })
-            | TableType::Target(Target::StringTable {
+            }
+            | Target::StringTable {
                 key_column: Some(key),
                 ..
-            })
-            | TableType::Target(Target::HashTable {
+            }
+            | Target::HashTable {
                 hash_key_column: Some(key),
                 ..
-            }) => {
+            } => {
                 self.key_index = Some(
                     ctx.in_schemas
                         .first()
@@ -258,9 +258,9 @@ impl ArrowOperator for RedisSinkFunc {
             _ => {}
         }
 
-        if let TableType::Target(Target::HashTable {
+        if let Target::HashTable {
             hash_field_column, ..
-        }) = &self.table.connector_type
+        } = &self.target
         {
             self.hash_index = Some(ctx.in_schemas.first().expect("no in-schema for redis sink!")
                 .schema
@@ -282,17 +282,17 @@ impl ArrowOperator for RedisSinkFunc {
                         size_estimate: 0,
                         last_flushed: Instant::now(),
                         max_push_keys: HashSet::new(),
-                        behavior: match self.table.connector_type {
-                            TableType::Target(Target::StringTable { ttl_secs, .. }) => {
+                        behavior: match &self.target {
+                            Target::StringTable { ttl_secs, .. } => {
                                 RedisBehavior::Set {
                                     ttl: ttl_secs.map(|t| t.get() as usize),
                                 }
                             }
-                            TableType::Target(Target::ListTable {
+                            Target::ListTable {
                                 max_length,
                                 operation,
                                 ..
-                            }) => {
+                            } => {
                                 let max = max_length.map(|x| x.get() as usize);
                                 match operation {
                                     ListOperation::Append => {
@@ -303,7 +303,7 @@ impl ArrowOperator for RedisSinkFunc {
                                     }
                                 }
                             }
-                            TableType::Target(Target::HashTable { .. }) => RedisBehavior::Hash,
+                            Target::HashTable { .. } => RedisBehavior::Hash,
                         },
                     }
                     .start();
@@ -328,39 +328,37 @@ impl ArrowOperator for RedisSinkFunc {
         _: &mut dyn Collector,
     ) {
         for (i, value) in self.serializer.serialize(&batch).enumerate() {
-            match &self.table.connector_type {
-                TableType::Target(target) => match &target {
-                    Target::StringTable { key_prefix, .. } => {
-                        let key = self.make_key(key_prefix, &batch, i);
-                        self.tx
-                            .send(RedisCmd::Data { key, value })
-                            .await
-                            .expect("Redis writer panicked");
-                    }
-                    Target::ListTable { list_prefix, .. } => {
-                        let key = self.make_key(list_prefix, &batch, i);
+            match &self.target {
+                Target::StringTable { key_prefix, .. } => {
+                    let key = self.make_key(key_prefix, &batch, i);
+                    self.tx
+                        .send(RedisCmd::Data { key, value })
+                        .await
+                        .expect("Redis writer panicked");
+                }
+                Target::ListTable { list_prefix, .. } => {
+                    let key = self.make_key(list_prefix, &batch, i);
 
-                        self.tx
-                            .send(RedisCmd::Data { key, value })
-                            .await
-                            .expect("Redis writer panicked");
-                    }
-                    Target::HashTable {
-                        hash_key_prefix, ..
-                    } => {
-                        let key = self.make_key(hash_key_prefix, &batch, i);
-                        let field = batch
-                            .column(self.hash_index.expect("no hash index"))
-                            .as_string::<i32>()
-                            .value(i)
-                            .to_string();
+                    self.tx
+                        .send(RedisCmd::Data { key, value })
+                        .await
+                        .expect("Redis writer panicked");
+                }
+                Target::HashTable {
+                    hash_key_prefix, ..
+                } => {
+                    let key = self.make_key(hash_key_prefix, &batch, i);
+                    let field = batch
+                        .column(self.hash_index.expect("no hash index"))
+                        .as_string::<i32>()
+                        .value(i)
+                        .to_string();
 
-                        self.tx
-                            .send(RedisCmd::HData { key, field, value })
-                            .await
-                            .expect("Redis writer panicked");
-                    }
-                },
+                    self.tx
+                        .send(RedisCmd::HData { key, field, value })
+                        .await
+                        .expect("Redis writer panicked");
+                }
             };
         }
     }

--- a/crates/arroyo-connectors/src/redis/table.json
+++ b/crates/arroyo-connectors/src/redis/table.json
@@ -114,6 +114,15 @@
                         "target"
                     ],
                     "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "title": "Lookup",
+                    "properties": {
+                        "lookup": {
+                            "type": "object"
+                        }
+                    }
                 }
             ]
         }

--- a/crates/arroyo-connectors/src/single_file/source.rs
+++ b/crates/arroyo-connectors/src/single_file/source.rs
@@ -100,6 +100,7 @@ impl SourceOperator for SingleFileSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         let state: &mut arroyo_state::tables::global_keyed_map::GlobalKeyedView<String, usize> =

--- a/crates/arroyo-connectors/src/sse/operator.rs
+++ b/crates/arroyo-connectors/src/sse/operator.rs
@@ -149,6 +149,7 @@ impl SSESourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         let mut client = eventsource_client::ClientBuilder::for_url(&self.url).unwrap();

--- a/crates/arroyo-connectors/src/websocket/operator.rs
+++ b/crates/arroyo-connectors/src/websocket/operator.rs
@@ -65,6 +65,7 @@ impl SourceOperator for WebsocketSourceFunc {
             self.format.clone(),
             self.framing.clone(),
             self.bad_data.clone(),
+            &[],
         );
 
         match self.run_int(ctx, collector).await {

--- a/crates/arroyo-datastream/src/logical.rs
+++ b/crates/arroyo-datastream/src/logical.rs
@@ -32,6 +32,7 @@ pub enum OperatorName {
     AsyncUdf,
     Join,
     InstantJoin,
+    LookupJoin,
     WindowFunction,
     TumblingWindowAggregate,
     SlidingWindowAggregate,
@@ -376,6 +377,7 @@ impl LogicalProgram {
                     OperatorName::Join => "join-with-expiration".to_string(),
                     OperatorName::InstantJoin => "windowed-join".to_string(),
                     OperatorName::WindowFunction => "sql-window-function".to_string(),
+                    OperatorName::LookupJoin => "lookup-join".to_string(),
                     OperatorName::TumblingWindowAggregate => {
                         "sql-tumbling-window-aggregate".to_string()
                     }

--- a/crates/arroyo-datastream/src/logical.rs
+++ b/crates/arroyo-datastream/src/logical.rs
@@ -134,16 +134,22 @@ impl TryFrom<LogicalProgram> for PipelineGraph {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LogicalEdge {
     pub edge_type: LogicalEdgeType,
-    pub schema: ArroyoSchema,
+    pub schema: Arc<ArroyoSchema>,
 }
 
 impl LogicalEdge {
     pub fn new(edge_type: LogicalEdgeType, schema: ArroyoSchema) -> Self {
-        LogicalEdge { edge_type, schema }
+        LogicalEdge {
+            edge_type,
+            schema: Arc::new(schema),
+        }
     }
 
     pub fn project_all(edge_type: LogicalEdgeType, schema: ArroyoSchema) -> Self {
-        LogicalEdge { edge_type, schema }
+        LogicalEdge {
+            edge_type,
+            schema: Arc::new(schema),
+        }
     }
 }
 
@@ -157,7 +163,7 @@ pub struct ChainedLogicalOperator {
 #[derive(Clone, Debug)]
 pub struct OperatorChain {
     pub(crate) operators: Vec<ChainedLogicalOperator>,
-    pub(crate) edges: Vec<ArroyoSchema>,
+    pub(crate) edges: Vec<Arc<ArroyoSchema>>,
 }
 
 impl OperatorChain {
@@ -168,7 +174,9 @@ impl OperatorChain {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&ChainedLogicalOperator, Option<&ArroyoSchema>)> {
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&ChainedLogicalOperator, Option<&Arc<ArroyoSchema>>)> {
         self.operators
             .iter()
             .zip_longest(self.edges.iter())
@@ -178,10 +186,10 @@ impl OperatorChain {
 
     pub fn iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = (&mut ChainedLogicalOperator, Option<&mut ArroyoSchema>)> {
+    ) -> impl Iterator<Item = (&mut ChainedLogicalOperator, Option<&Arc<ArroyoSchema>>)> {
         self.operators
             .iter_mut()
-            .zip_longest(self.edges.iter_mut())
+            .zip_longest(self.edges.iter())
             .map(|e| e.left_and_right())
             .map(|(l, r)| (l.unwrap(), r))
     }
@@ -438,7 +446,7 @@ impl TryFrom<ArrowProgram> for LogicalProgram {
                         edges: node
                             .edges
                             .into_iter()
-                            .map(|e| Ok(e.try_into()?))
+                            .map(|e| Ok(Arc::new(e.try_into()?)))
                             .collect::<anyhow::Result<Vec<_>>>()?,
                     },
                     parallelism: node.parallelism as usize,
@@ -456,7 +464,7 @@ impl TryFrom<ArrowProgram> for LogicalProgram {
                 target,
                 LogicalEdge {
                     edge_type: edge.edge_type().into(),
-                    schema: schema.clone().try_into()?,
+                    schema: Arc::new(schema.clone().try_into()?),
                 },
             );
         }
@@ -623,7 +631,7 @@ impl From<LogicalProgram> for ArrowProgram {
                         .operator_chain
                         .edges
                         .iter()
-                        .map(|edge| edge.clone().into())
+                        .map(|edge| (**edge).clone().into())
                         .collect(),
                 }
             })
@@ -639,7 +647,7 @@ impl From<LogicalProgram> for ArrowProgram {
                 api::ArrowEdge {
                     source: source.index() as i32,
                     target: target.index() as i32,
-                    schema: Some(edge.schema.clone().into()),
+                    schema: Some((*edge.schema).clone().into()),
                     edge_type: edge_type as i32,
                 }
             })

--- a/crates/arroyo-formats/src/avro/de.rs
+++ b/crates/arroyo-formats/src/avro/de.rs
@@ -214,7 +214,7 @@ mod tests {
     fn deserializer_with_schema(
         format: AvroFormat,
         writer_schema: Option<&str>,
-    ) -> (ArrowDeserializer, Vec<Box<dyn ArrayBuilder>>, ArroyoSchema) {
+    ) -> (ArrowDeserializer, ArroyoSchema) {
         let arrow_schema = if format.into_unstructured_json {
             Schema::new(vec![Field::new("value", DataType::Utf8, false)])
         } else {
@@ -239,13 +239,6 @@ mod tests {
             ArroyoSchema::from_schema_keys(Arc::new(Schema::new(fields)), vec![]).unwrap()
         };
 
-        let builders: Vec<_> = arroyo_schema
-            .schema
-            .fields
-            .iter()
-            .map(|f| make_builder(f.data_type(), 8))
-            .collect();
-
         let resolver: Arc<dyn SchemaResolver + Sync> = if let Some(schema) = &writer_schema {
             Arc::new(FixedSchemaResolver::new(
                 if format.confluent_schema_registry {
@@ -263,11 +256,10 @@ mod tests {
             ArrowDeserializer::with_schema_resolver(
                 Format::Avro(format),
                 None,
-                arroyo_schema.clone(),
+                Arc::new(arroyo_schema.clone()),
                 BadData::Fail {},
                 resolver,
             ),
-            builders,
             arroyo_schema,
         )
     }
@@ -277,23 +269,15 @@ mod tests {
         writer_schema: Option<&str>,
         message: &[u8],
     ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-        let (mut deserializer, mut builders, arroyo_schema) =
+        let (mut deserializer, arroyo_schema) =
             deserializer_with_schema(format.clone(), writer_schema);
 
         let errors = deserializer
-            .deserialize_slice(&mut builders, message, SystemTime::now(), None)
+            .deserialize_slice(message, SystemTime::now(), None)
             .await;
         assert_eq!(errors, vec![]);
 
-        let batch = if format.into_unstructured_json {
-            RecordBatch::try_new(
-                arroyo_schema.schema,
-                builders.into_iter().map(|mut b| b.finish()).collect(),
-            )
-            .unwrap()
-        } else {
-            deserializer.flush_buffer().unwrap().unwrap()
-        };
+        let batch = deserializer.flush_buffer().unwrap().unwrap();
 
         record_batch_to_vec(&batch, true, arrow_json::writer::TimestampFormat::RFC3339)
             .unwrap()

--- a/crates/arroyo-formats/src/avro/de.rs
+++ b/crates/arroyo-formats/src/avro/de.rs
@@ -132,8 +132,7 @@ pub(crate) fn avro_to_json(value: AvroValue) -> JsonValue {
 mod tests {
     use crate::avro::schema::to_arrow;
     use crate::de::ArrowDeserializer;
-    use arrow_array::builder::{make_builder, ArrayBuilder};
-    use arrow_array::RecordBatch;
+
     use arrow_json::writer::record_batch_to_vec;
     use arrow_schema::{DataType, Field, Schema, TimeUnit};
     use arroyo_rpc::df::ArroyoSchema;
@@ -257,6 +256,7 @@ mod tests {
                 Format::Avro(format),
                 None,
                 Arc::new(arroyo_schema.clone()),
+                &[],
                 BadData::Fail {},
                 resolver,
             ),
@@ -269,8 +269,7 @@ mod tests {
         writer_schema: Option<&str>,
         message: &[u8],
     ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-        let (mut deserializer, arroyo_schema) =
-            deserializer_with_schema(format.clone(), writer_schema);
+        let (mut deserializer, _) = deserializer_with_schema(format.clone(), writer_schema);
 
         let errors = deserializer
             .deserialize_slice(message, SystemTime::now(), None)

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -137,6 +137,7 @@ impl BufferDecoder {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn flush(
         &mut self,
         bad_data: &BadData,
@@ -350,7 +351,7 @@ impl ArrowDeserializer {
                 .fields()
                 .iter()
                 .filter(|f| !metadata_names.contains(f.name()))
-                .map(|f| f.clone())
+                .cloned()
                 .collect::<Vec<_>>();
             Arc::new(Schema::new_with_metadata(
                 fields,
@@ -821,7 +822,7 @@ mod tests {
 
         let schema = Arc::new(ArroyoSchema::from_schema_unkeyed(schema).unwrap());
 
-        let deserializer = ArrowDeserializer::new(
+        ArrowDeserializer::new(
             Format::Json(JsonFormat {
                 confluent_schema_registry: false,
                 schema_id: None,
@@ -833,9 +834,7 @@ mod tests {
             schema,
             None,
             bad_data,
-        );
-
-        deserializer
+        )
     }
 
     #[tokio::test]

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -1,11 +1,10 @@
 use crate::operator::ConstructedOperator;
 use anyhow::{anyhow, bail};
 use arrow::array::{ArrayRef, RecordBatch};
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::{DataType, Field, Schema};
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::OperatorConfig;
 use arroyo_types::{DisplayAsSql, SourceError};
 use async_trait::async_trait;
@@ -129,7 +128,7 @@ pub trait Connector: Send {
         profile: Self::ProfileT,
         table: Self::TableT,
         config: OperatorConfig,
-        schema: Arc<ArroyoSchema>,
+        schema: Arc<Schema>,
     ) -> anyhow::Result<Box<dyn LookupConnector + Send>> {
         bail!("{} is not a lookup connector", self.name())
     }
@@ -206,7 +205,7 @@ pub trait ErasedConnector: Send {
     fn make_lookup(
         &self,
         config: OperatorConfig,
-        schema: Arc<ArroyoSchema>,
+        schema: Arc<Schema>,
     ) -> anyhow::Result<Box<dyn LookupConnector + Send>>;
 }
 
@@ -360,7 +359,7 @@ impl<C: Connector> ErasedConnector for C {
     fn make_lookup(
         &self,
         config: OperatorConfig,
-        schema: Arc<ArroyoSchema>,
+        schema: Arc<Schema>,
     ) -> anyhow::Result<Box<dyn LookupConnector + Send>> {
         self.make_lookup(
             self.parse_config(&config.connection)?,

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -320,6 +320,7 @@ impl SourceCollector {
         format: Format,
         framing: Option<Framing>,
         bad_data: Option<BadData>,
+        metadata_fields: &[MetadataField],
     ) {
         if self.deserializer.is_some() {
             panic!("Deserialize already initialized");
@@ -328,6 +329,7 @@ impl SourceCollector {
         self.deserializer = Some(ArrowDeserializer::new(
             format,
             self.out_schema.clone(),
+            metadata_fields,
             framing,
             bad_data.unwrap_or_default(),
         ));

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -226,7 +226,7 @@ impl OperatorNode {
         control_rx: Receiver<ControlMessage>,
         mut in_qs: Vec<BatchReceiver>,
         out_qs: Vec<Vec<BatchSender>>,
-        out_schema: Option<ArroyoSchema>,
+        out_schema: Option<Arc<ArroyoSchema>>,
         ready: Arc<Barrier>,
     ) {
         info!(

--- a/crates/arroyo-planner/src/builder.rs
+++ b/crates/arroyo-planner/src/builder.rs
@@ -172,7 +172,7 @@ impl<'a> Planner<'a> {
 
         let (partial_schema, timestamp_index) = if add_timestamp_field {
             (
-                add_timestamp_field_arrow(partial_schema.clone()),
+                add_timestamp_field_arrow((*partial_schema).clone()),
                 partial_schema.fields().len(),
             )
         } else {

--- a/crates/arroyo-planner/src/extension/join.rs
+++ b/crates/arroyo-planner/src/extension/join.rs
@@ -80,7 +80,7 @@ impl ArroyoExtension for JoinExtension {
     }
 
     fn output_schema(&self) -> ArroyoSchema {
-        ArroyoSchema::from_schema_unkeyed(Arc::new(self.schema().as_ref().clone().into())).unwrap()
+        ArroyoSchema::from_schema_unkeyed(self.schema().inner().clone()).unwrap()
     }
 }
 

--- a/crates/arroyo-planner/src/extension/join.rs
+++ b/crates/arroyo-planner/src/extension/join.rs
@@ -10,7 +10,6 @@ use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion_proto::generated::datafusion::PhysicalPlanNode;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use prost::Message;
-use std::sync::Arc;
 use std::time::Duration;
 
 pub(crate) const JOIN_NODE_NAME: &str = "JoinNode";

--- a/crates/arroyo-planner/src/extension/lookup.rs
+++ b/crates/arroyo-planner/src/extension/lookup.rs
@@ -67,15 +67,15 @@ multifield_partial_ord!(LookupJoin, input, connector, on, filter, alias);
 
 impl ArroyoExtension for LookupJoin {
     fn node_name(&self) -> Option<NamedNode> {
-        todo!()
+        None
     }
 
     fn plan_node(&self, planner: &Planner, index: usize, input_schemas: Vec<ArroyoSchemaRef>) -> datafusion::common::Result<NodeWithIncomingEdges> {
-        todo!()
+        let keys = 
     }
 
     fn output_schema(&self) -> ArroyoSchema {
-        todo!()
+        ArroyoSchema::from_schema_unkeyed(self.schema.inner().clone()).unwrap()
     }
 }
 

--- a/crates/arroyo-planner/src/extension/lookup.rs
+++ b/crates/arroyo-planner/src/extension/lookup.rs
@@ -118,6 +118,11 @@ impl ArroyoExtension for LookupJoin {
                     return plan_err!("unsupported join type '{j}' for lookup join; only inner and left joins are supported");
                 }
             },
+            ttl_micros: self
+                .connector
+                .lookup_cache_ttl
+                .map(|t| t.as_micros() as u64),
+            max_capacity_bytes: self.connector.lookup_cache_max_bytes,
         };
 
         let incoming_edge =

--- a/crates/arroyo-planner/src/extension/lookup.rs
+++ b/crates/arroyo-planner/src/extension/lookup.rs
@@ -1,6 +1,7 @@
 use crate::builder::{NamedNode, Planner};
 use crate::extension::{ArroyoExtension, NodeWithIncomingEdges};
 use crate::multifield_partial_ord;
+use crate::schemas::add_timestamp_field_arrow;
 use crate::tables::ConnectorTable;
 use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalNode, OperatorName};
 use arroyo_rpc::df::{ArroyoSchema, ArroyoSchemaRef};
@@ -13,7 +14,6 @@ use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
 use prost::Message;
 use std::fmt::Formatter;
 use std::sync::Arc;
-use crate::schemas::{add_timestamp_field_arrow};
 
 pub const SOURCE_EXTENSION_NAME: &str = "LookupSource";
 pub const JOIN_EXTENSION_NAME: &str = "LookupJoin";
@@ -88,8 +88,9 @@ impl ArroyoExtension for LookupJoin {
         input_schemas: Vec<ArroyoSchemaRef>,
     ) -> datafusion::common::Result<NodeWithIncomingEdges> {
         let schema = ArroyoSchema::from_schema_unkeyed(Arc::new(self.schema.as_ref().into()))?;
-        let lookup_schema = ArroyoSchema::from_schema_unkeyed(
-            add_timestamp_field_arrow(self.connector.physical_schema()))?;
+        let lookup_schema = ArroyoSchema::from_schema_unkeyed(add_timestamp_field_arrow(
+            self.connector.physical_schema(),
+        ))?;
         let join_config = LookupJoinOperator {
             input_schema: Some(schema.into()),
             lookup_schema: Some(lookup_schema.into()),

--- a/crates/arroyo-planner/src/extension/lookup.rs
+++ b/crates/arroyo-planner/src/extension/lookup.rs
@@ -1,12 +1,19 @@
-use std::fmt::Formatter;
-use datafusion::common::{internal_err, DFSchemaRef};
-use datafusion::logical_expr::{Expr, Join, LogicalPlan, UserDefinedLogicalNodeCore};
-use datafusion::sql::TableReference;
-use arroyo_rpc::df::{ArroyoSchema, ArroyoSchemaRef};
 use crate::builder::{NamedNode, Planner};
 use crate::extension::{ArroyoExtension, NodeWithIncomingEdges};
 use crate::multifield_partial_ord;
 use crate::tables::ConnectorTable;
+use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalNode, OperatorName};
+use arroyo_rpc::df::{ArroyoSchema, ArroyoSchemaRef};
+use arroyo_rpc::grpc::api::{ConnectorOp, LookupJoinCondition, LookupJoinOperator};
+use datafusion::common::{internal_err, plan_err, Column, DFSchemaRef, JoinType};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use datafusion::sql::TableReference;
+use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
+use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
+use prost::Message;
+use std::fmt::Formatter;
+use std::sync::Arc;
+use crate::schemas::{add_timestamp_field_arrow};
 
 pub const SOURCE_EXTENSION_NAME: &str = "LookupSource";
 pub const JOIN_EXTENSION_NAME: &str = "LookupJoin";
@@ -40,12 +47,15 @@ impl UserDefinedLogicalNodeCore for LookupSource {
         write!(f, "LookupSource: {}", self.schema)
     }
 
-    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> datafusion::common::Result<Self> {
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
         if !inputs.is_empty() {
             return internal_err!("LookupSource cannot have inputs");
         }
-        
-        
+
         Ok(Self {
             table: self.table.clone(),
             schema: self.schema.clone(),
@@ -57,10 +67,11 @@ impl UserDefinedLogicalNodeCore for LookupSource {
 pub struct LookupJoin {
     pub(crate) input: LogicalPlan,
     pub(crate) schema: DFSchemaRef,
-    pub(crate) connector: ConnectorTable,    
-    pub(crate) on: Vec<(Expr, Expr)>,
+    pub(crate) connector: ConnectorTable,
+    pub(crate) on: Vec<(Expr, Column)>,
     pub(crate) filter: Option<Expr>,
     pub(crate) alias: Option<TableReference>,
+    pub(crate) join_type: JoinType,
 }
 
 multifield_partial_ord!(LookupJoin, input, connector, on, filter, alias);
@@ -70,8 +81,58 @@ impl ArroyoExtension for LookupJoin {
         None
     }
 
-    fn plan_node(&self, planner: &Planner, index: usize, input_schemas: Vec<ArroyoSchemaRef>) -> datafusion::common::Result<NodeWithIncomingEdges> {
-        let keys = 
+    fn plan_node(
+        &self,
+        planner: &Planner,
+        index: usize,
+        input_schemas: Vec<ArroyoSchemaRef>,
+    ) -> datafusion::common::Result<NodeWithIncomingEdges> {
+        let schema = ArroyoSchema::from_schema_unkeyed(Arc::new(self.schema.as_ref().into()))?;
+        let lookup_schema = ArroyoSchema::from_schema_unkeyed(
+            add_timestamp_field_arrow(self.connector.physical_schema()))?;
+        let join_config = LookupJoinOperator {
+            input_schema: Some(schema.into()),
+            lookup_schema: Some(lookup_schema.into()),
+            connector: Some(ConnectorOp {
+                connector: self.connector.connector.clone(),
+                config: self.connector.config.clone(),
+                description: self.connector.description.clone(),
+            }),
+            key_exprs: self
+                .on
+                .iter()
+                .map(|(l, r)| {
+                    let expr = planner.create_physical_expr(l, &self.schema)?;
+                    let expr = serialize_physical_expr(&expr, &DefaultPhysicalExtensionCodec {})?;
+                    Ok(LookupJoinCondition {
+                        left_expr: expr.encode_to_vec(),
+                        right_key: r.name.clone(),
+                    })
+                })
+                .collect::<datafusion::error::Result<Vec<_>>>()?,
+            join_type: match self.join_type {
+                JoinType::Inner => arroyo_rpc::grpc::api::JoinType::Inner as i32,
+                JoinType::Left => arroyo_rpc::grpc::api::JoinType::Left as i32,
+                j => {
+                    return plan_err!("unsupported join type '{j}' for lookup join; only inner and left joins are supported");
+                }
+            },
+        };
+
+        let incoming_edge =
+            LogicalEdge::project_all(LogicalEdgeType::Shuffle, (*input_schemas[0]).clone());
+
+        Ok(NodeWithIncomingEdges {
+            node: LogicalNode::single(
+                index as u32,
+                format!("lookupjoin_{}", index),
+                OperatorName::LookupJoin,
+                join_config.encode_to_vec(),
+                format!("LookupJoin<{}>", self.connector.name),
+                1,
+            ),
+            edges: vec![incoming_edge],
+        })
     }
 
     fn output_schema(&self) -> ArroyoSchema {
@@ -93,14 +154,12 @@ impl UserDefinedLogicalNodeCore for LookupJoin {
     }
 
     fn expressions(&self) -> Vec<Expr> {
-        let mut e: Vec<_> = self.on.iter()
-            .flat_map(|(l, r)| vec![l.clone(), r.clone()])
-            .collect();
-        
+        let mut e: Vec<_> = self.on.iter().map(|(l, _)| l.clone()).collect();
+
         if let Some(filter) = &self.filter {
             e.push(filter.clone());
         }
-        
+
         e
     }
 
@@ -108,7 +167,11 @@ impl UserDefinedLogicalNodeCore for LookupJoin {
         write!(f, "LookupJoinExtension: {}", self.schema)
     }
 
-    fn with_exprs_and_inputs(&self, _: Vec<Expr>, inputs: Vec<LogicalPlan>) -> datafusion::common::Result<Self> {
+    fn with_exprs_and_inputs(
+        &self,
+        _: Vec<Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion::common::Result<Self> {
         Ok(Self {
             input: inputs[0].clone(),
             schema: self.schema.clone(),
@@ -116,6 +179,7 @@ impl UserDefinedLogicalNodeCore for LookupJoin {
             on: self.on.clone(),
             filter: self.filter.clone(),
             alias: self.alias.clone(),
+            join_type: self.join_type,
         })
     }
 }

--- a/crates/arroyo-planner/src/extension/lookup.rs
+++ b/crates/arroyo-planner/src/extension/lookup.rs
@@ -1,0 +1,121 @@
+use std::fmt::Formatter;
+use datafusion::common::{internal_err, DFSchemaRef};
+use datafusion::logical_expr::{Expr, Join, LogicalPlan, UserDefinedLogicalNodeCore};
+use datafusion::sql::TableReference;
+use arroyo_rpc::df::{ArroyoSchema, ArroyoSchemaRef};
+use crate::builder::{NamedNode, Planner};
+use crate::extension::{ArroyoExtension, NodeWithIncomingEdges};
+use crate::multifield_partial_ord;
+use crate::tables::ConnectorTable;
+
+pub const SOURCE_EXTENSION_NAME: &str = "LookupSource";
+pub const JOIN_EXTENSION_NAME: &str = "LookupJoin";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LookupSource {
+    pub(crate) table: ConnectorTable,
+    pub(crate) schema: DFSchemaRef,
+}
+
+multifield_partial_ord!(LookupSource, table);
+
+impl UserDefinedLogicalNodeCore for LookupSource {
+    fn name(&self) -> &str {
+        SOURCE_EXTENSION_NAME
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "LookupSource: {}", self.schema)
+    }
+
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> datafusion::common::Result<Self> {
+        if !inputs.is_empty() {
+            return internal_err!("LookupSource cannot have inputs");
+        }
+        
+        
+        Ok(Self {
+            table: self.table.clone(),
+            schema: self.schema.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LookupJoin {
+    pub(crate) input: LogicalPlan,
+    pub(crate) schema: DFSchemaRef,
+    pub(crate) connector: ConnectorTable,    
+    pub(crate) on: Vec<(Expr, Expr)>,
+    pub(crate) filter: Option<Expr>,
+    pub(crate) alias: Option<TableReference>,
+}
+
+multifield_partial_ord!(LookupJoin, input, connector, on, filter, alias);
+
+impl ArroyoExtension for LookupJoin {
+    fn node_name(&self) -> Option<NamedNode> {
+        todo!()
+    }
+
+    fn plan_node(&self, planner: &Planner, index: usize, input_schemas: Vec<ArroyoSchemaRef>) -> datafusion::common::Result<NodeWithIncomingEdges> {
+        todo!()
+    }
+
+    fn output_schema(&self) -> ArroyoSchema {
+        todo!()
+    }
+}
+
+impl UserDefinedLogicalNodeCore for LookupJoin {
+    fn name(&self) -> &str {
+        JOIN_EXTENSION_NAME
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        let mut e: Vec<_> = self.on.iter()
+            .flat_map(|(l, r)| vec![l.clone(), r.clone()])
+            .collect();
+        
+        if let Some(filter) = &self.filter {
+            e.push(filter.clone());
+        }
+        
+        e
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "LookupJoinExtension: {}", self.schema)
+    }
+
+    fn with_exprs_and_inputs(&self, _: Vec<Expr>, inputs: Vec<LogicalPlan>) -> datafusion::common::Result<Self> {
+        Ok(Self {
+            input: inputs[0].clone(),
+            schema: self.schema.clone(),
+            connector: self.connector.clone(),
+            on: self.on.clone(),
+            filter: self.filter.clone(),
+            alias: self.alias.clone(),
+        })
+    }
+}

--- a/crates/arroyo-planner/src/extension/mod.rs
+++ b/crates/arroyo-planner/src/extension/mod.rs
@@ -29,6 +29,7 @@ use crate::builder::{NamedNode, Planner};
 use crate::schemas::{add_timestamp_field, has_timestamp_field};
 use crate::{fields_with_qualifiers, schema_from_df_fields, DFField, ASYNC_RESULT_FIELD};
 use join::JoinExtension;
+use crate::extension::lookup::LookupJoin;
 
 pub(crate) mod aggregate;
 pub(crate) mod debezium;
@@ -87,6 +88,7 @@ impl<'a> TryFrom<&'a dyn UserDefinedLogicalNode> for &'a dyn ArroyoExtension {
             .or_else(|_| try_from_t::<ToDebeziumExtension>(node))
             .or_else(|_| try_from_t::<DebeziumUnrollingExtension>(node))
             .or_else(|_| try_from_t::<UpdatingAggregateExtension>(node))
+            .or_else(|_| try_from_t::<LookupJoin>(node))
             .map_err(|_| DataFusionError::Plan(format!("unexpected node: {}", node.name())))
     }
 }

--- a/crates/arroyo-planner/src/extension/mod.rs
+++ b/crates/arroyo-planner/src/extension/mod.rs
@@ -26,22 +26,22 @@ use self::{
     window_fn::WindowFunctionExtension,
 };
 use crate::builder::{NamedNode, Planner};
+use crate::extension::lookup::LookupJoin;
 use crate::schemas::{add_timestamp_field, has_timestamp_field};
 use crate::{fields_with_qualifiers, schema_from_df_fields, DFField, ASYNC_RESULT_FIELD};
 use join::JoinExtension;
-use crate::extension::lookup::LookupJoin;
 
 pub(crate) mod aggregate;
 pub(crate) mod debezium;
 pub(crate) mod join;
 pub(crate) mod key_calculation;
+pub(crate) mod lookup;
 pub(crate) mod remote_table;
 pub(crate) mod sink;
 pub(crate) mod table_source;
 pub(crate) mod updating_aggregate;
 pub(crate) mod watermark_node;
 pub(crate) mod window_fn;
-pub(crate) mod lookup;
 
 pub(crate) trait ArroyoExtension: Debug {
     // if the extension has a name, return it so that we can memoize.

--- a/crates/arroyo-planner/src/extension/mod.rs
+++ b/crates/arroyo-planner/src/extension/mod.rs
@@ -40,6 +40,8 @@ pub(crate) mod table_source;
 pub(crate) mod updating_aggregate;
 pub(crate) mod watermark_node;
 pub(crate) mod window_fn;
+pub(crate) mod lookup;
+
 pub(crate) trait ArroyoExtension: Debug {
     // if the extension has a name, return it so that we can memoize.
     fn node_name(&self) -> Option<NamedNode>;

--- a/crates/arroyo-planner/src/extension/sink.rs
+++ b/crates/arroyo-planner/src/extension/sink.rs
@@ -61,6 +61,7 @@ impl SinkExtension {
                     (false, false) => {}
                 }
             }
+            Table::LookupTable(..) => return plan_err!("cannot use a lookup table as a sink"),
             Table::MemoryTable { .. } => return plan_err!("memory tables not supported"),
             Table::TableFromQuery { .. } => {}
             Table::PreviewSink { .. } => {

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -826,8 +826,11 @@ pub async fn parse_and_get_arrow_program(
                         logical_plan.replace(plan_rewrite);
                         continue;
                     }
+                    Table::LookupTable(_) => {
+                        plan_err!("lookup (temporary) tables cannot be inserted into")
+                    }
                     Table::TableFromQuery { .. } => {
-                        plan_err!("Shouldn't be inserting more data into a table made with CREATE TABLE AS")
+                        plan_err!("shouldn't be inserting more data into a table made with CREATE TABLE AS")
                     }
                     Table::PreviewSink { .. } => {
                         plan_err!("queries shouldn't be able insert into preview sink.")

--- a/crates/arroyo-planner/src/plan/join.rs
+++ b/crates/arroyo-planner/src/plan/join.rs
@@ -234,7 +234,6 @@ fn has_lookup(plan: &LogicalPlan) -> Result<bool> {
 }
 
 fn maybe_plan_lookup_join(join: &Join) -> Result<Option<LogicalPlan>> {
-    println!("Planning lookup join");
     if has_lookup(&join.left)? {
         return plan_err!("lookup sources must be on the right side of an inner or left join");
     }

--- a/crates/arroyo-planner/src/plan/join.rs
+++ b/crates/arroyo-planner/src/plan/join.rs
@@ -201,7 +201,7 @@ struct FindLookupExtension {
     alias: Option<TableReference>,
 }
 
-impl<'a> TreeNodeVisitor<'a> for FindLookupExtension {
+impl TreeNodeVisitor<'_> for FindLookupExtension {
     type Node = LogicalPlan;
 
     fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion> {
@@ -266,8 +266,8 @@ fn maybe_plan_lookup_join(join: &Join) -> Result<Option<LogicalPlan>> {
         match r {
             Expr::Column(c) => Ok((l.clone(), c.clone())),
             e => {
-                return plan_err!("invalid right-side condition for lookup join: `{}`; only column references are supported", 
-                expr_to_sql(e).map(|e| e.to_string()).unwrap_or_else(|_| e.to_string()));
+                plan_err!("invalid right-side condition for lookup join: `{}`; only column references are supported", 
+                expr_to_sql(e).map(|e| e.to_string()).unwrap_or_else(|_| e.to_string()))
             }
         }
     }).collect::<Result<_>>()?;

--- a/crates/arroyo-planner/src/plan/join.rs
+++ b/crates/arroyo-planner/src/plan/join.rs
@@ -248,11 +248,6 @@ fn maybe_plan_lookup_join(join: &Join) -> Result<Option<LogicalPlan>> {
         return Ok(None);
     }
 
-    println!(
-        "JOin = {:?} {:?}\n{:#?}",
-        join.join_constraint, join.join_type, join.on
-    );
-
     match join.join_type {
         JoinType::Inner | JoinType::Left => {}
         t => {

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -19,6 +19,7 @@ use arroyo_rpc::TIMESTAMP_FIELD;
 use arroyo_rpc::UPDATING_META_FIELD;
 use datafusion::logical_expr::UserDefinedLogicalNode;
 
+use crate::extension::lookup::LookupSource;
 use crate::extension::AsyncUDFExtension;
 use arroyo_udf_host::parse::{AsyncOptions, UdfType};
 use datafusion::common::tree_node::{
@@ -36,7 +37,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
-use crate::extension::lookup::LookupSource;
 
 /// Rewrites a logical plan to move projections out of table scans
 /// and into a separate projection node which may include virtual fields,
@@ -219,13 +219,13 @@ impl SourceRewriter<'_> {
     fn mutate_lookup_table(
         &self,
         table_scan: &TableScan,
-        table: &ConnectorTable
+        table: &ConnectorTable,
     ) -> DFResult<Transformed<LogicalPlan>> {
         Ok(Transformed::yes(LogicalPlan::Extension(Extension {
             node: Arc::new(LookupSource {
                 table: table.clone(),
                 schema: table_scan.projected_schema.clone(),
-            })
+            }),
         })))
     }
 

--- a/crates/arroyo-planner/src/schemas.rs
+++ b/crates/arroyo-planner/src/schemas.rs
@@ -49,7 +49,7 @@ pub(crate) fn has_timestamp_field(schema: &DFSchemaRef) -> bool {
         .any(|field| field.name() == "_timestamp")
 }
 
-pub fn add_timestamp_field_arrow(schema: SchemaRef) -> SchemaRef {
+pub fn add_timestamp_field_arrow(schema: Schema) -> SchemaRef {
     let mut fields = schema.fields().to_vec();
     fields.push(Arc::new(Field::new(
         "_timestamp",

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -759,15 +759,14 @@ impl Table {
                         primary_keys,
                         &mut with_map,
                         connection_profile,
-                    ).map_err(|e| e.context(format!("Failed to create table {}", name)))?;
+                    )
+                    .map_err(|e| e.context(format!("Failed to create table {}", name)))?;
 
                     Ok(Some(match table.connection_type {
                         ConnectionType::Source | ConnectionType::Sink => {
                             Table::ConnectorTable(table)
                         }
-                        ConnectionType::Lookup => {
-                            Table::LookupTable(table)
-                        }
+                        ConnectionType::Lookup => Table::LookupTable(table),
                     }))
                 }
             }
@@ -844,11 +843,12 @@ impl Table {
                 fields,
                 inferred_fields,
                 ..
-            }) | Table::LookupTable(ConnectorTable {
+            })
+            | Table::LookupTable(ConnectorTable {
                 fields,
                 inferred_fields,
-            ..
-                                                }) => inferred_fields
+                ..
+            }) => inferred_fields
                 .as_ref()
                 .map(|fs| fs.iter().map(|f| f.field().clone()).collect())
                 .unwrap_or_else(|| {

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -308,6 +308,7 @@ impl ConnectorTable {
             schema_fields,
             None,
             Some(fields.is_empty()),
+            primary_keys.iter().cloned().collect(),
         )
         .map_err(|e| DataFusionError::Plan(format!("could not create connection schema: {}", e)))?;
 

--- a/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
+++ b/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
@@ -1,0 +1,21 @@
+--fail=the right-side of a look-up join condition must be a PRIMARY KEY column, but 'value' is not
+create table impulse with (
+    connector = 'impulse',
+    event_rate = '2'
+);
+
+create temporary table lookup (
+    key TEXT PRIMARY KEY GENERATED ALWAYS AS (metadata('key')) STORED, 
+    value TEXT,
+    len INT
+) with (
+    connector = 'redis',
+    format = 'raw_string',
+    address = 'redis://localhost:6379',
+    format = 'json',
+    'lookup.cache.max_bytes' = '100000'
+);
+
+select A.counter, B.key, B.value, len
+from impulse A inner join lookup B
+on cast((A.counter % 10) as TEXT) = B.value;

--- a/crates/arroyo-planner/src/test/queries/error_missing_redis_key.sql
+++ b/crates/arroyo-planner/src/test/queries/error_missing_redis_key.sql
@@ -1,0 +1,19 @@
+--fail=Redis lookup tables must have a PRIMARY KEY field defined as `field_name TEXT GENERATED ALWAYS AS (metadata('key')) STORED`
+create table impulse with (
+    connector = 'impulse',
+    event_rate = '2'
+);
+
+create table lookup (
+    key TEXT PRIMARY KEY, 
+    value TEXT
+) with (
+    connector = 'redis',
+    format = 'json',
+    address = 'redis://localhost:6379',
+    type = 'lookup'
+);
+
+select A.counter, B.key, B.value
+from impulse A left join lookup B
+on cast((A.counter % 10) as TEXT) = B.key;

--- a/crates/arroyo-planner/src/test/queries/lookup_join.sql
+++ b/crates/arroyo-planner/src/test/queries/lookup_join.sql
@@ -13,7 +13,7 @@ CREATE TABLE orders (
 );
 
 CREATE TEMPORARY TABLE products (
-    product_id INT PRIMARY KEY,
+    key TEXT PRIMARY KEY,
     product_name TEXT,
     unit_price FLOAT,
     category TEXT,
@@ -36,4 +36,4 @@ SELECT
     (o.quantity * p.unit_price) as total_amount
 FROM orders o
     JOIN products p
-    ON o.product_id = p.product_id;
+    ON concat('blah', o.product_id) = p.key;

--- a/crates/arroyo-planner/src/test/queries/lookup_join.sql
+++ b/crates/arroyo-planner/src/test/queries/lookup_join.sql
@@ -1,0 +1,39 @@
+CREATE TABLE orders (
+    order_id INT,
+    user_id INT,
+    product_id INT,
+    quantity INT,
+    order_timestamp TIMESTAMP
+) with (
+    connector = 'kafka',
+    bootstrap_servers = 'localhost:9092',
+    type = 'source',
+    topic = 'orders',
+    format = 'json'
+);
+
+CREATE TEMPORARY TABLE products (
+    product_id INT PRIMARY KEY,
+    product_name TEXT,
+    unit_price FLOAT,
+    category TEXT,
+    last_updated TIMESTAMP
+) with (
+    connector = 'redis',
+    format = 'json',
+    type = 'lookup',
+    address = 'redis://localhost:6379'
+);
+
+SELECT 
+    o.order_id,
+    o.user_id,
+    o.quantity,
+    o.order_timestamp,
+    p.product_name,
+    p.unit_price,
+    p.category,
+    (o.quantity * p.unit_price) as total_amount
+FROM orders o
+    JOIN products p
+    ON o.product_id = p.product_id;

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -70,11 +70,16 @@ message JoinOperator {
   optional uint64 ttl_micros = 6;
 }
 
+message LookupJoinCondition {
+  bytes left_expr = 1;
+  string right_key = 2;
+}
+
 message LookupJoinOperator {
-  string name = 1;
-  ArroyoSchema schema = 2;
+  ArroyoSchema input_schema = 1;
+  ArroyoSchema lookup_schema = 2;
   ConnectorOp connector = 3;
-  repeated bytes key_exprs = 4;
+  repeated LookupJoinCondition key_exprs = 4;
   JoinType join_type = 5;
 }
 

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -81,6 +81,8 @@ message LookupJoinOperator {
   ConnectorOp connector = 3;
   repeated LookupJoinCondition key_exprs = 4;
   JoinType join_type = 5;
+  optional uint64 ttl_micros = 6;
+  optional uint64 max_capacity_bytes = 7;
 }
 
 message WindowFunctionOperator {

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -74,7 +74,8 @@ message LookupJoinOperator {
   string name = 1;
   ArroyoSchema schema = 2;
   ConnectorOp connector = 3;
-  
+  repeated bytes key_exprs = 4;
+  JoinType join_type = 5;
 }
 
 message WindowFunctionOperator {

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -70,6 +70,13 @@ message JoinOperator {
   optional uint64 ttl_micros = 6;
 }
 
+message LookupJoinOperator {
+  string name = 1;
+  ArroyoSchema schema = 2;
+  ConnectorOp connector = 3;
+  
+}
+
 message WindowFunctionOperator {
   string name = 1;
   ArroyoSchema input_schema = 2;

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -323,6 +323,7 @@ impl ConnectionSchema {
                 Some(MetadataField {
                     field_name: f.field_name.clone(),
                     key: f.metadata_key.clone()?,
+                    data_type: Some(Field::from(f.clone()).data_type().clone()),
                 })
             })
             .collect()

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -257,6 +257,7 @@ pub struct ConnectionSchema {
 }
 
 impl ConnectionSchema {
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         format: Option<Format>,
         bad_data: Option<BadData>,

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -51,6 +51,7 @@ pub struct ConnectionProfilePost {
 pub enum ConnectionType {
     Source,
     Sink,
+    Lookup,
 }
 
 impl Display for ConnectionType {
@@ -58,6 +59,7 @@ impl Display for ConnectionType {
         match self {
             ConnectionType::Source => write!(f, "SOURCE"),
             ConnectionType::Sink => write!(f, "SINK"),
+            ConnectionType::Lookup => write!(f, "LOOKUP"),
         }
     }
 }

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -1,14 +1,14 @@
+use crate::df::{ArroyoSchema, ArroyoSchemaRef};
 use crate::formats::{BadData, Format, Framing};
 use crate::{primitive_to_sql, MetadataField};
+use ahash::HashSet;
 use anyhow::bail;
 use arrow_schema::{DataType, Field, Fields, TimeUnit};
+use arroyo_types::ArroyoExtensionType;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
-
-use crate::df::{ArroyoSchema, ArroyoSchemaRef};
-use arroyo_types::ArroyoExtensionType;
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -252,6 +252,8 @@ pub struct ConnectionSchema {
     pub fields: Vec<SourceField>,
     pub definition: Option<SchemaDefinition>,
     pub inferred: Option<bool>,
+    #[serde(default)]
+    pub primary_keys: HashSet<String>,
 }
 
 impl ConnectionSchema {
@@ -263,6 +265,7 @@ impl ConnectionSchema {
         fields: Vec<SourceField>,
         definition: Option<SchemaDefinition>,
         inferred: Option<bool>,
+        primary_keys: HashSet<String>,
     ) -> anyhow::Result<Self> {
         let s = ConnectionSchema {
             format,
@@ -272,6 +275,7 @@ impl ConnectionSchema {
             fields,
             definition,
             inferred,
+            primary_keys,
         };
 
         s.validate()

--- a/crates/arroyo-rpc/src/df.rs
+++ b/crates/arroyo-rpc/src/df.rs
@@ -1,6 +1,6 @@
 use crate::grpc::api;
 use crate::{grpc, Converter, TIMESTAMP_FIELD};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use arrow::compute::kernels::numeric::div;
 use arrow::compute::{filter_record_batch, take};
 use arrow::datatypes::{DataType, Field, Schema, SchemaBuilder, TimeUnit};
@@ -382,6 +382,19 @@ impl ArroyoSchema {
             schema: Arc::new(unkeyed_schema),
             timestamp_index,
             key_indices: None,
+        })
+    }
+    
+    pub fn with_field(&self, name: &str, data_type: DataType, nullable: bool) -> Result<Self> {
+        if self.schema.field_with_name(name).is_ok() {
+            bail!("cannot add field '{}' to schema, it is already present", name);
+        }
+        let mut fields = self.schema.fields().to_vec();
+        fields.push(Arc::new(Field::new(name, data_type, nullable)));
+        Ok(Self {
+            schema: Arc::new(Schema::new_with_metadata(fields, self.schema.metadata.clone())),
+            timestamp_index: self.timestamp_index,
+            key_indices: self.key_indices.clone(),
         })
     }
 }

--- a/crates/arroyo-rpc/src/df.rs
+++ b/crates/arroyo-rpc/src/df.rs
@@ -384,15 +384,21 @@ impl ArroyoSchema {
             key_indices: None,
         })
     }
-    
+
     pub fn with_field(&self, name: &str, data_type: DataType, nullable: bool) -> Result<Self> {
         if self.schema.field_with_name(name).is_ok() {
-            bail!("cannot add field '{}' to schema, it is already present", name);
+            bail!(
+                "cannot add field '{}' to schema, it is already present",
+                name
+            );
         }
         let mut fields = self.schema.fields().to_vec();
         fields.push(Arc::new(Field::new(name, data_type, nullable)));
         Ok(Self {
-            schema: Arc::new(Schema::new_with_metadata(fields, self.schema.metadata.clone())),
+            schema: Arc::new(Schema::new_with_metadata(
+                fields,
+                self.schema.metadata.clone(),
+            )),
             timestamp_index: self.timestamp_index,
             key_indices: self.key_indices.clone(),
         })

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -37,7 +37,7 @@ pub mod grpc {
     pub mod api {
         #![allow(clippy::derive_partial_eq_without_eq, deprecated)]
         tonic::include_proto!("api");
-        
+
         impl From<self::JoinType> for arroyo_types::JoinType {
             fn from(value: JoinType) -> Self {
                 match value {

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -201,6 +201,8 @@ pub struct RateLimit {
 pub struct MetadataField {
     pub field_name: String,
     pub key: String,
+    #[serde(default)]
+    pub data_type: Option<DataType>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -37,6 +37,17 @@ pub mod grpc {
     pub mod api {
         #![allow(clippy::derive_partial_eq_without_eq, deprecated)]
         tonic::include_proto!("api");
+        
+        impl From<self::JoinType> for arroyo_types::JoinType {
+            fn from(value: JoinType) -> Self {
+                match value {
+                    JoinType::Inner => arroyo_types::JoinType::Inner,
+                    JoinType::Left => arroyo_types::JoinType::Left,
+                    JoinType::Right => arroyo_types::JoinType::Right,
+                    JoinType::Full => arroyo_types::JoinType::Full,
+                }
+            }
+        }
     }
 
     pub const API_FILE_DESCRIPTOR_SET: &[u8] =

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -641,6 +641,8 @@ pub fn range_for_server(i: usize, n: usize) -> RangeInclusive<u64> {
     start..=end
 }
 
+pub const LOOKUP_KEY_INDEX_FIELD: &str = "__lookup_key_index";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -693,5 +695,3 @@ mod tests {
         );
     }
 }
-
-pub const LOOKUP_KEY_INDEX_FIELD: &str = "__lookup_key_index";

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -350,7 +350,7 @@ impl Serialize for DebeziumOp {
     }
 }
 
-#[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Encode, Decode, Debug, Serialize, Deserialize, PartialEq)]
 pub enum JoinType {
     /// Inner Join
     Inner,

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -693,3 +693,5 @@ mod tests {
         );
     }
 }
+
+pub const LOOKUP_KEY_INDEX_FIELD: &str = "__lookup_key_index";

--- a/crates/arroyo-worker/Cargo.toml
+++ b/crates/arroyo-worker/Cargo.toml
@@ -77,6 +77,7 @@ itertools = "0.12.0"
 async-ffi = "0.5.0"
 dlopen2 = "0.7.0"
 dlopen2_derive = "0.4.0"
+mini-moka = { version = "0.10.3" }
 
 
 [dev-dependencies]

--- a/crates/arroyo-worker/src/arrow/lookup_join.rs
+++ b/crates/arroyo-worker/src/arrow/lookup_join.rs
@@ -1,0 +1,31 @@
+use arrow_array::RecordBatch;
+use async_trait::async_trait;
+use datafusion::physical_expr::PhysicalExpr;
+use arroyo_connectors::LookupConnector;
+use arroyo_operator::context::{Collector, OperatorContext};
+use arroyo_operator::operator::ArrowOperator;
+
+
+pub struct LookupJoin {
+    connector: Box<dyn LookupConnector + Send>,
+    key_exprs: Vec<dyn PhysicalExpr>,
+}
+
+#[async_trait]
+impl ArrowOperator for LookupJoin {
+    fn name(&self) -> String {
+        format!("LookupJoin<{}>", self.connector.name())
+    }
+
+    async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut OperatorContext, collector: &mut dyn Collector) {
+        let keys = self.key_exprs.iter()
+            .map(|expr| expr.evaluate(&batch).unwrap().into_array().unwrap())
+            .collect::<Vec<_>>();
+
+        
+        
+        for i in 0..keys.num_rows() {
+
+        }
+    }
+}

--- a/crates/arroyo-worker/src/arrow/lookup_join.rs
+++ b/crates/arroyo-worker/src/arrow/lookup_join.rs
@@ -239,7 +239,7 @@ impl OperatorConstructor for LookupJoinConstructor {
             .unwrap_or_else(|| panic!("No connector with name '{}'", op.connector))
             .make_lookup(operator_config.clone(), lookup_schema.clone())?;
 
-        let max_capacity_bytes = config.max_capacity_bytes.unwrap_or_else(|| 8 * 1024 * 1024);
+        let max_capacity_bytes = config.max_capacity_bytes.unwrap_or(8 * 1024 * 1024);
         let cache = (max_capacity_bytes > 0).then(|| {
             let mut c = Cache::builder()
                 .weigher(|k: &OwnedRow, v: &OwnedRow| (k.as_ref().len() + v.as_ref().len()) as u32)

--- a/crates/arroyo-worker/src/arrow/lookup_join.rs
+++ b/crates/arroyo-worker/src/arrow/lookup_join.rs
@@ -1,4 +1,4 @@
-use arrow::compute::{filter_record_batch, is_null};
+use arrow::compute::filter_record_batch;
 use arrow::row::{OwnedRow, RowConverter, SortField};
 use arrow_array::cast::AsArray;
 use arrow_array::types::UInt64Type;
@@ -152,14 +152,12 @@ impl ArrowOperator for LookupJoin {
                 }
             }
 
-
             BooleanArray::from(nonnull)
         });
 
         let in_schema = ctx.in_schemas.first().unwrap();
         let key_indices = in_schema.key_indices.as_ref().unwrap();
         let non_keys: Vec<_> = (0..batch.num_columns())
-            .into_iter()
             .filter(|i| !key_indices.contains(i) && *i != in_schema.timestamp_index)
             .collect();
 

--- a/crates/arroyo-worker/src/arrow/lookup_join.rs
+++ b/crates/arroyo-worker/src/arrow/lookup_join.rs
@@ -1,14 +1,25 @@
-use arrow_array::RecordBatch;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch};
+use arrow::row::{OwnedRow, RowConverter};
 use async_trait::async_trait;
+use datafusion::common::DFSchemaRef;
 use datafusion::physical_expr::PhysicalExpr;
+
 use arroyo_connectors::LookupConnector;
 use arroyo_operator::context::{Collector, OperatorContext};
 use arroyo_operator::operator::ArrowOperator;
+use arroyo_types::JoinType;
 
-
+/// A simple in-operator cache storing the entire “right side” row batch keyed by a string.
 pub struct LookupJoin {
     connector: Box<dyn LookupConnector + Send>,
-    key_exprs: Vec<dyn PhysicalExpr>,
+    key_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    cache: HashMap<Vec<u8>, OwnedRow>,
+    key_row_converter: RowConverter,
+    result_row_converter: RowConverter,
+    join_type: JoinType,
 }
 
 #[async_trait]
@@ -17,15 +28,68 @@ impl ArrowOperator for LookupJoin {
         format!("LookupJoin<{}>", self.connector.name())
     }
 
-    async fn process_batch(&mut self, batch: RecordBatch, ctx: &mut OperatorContext, collector: &mut dyn Collector) {
-        let keys = self.key_exprs.iter()
-            .map(|expr| expr.evaluate(&batch).unwrap().into_array().unwrap())
-            .collect::<Vec<_>>();
+    async fn process_batch(
+        &mut self,
+        batch: RecordBatch,
+        ctx: &mut OperatorContext,
+        collector: &mut dyn Collector,
+    ) {
+        let num_rows = batch.num_rows();
 
-        
-        
-        for i in 0..keys.num_rows() {
+        let key_arrays: Vec<_> = self
+            .key_exprs
+            .iter()
+            .map(|expr| {
+                expr.evaluate(&batch)
+                    .unwrap()
+                    .into_array(num_rows)
+                    .unwrap()
+            })
+            .collect();
 
+        let rows = self.key_row_converter.convert_columns(&key_arrays).unwrap();
+
+        let mut key_map: HashMap<_, Vec<usize>> = HashMap::new();
+        for (i, row) in rows.iter().enumerate() {
+            key_map.entry(row.owned()).or_default().push(i);
         }
+
+        let mut uncached_keys = Vec::new();
+        for k in key_map.keys() {
+            if !self.cache.contains_key(k.row().as_ref()) {
+                uncached_keys.push(k.clone());
+            }
+        }
+
+        if !uncached_keys.is_empty() {
+            let cols = self.key_row_converter.convert_rows(uncached_keys.iter().map(|r| r.row())).unwrap();
+
+            let result_batch = self
+                .connector
+                .lookup(&cols)
+                .await;
+
+            let result_rows = self.result_row_converter.convert_columns(result_batch.columns())
+                .unwrap();
+
+            assert_eq!(result_rows.num_rows(), uncached_keys.len());
+
+            for (k, v) in uncached_keys.iter().zip(result_rows.iter()) {
+                self.cache.insert(k.as_ref().to_vec(), v.owned());
+            }
+        }
+
+        let mut output_rows = self.result_row_converter.empty_rows(batch.num_rows(), batch.num_rows() * 10);
+
+        for row in rows.iter() {
+            output_rows.push(self.cache.get(row.data()).expect("row should be cached").row());
+        }
+        
+        let right_side = self.result_row_converter.convert_rows(output_rows.iter()).unwrap();
+        let mut result = batch.columns().to_vec();
+        result.extend(right_side);
+        
+        collector.collect(RecordBatch::try_new(ctx.out_schema.as_ref().unwrap().schema.clone(), result).unwrap())
+            .await;
     }
 }

--- a/crates/arroyo-worker/src/arrow/mod.rs
+++ b/crates/arroyo-worker/src/arrow/mod.rs
@@ -28,6 +28,7 @@ use std::sync::RwLock;
 pub mod async_udf;
 pub mod instant_join;
 pub mod join_with_expiration;
+pub mod lookup_join;
 pub mod session_aggregating_window;
 pub mod sliding_aggregating_window;
 pub(crate) mod sync;
@@ -35,7 +36,6 @@ pub mod tumbling_aggregating_window;
 pub mod updating_aggregator;
 pub mod watermark_generator;
 pub mod window_fn;
-mod lookup_join;
 
 pub struct ValueExecutionOperator {
     name: String,

--- a/crates/arroyo-worker/src/arrow/mod.rs
+++ b/crates/arroyo-worker/src/arrow/mod.rs
@@ -35,6 +35,7 @@ pub mod tumbling_aggregating_window;
 pub mod updating_aggregator;
 pub mod watermark_generator;
 pub mod window_fn;
+mod lookup_join;
 
 pub struct ValueExecutionOperator {
     name: String,

--- a/crates/arroyo-worker/src/arrow/tumbling_aggregating_window.rs
+++ b/crates/arroyo-worker/src/arrow/tumbling_aggregating_window.rs
@@ -181,7 +181,7 @@ impl OperatorConstructor for TumblingAggregateWindowConstructor {
             .transpose()?;
 
         let aggregate_with_timestamp_schema =
-            add_timestamp_field_arrow(finish_execution_plan.schema());
+            add_timestamp_field_arrow((*finish_execution_plan.schema()).clone());
 
         Ok(ConstructedOperator::from_operator(Box::new(
             TumblingAggregatingWindowFunc {

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -782,11 +782,9 @@ pub async fn construct_node(
 ) -> OperatorNode {
     if chain.is_source() {
         let (head, _) = chain.iter().next().unwrap();
-        let ConstructedOperator::Source(operator) = construct_operator(
-            head.operator_name,
-            &head.operator_config,
-            registry,
-        ) else {
+        let ConstructedOperator::Source(operator) =
+            construct_operator(head.operator_name, &head.operator_config, registry)
+        else {
             unreachable!();
         };
 

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -874,6 +874,7 @@ pub fn construct_operator(
         OperatorName::ExpressionWatermark => Box::new(WatermarkGeneratorConstructor),
         OperatorName::Join => Box::new(JoinWithExpirationConstructor),
         OperatorName::InstantJoin => Box::new(InstantJoinConstructor),
+        OperatorName::LookupJoin => todo!(),
         OperatorName::WindowFunction => Box::new(WindowFunctionConstructor),
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
             let op: api::ConnectorOp = prost::Message::decode(config).unwrap();

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -1,6 +1,7 @@
 use crate::arrow::async_udf::AsyncUdfConstructor;
 use crate::arrow::instant_join::InstantJoinConstructor;
 use crate::arrow::join_with_expiration::JoinWithExpirationConstructor;
+use crate::arrow::lookup_join::LookupJoinConstructor;
 use crate::arrow::session_aggregating_window::SessionAggregatingWindowConstructor;
 use crate::arrow::sliding_aggregating_window::SlidingAggregatingWindowConstructor;
 use crate::arrow::tumbling_aggregating_window::TumblingAggregateWindowConstructor;
@@ -54,8 +55,8 @@ pub struct SubtaskNode {
     pub node_id: u32,
     pub subtask_idx: usize,
     pub parallelism: usize,
-    pub in_schemas: Vec<ArroyoSchema>,
-    pub out_schema: Option<ArroyoSchema>,
+    pub in_schemas: Vec<Arc<ArroyoSchema>>,
+    pub out_schema: Option<Arc<ArroyoSchema>>,
     pub node: OperatorNode,
 }
 
@@ -97,7 +98,7 @@ pub struct PhysicalGraphEdge {
     edge_idx: usize,
     in_logical_idx: usize,
     out_logical_idx: usize,
-    schema: ArroyoSchema,
+    schema: Arc<ArroyoSchema>,
     edge: LogicalEdgeType,
     tx: Option<BatchSender>,
     rx: Option<BatchReceiver>,
@@ -773,17 +774,19 @@ pub async fn construct_node(
     subtask_idx: u32,
     parallelism: u32,
     input_partitions: u32,
-    in_schemas: Vec<ArroyoSchema>,
-    out_schema: Option<ArroyoSchema>,
+    in_schemas: Vec<Arc<ArroyoSchema>>,
+    out_schema: Option<Arc<ArroyoSchema>>,
     restore_from: Option<&CheckpointMetadata>,
     control_tx: Sender<ControlResp>,
     registry: Arc<Registry>,
 ) -> OperatorNode {
     if chain.is_source() {
         let (head, _) = chain.iter().next().unwrap();
-        let ConstructedOperator::Source(operator) =
-            construct_operator(head.operator_name, &head.operator_config, registry)
-        else {
+        let ConstructedOperator::Source(operator) = construct_operator(
+            head.operator_name,
+            &head.operator_config,
+            registry,
+        ) else {
             unreachable!();
         };
 
@@ -874,7 +877,7 @@ pub fn construct_operator(
         OperatorName::ExpressionWatermark => Box::new(WatermarkGeneratorConstructor),
         OperatorName::Join => Box::new(JoinWithExpirationConstructor),
         OperatorName::InstantJoin => Box::new(InstantJoinConstructor),
-        OperatorName::LookupJoin => todo!(),
+        OperatorName::LookupJoin => Box::new(LookupJoinConstructor),
         OperatorName::WindowFunction => Box::new(WindowFunctionConstructor),
         OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
             let op: api::ConnectorOp = prost::Message::decode(config).unwrap();


### PR DESCRIPTION
This PR introduces a new type of table, connector, and join, to support use cases where we wish to enrich a stream by performing ad-hoc queries on another system (typically a DB or cache). We call these _lookup joins_, as we are joining a stream to another table via a query mechanism, as well as an initial Redis lookup connector.

It looks like this:

```sql
CREATE TABLE events (
    event_id TEXT,
    timestamp TIMESTAMP,
    customer_id TEXT,
    event_type TEXT
) WITH (
    connector = 'kafka',
    topic = 'events',
    type = 'source',
    format = 'json',
    bootstrap_servers = 'broker:9092'
);

CREATE TEMPORARY TABLE customers (
    customer_id TEXT GENERATED ALWAYS AS (metadata('key')) STORED, 
    name TEXT,
    plan TEXT
) with (
    connector = 'redis',
    format = 'raw_string',
    address = 'redis://localhost:6379',
    format = 'json',
    'lookup.cache.max_bytes' = '1000000'
    'lookup.cache.ttl' = '5 second'
);

SELECT  e.event_id,  e.timestamp,  e.customer_id,  e.event_type, c.customer_name, c.plan
FROM  events e
LEFT JOIN customers c
ON concat('customer.', e.customer_id) = c.customer_id
WHERE c.plan = 'Premium';
```

Here, we create a "temporary table"—implying that it's not fully materialized—backed by a Redis cache, with the Redis key specified via the metadata syntax introduced in 0.13. We then perform a join (in this case a left join, although inner is also supported) against it, causing a lookup into Redis for the specified key.

Lookup joins also optionally include a cache, which can be configured by the user with a TTL and/or a max size in bytes.

This PR also includes a refactor of the deserialization system to reduce the number of independent codepaths that handle metadata field deserialization and combines logic between JSON and non-JSON paths. This also fixed several corner cases where additional fields were not being injected properly in certain formats.

This addresses #820