### PR TITLE
Add  metadata field to Kafka source

### DIFF
--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -336,6 +336,10 @@ impl Connector for KafkaConnector {
                 name: "timestamp",
                 data_type: DataType::Int64,
             },
+            MetadataDef {
+                name: "key",
+                data_type: DataType::Binary,
+            },
         ]
     }
 

--- a/crates/arroyo-connectors/src/kafka/source/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/source/mod.rs
@@ -204,10 +204,11 @@ impl KafkaSourceFunc {
                                     let mut connector_metadata = HashMap::new();
                                     for f in &self.metadata_fields {
                                         connector_metadata.insert(f.field_name.as_str(), match f.key.as_str() {
-                                            "offset_id" => FieldValueType::Int64(msg.offset()),
-                                            "partition" => FieldValueType::Int32(msg.partition()),
-                                            "topic" => FieldValueType::String(topic),
-                                            "timestamp" => FieldValueType::Int64(timestamp),
+                                            "key" => FieldValueType::Bytes(msg.key()),
+                                            "offset_id" => FieldValueType::Int64(Some(msg.offset())),
+                                            "partition" => FieldValueType::Int32(Some(msg.partition())),
+                                            "topic" => FieldValueType::String(Some(topic)),
+                                            "timestamp" => FieldValueType::Int64(Some(timestamp)),
                                             k => unreachable!("Invalid metadata key '{}'", k),
                                         });
                                     }

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -154,7 +154,7 @@ impl MqttSourceFunc {
                                 let mut connector_metadata = HashMap::new();
                                 for mf in &self.metadata_fields {
                                     connector_metadata.insert(mf.field_name.as_str(), match mf.key.as_str() {
-                                        "topic" => FieldValueType::String(&topic),
+                                        "topic" => FieldValueType::String(Some(&topic)),
                                         k => unreachable!("invalid metadata key '{}' for mqtt", k)
                                     });
                                 }

--- a/crates/arroyo-connectors/src/redis/lookup.rs
+++ b/crates/arroyo-connectors/src/redis/lookup.rs
@@ -59,12 +59,15 @@ impl LookupConnector for RedisLookup {
         let mut additional = HashMap::new();
 
         for (idx, (v, k)) in vs.iter().zip(keys).enumerate() {
-            additional.insert(LOOKUP_KEY_INDEX_FIELD, FieldValueType::UInt64(idx as u64));
+            additional.insert(
+                LOOKUP_KEY_INDEX_FIELD,
+                FieldValueType::UInt64(Some(idx as u64)),
+            );
             for m in &self.metadata_fields {
                 additional.insert(
                     m.field_name.as_str(),
                     match m.key.as_str() {
-                        "key" => FieldValueType::String(k.unwrap()),
+                        "key" => FieldValueType::String(Some(k.unwrap())),
                         k => unreachable!("Invalid metadata key '{}'", k),
                     },
                 );


### PR DESCRIPTION
Adds `key` as a metadata field to the kafka source, allowing the message key to be injected into queries:

```sql
create table kafka (
    key BYTEA GENERATED ALWAYS AS (metadata('key')) STORED,
    topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED,
    value TEXT
)  with (
    connector = 'kafka',
    bootstrap_servers = 'localhost:9092',
    topic = 'logs',
    type = 'source',
    format = 'raw_string'
);

select cast(key as TEXT), value, topic from kafka;
```