### PR TITLE
Support typed SQL opts in with clause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
  "arroyo-types",
  "async-trait",
  "base64 0.21.7",
- "datafusion-common",
+ "datafusion",
  "dirs",
  "figment",
  "futures",

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -5,8 +5,7 @@ use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
-use std::collections::HashMap;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
 use crate::EmptyConfig;
 
@@ -75,7 +74,7 @@ impl Connector for BlackholeConnector {
     fn from_options(
         &self,
         name: &str,
-        _options: &mut HashMap<String, String>,
+        _options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-connectors/src/confluent/mod.rs
+++ b/crates/arroyo-connectors/src/confluent/mod.rs
@@ -1,7 +1,7 @@
+use crate::kafka;
 use crate::kafka::{
     KafkaConfig, KafkaConfigAuthentication, KafkaConnector, KafkaTable, KafkaTester, TableType,
 };
-use crate::{kafka};
 use anyhow::anyhow;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
@@ -35,8 +35,9 @@ impl ConfluentConnector {
     pub fn connection_from_options(
         opts: &mut ConnectorOptions,
     ) -> anyhow::Result<ConfluentProfile> {
-        let schema_registry: Option<anyhow::Result<_>> =
-            opts.pull_opt_str("schema_registry.endpoint")?.map(|endpoint| {
+        let schema_registry: Option<anyhow::Result<_>> = opts
+            .pull_opt_str("schema_registry.endpoint")?
+            .map(|endpoint| {
                 let api_key = VarStr::new(opts.pull_str("schema_registry.api_key")?);
                 let api_secret = VarStr::new(opts.pull_str("schema_registry.api_secret")?);
                 Ok(ConfluentSchemaRegistry {

--- a/crates/arroyo-connectors/src/confluent/mod.rs
+++ b/crates/arroyo-connectors/src/confluent/mod.rs
@@ -9,7 +9,7 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
 use arroyo_rpc::var_str::VarStr;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
@@ -33,12 +33,12 @@ pub struct ConfluentConnector {}
 
 impl ConfluentConnector {
     pub fn connection_from_options(
-        opts: &mut HashMap<String, String>,
+        opts: &mut ConnectorOptions,
     ) -> anyhow::Result<ConfluentProfile> {
         let schema_registry: Option<anyhow::Result<_>> =
-            opts.remove("schema_registry.endpoint").map(|endpoint| {
-                let api_key = VarStr::new(pull_opt("schema_registry.api_key", opts)?);
-                let api_secret = VarStr::new(pull_opt("schema_registry.api_secret", opts)?);
+            opts.pull_opt_str("schema_registry.endpoint")?.map(|endpoint| {
+                let api_key = VarStr::new(opts.pull_str("schema_registry.api_key")?);
+                let api_secret = VarStr::new(opts.pull_str("schema_registry.api_secret")?);
                 Ok(ConfluentSchemaRegistry {
                     endpoint: Some(endpoint),
                     api_key: Some(api_key),
@@ -159,7 +159,7 @@ impl Connector for ConfluentConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-connectors/src/confluent/mod.rs
+++ b/crates/arroyo-connectors/src/confluent/mod.rs
@@ -1,7 +1,7 @@
 use crate::kafka::{
     KafkaConfig, KafkaConfigAuthentication, KafkaConnector, KafkaTable, KafkaTester, TableType,
 };
-use crate::{kafka, pull_opt};
+use crate::{kafka};
 use anyhow::anyhow;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
@@ -47,9 +47,9 @@ impl ConfluentConnector {
             });
 
         Ok(ConfluentProfile {
-            bootstrap_servers: BootstrapServers(pull_opt("bootstrap_servers", opts)?),
-            key: VarStr::new(pull_opt("key", opts)?),
-            secret: VarStr::new(pull_opt("secret", opts)?),
+            bootstrap_servers: BootstrapServers(opts.pull_str("bootstrap_servers")?),
+            key: VarStr::new(opts.pull_str("key")?),
+            secret: VarStr::new(opts.pull_str("secret")?),
             schema_registry: schema_registry.transpose()?,
         })
     }

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
 use crate::filesystem::{
     file_system_sink_from_options, CommitStyle, FileSystemTable, FormatSettings, TableType,
@@ -140,9 +140,9 @@ impl Connector for DeltaLakeConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let table = file_system_sink_from_options(options, schema, CommitStyle::DeltaLake)?;
 

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, bail};
 use arroyo_operator::connector::Connection;
 use arroyo_storage::BackendConfig;
-use std::collections::HashMap;
 
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
@@ -142,7 +141,7 @@ impl Connector for DeltaLakeConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let table = file_system_sink_from_options(options, schema, CommitStyle::DeltaLake)?;
 

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -14,7 +14,7 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
 use arroyo_rpc::formats::Format;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
 use crate::{pull_opt, pull_option_to_i64, EmptyConfig};
@@ -185,9 +185,9 @@ impl Connector for FileSystemConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         match options.remove("type") {
             Some(t) if t == "source" => {

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -17,7 +17,7 @@ use arroyo_rpc::formats::Format;
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
-use crate::{EmptyConfig};
+use crate::EmptyConfig;
 
 use crate::filesystem::source::FileSystemSourceFunc;
 use arroyo_operator::connector::Connector;
@@ -187,7 +187,7 @@ impl Connector for FileSystemConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         match options.pull_opt_str("type")? {
             Some(t) if t == "source" => {
@@ -281,12 +281,17 @@ fn get_storage_url_and_options(
 ) -> Result<(String, HashMap<String, String>)> {
     let storage_url = opts.pull_str("path")?;
     let storage_keys: Vec<_> = opts.keys_with_prefix("storage.").cloned().collect();
-    
-    let storage_options = storage_keys.iter().map(|k| Ok((
-        k.trim_start_matches("storage.").to_string(),
-        opts.pull_str(k)?
-    ))).collect::<Result<HashMap<String, String>>>()?;
-    
+
+    let storage_options = storage_keys
+        .iter()
+        .map(|k| {
+            Ok((
+                k.trim_start_matches("storage.").to_string(),
+                opts.pull_str(k)?,
+            ))
+        })
+        .collect::<Result<HashMap<String, String>>>()?;
+
     BackendConfig::parse_url(&storage_url, true)?;
     Ok((storage_url, storage_options))
 }

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -6,7 +6,6 @@ use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema, Te
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use fluvio::Offset;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use typify::import_types;
 
 use crate::fluvio::sink::FluvioSinkFunc;
@@ -87,7 +86,7 @@ impl Connector for FluvioConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = options.pull_opt_str("endpoint")?;
         let topic = options.pull_str("topic")?;

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -3,7 +3,7 @@ use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema, TestSourceMessage};
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use fluvio::Offset;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -85,9 +85,9 @@ impl Connector for FluvioConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = options.remove("endpoint");
         let topic = pull_opt("topic", options)?;

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -11,7 +11,7 @@ use typify::import_types;
 
 use crate::fluvio::sink::FluvioSinkFunc;
 use crate::fluvio::source::FluvioSourceFunc;
-use crate::{pull_opt, ConnectionType, EmptyConfig};
+use crate::{ConnectionType, EmptyConfig};
 
 mod sink;
 mod source;
@@ -89,13 +89,13 @@ impl Connector for FluvioConnector {
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let endpoint = options.remove("endpoint");
-        let topic = pull_opt("topic", options)?;
-        let table_type = pull_opt("type", options)?;
+        let endpoint = options.pull_opt_str("endpoint")?;
+        let topic = options.pull_str("topic")?;
+        let table_type = options.pull_str("type")?;
 
         let table_type = match table_type.as_str() {
             "source" => {
-                let offset = options.remove("source.offset");
+                let offset = options.pull_opt_str("source.offset")?;
                 TableType::Source {
                     offset: match offset.as_deref() {
                         Some("earliest") => SourceOffset::Earliest,

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -7,7 +7,7 @@ use arroyo_rpc::api_types::connections::FieldType::Primitive;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, PrimitiveType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -99,9 +99,9 @@ impl Connector for ImpulseConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -1,6 +1,6 @@
 mod operator;
 
-use anyhow::{bail};
+use anyhow::bail;
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::FieldType::Primitive;
@@ -9,7 +9,6 @@ use arroyo_rpc::api_types::connections::{
 };
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use typify::import_types;
 

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -9,7 +9,7 @@ use arroyo_rpc::formats::{BadData, Format, JsonFormat};
 use arroyo_rpc::schema_resolver::{
     ConfluentSchemaRegistry, ConfluentSchemaRegistryClient, SchemaResolver,
 };
-use arroyo_rpc::{schema_resolver, var_str::VarStr, OperatorConfig};
+use arroyo_rpc::{schema_resolver, var_str::VarStr, ConnectorOptions, OperatorConfig};
 use arroyo_types::string_to_map;
 use aws_config::Region;
 use aws_msk_iam_sasl_signer::generate_auth_token;
@@ -346,7 +346,7 @@ impl Connector for KafkaConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -36,7 +36,7 @@ use tonic::Status;
 use tracing::{error, info, warn};
 use typify::import_types;
 
-use crate::{pull_opt, send, ConnectionType};
+use crate::{send, ConnectionType};
 
 use crate::kafka::sink::KafkaSinkFunc;
 use crate::kafka::source::KafkaSourceFunc;
@@ -72,47 +72,49 @@ pub struct KafkaConnector {}
 
 impl KafkaConnector {
     pub fn connection_from_options(
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
     ) -> anyhow::Result<KafkaConfig> {
-        let auth = options.remove("auth.type");
+        let auth = options.pull_opt_str("auth.type")?;
         let auth = match auth.as_deref() {
             Some("none") | None => KafkaConfigAuthentication::None {},
             Some("sasl") => KafkaConfigAuthentication::Sasl {
-                mechanism: pull_opt("auth.mechanism", options)?,
-                protocol: pull_opt("auth.protocol", options)?,
-                username: VarStr::new(pull_opt("auth.username", options)?),
-                password: VarStr::new(pull_opt("auth.password", options)?),
+                mechanism: options.pull_str("auth.mechanism")?,
+                protocol: options.pull_str("auth.protocol")?,
+                username: VarStr::new(options.pull_str("auth.username")?),
+                password: VarStr::new(options.pull_str("auth.password")?),
             },
             Some("aws_msk_iam") => KafkaConfigAuthentication::AwsMskIam {
-                region: pull_opt("auth.region", options)?,
+                region: options.pull_str("auth.region")
+                    .map_err(|e| anyhow!("failed to get auth.region: {}", e))?,
             },
             Some(other) => bail!("unknown auth type '{}'", other),
         };
 
-        let schema_registry = options.remove("schema_registry.endpoint").map(|endpoint| {
-            let api_key = options.remove("schema_registry.api_key").map(VarStr::new);
-            let api_secret = options
-                .remove("schema_registry.api_secret")
-                .map(VarStr::new);
+        let schema_registry = options.pull_opt_str("schema_registry.endpoint")?.map(|endpoint| {
+            let api_key = options.pull_opt_str("schema_registry.api_key").ok().flatten().map(VarStr::new);
+            let api_secret = options.pull_opt_str("schema_registry.api_secret").ok().flatten().map(VarStr::new);
             SchemaRegistry::ConfluentSchemaRegistry {
                 endpoint,
                 api_key,
                 api_secret,
             }
         });
+
         Ok(KafkaConfig {
             authentication: auth,
-            bootstrap_servers: BootstrapServers(pull_opt("bootstrap_servers", options)?),
+            bootstrap_servers: BootstrapServers(options.pull_str("bootstrap_servers")
+                .map_err(|e| anyhow!("failed to get bootstrap_servers: {}", e))?),
             schema_registry_enum: schema_registry,
             connection_properties: HashMap::new(),
         })
     }
 
-    pub fn table_from_options(options: &mut HashMap<String, String>) -> anyhow::Result<KafkaTable> {
-        let typ = pull_opt("type", options)?;
+    pub fn table_from_options(options: &mut ConnectorOptions) -> anyhow::Result<KafkaTable> {
+        let typ = options.pull_str("type")
+            .map_err(|e| anyhow!("failed to get type: {}", e))?;
         let table_type = match typ.as_str() {
             "source" => {
-                let offset = options.remove("source.offset");
+                let offset = options.pull_opt_str("source.offset")?;
                 TableType::Source {
                     offset: match offset.as_deref() {
                         Some("earliest") => SourceOffset::Earliest,
@@ -120,25 +122,25 @@ impl KafkaConnector {
                         None | Some("latest") => SourceOffset::Latest,
                         Some(other) => bail!("invalid value for source.offset '{}'", other),
                     },
-                    read_mode: match options.remove("source.read_mode").as_deref() {
+                    read_mode: match options.pull_opt_str("source.read_mode")?.as_deref() {
                         Some("read_committed") => Some(ReadMode::ReadCommitted),
                         Some("read_uncommitted") | None => Some(ReadMode::ReadUncommitted),
                         Some(other) => bail!("invalid value for source.read_mode '{}'", other),
                     },
-                    group_id: options.remove("source.group_id"),
-                    group_id_prefix: options.remove("source.group_id_prefix"),
+                    group_id: options.pull_opt_str("source.group_id")?,
+                    group_id_prefix: options.pull_opt_str("source.group_id_prefix")?,
                 }
             }
             "sink" => {
-                let commit_mode = options.remove("sink.commit_mode");
+                let commit_mode = options.pull_opt_str("sink.commit_mode")?;
                 TableType::Sink {
                     commit_mode: match commit_mode.as_deref() {
                         Some("at_least_once") | None => SinkCommitMode::AtLeastOnce,
                         Some("exactly_once") => SinkCommitMode::ExactlyOnce,
                         Some(other) => bail!("invalid value for commit_mode '{}'", other),
                     },
-                    timestamp_field: options.remove("sink.timestamp_field"),
-                    key_field: options.remove("sink.key_field"),
+                    timestamp_field: options.pull_opt_str("sink.timestamp_field")?,
+                    key_field: options.pull_opt_str("sink.key_field")?,
                 }
             }
             _ => {
@@ -147,10 +149,10 @@ impl KafkaConnector {
         };
 
         Ok(KafkaTable {
-            topic: pull_opt("topic", options)?,
+            topic: options.pull_str("topic")
+                .map_err(|e| anyhow!("failed to get topic: {}", e))?,
             type_: table_type,
-            client_configs: options
-                .remove("client_configs")
+            client_configs: options.pull_opt_str("client_configs")?
                 .map(|c| {
                     string_to_map(&c, '=').ok_or_else(|| {
                         anyhow!("invalid client_config: expected comma and equals-separated pairs")
@@ -158,7 +160,7 @@ impl KafkaConnector {
                 })
                 .transpose()?
                 .unwrap_or_else(HashMap::new),
-            value_subject: options.remove("value.subject"),
+            value_subject: options.pull_opt_str("value.subject")?,
         })
     }
 }

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -5,7 +5,7 @@ use typify::import_types;
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::api_types::connections::{ConnectionProfile, TestSourceMessage};
-use arroyo_rpc::{api_types, OperatorConfig};
+use arroyo_rpc::{api_types, ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
 use crate::{pull_opt, pull_option_to_i64, ConnectionSchema, ConnectionType, EmptyConfig};
@@ -128,9 +128,9 @@ impl Connector for KinesisConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let typ = pull_opt("type", options)?;
         let table_type = match typ.as_str() {

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -147,8 +147,7 @@ impl Connector for KinesisConnector {
             "sink" => {
                 let batch_flush_interval_millis =
                     options.pull_opt_i64("sink.flush_interval_millis")?;
-                let batch_max_buffer_size =
-                    options.pull_opt_i64("sink.max_bytes_per_batch")?;
+                let batch_max_buffer_size = options.pull_opt_i64("sink.max_bytes_per_batch")?;
                 let records_per_batch = options.pull_opt_i64("sink.max_records_per_batch")?;
                 TableType::Sink {
                     batch_flush_interval_millis,

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -34,9 +34,6 @@ pub mod stdout;
 pub mod webhook;
 pub mod websocket;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-
-pub struct EmptyConfig {}
 pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
     let connectors: Vec<Box<dyn ErasedConnector>> = vec![
         Box::new(blackhole::BlackholeConnector {}),
@@ -63,6 +60,9 @@ pub fn connectors() -> HashMap<&'static str, Box<dyn ErasedConnector>> {
 
     connectors.into_iter().map(|c| (c.name(), c)).collect()
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct EmptyConfig {}
 
 pub(crate) async fn send(tx: &mut Sender<TestSourceMessage>, msg: TestSourceMessage) {
     if tx.send(msg).await.is_err() {

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -11,6 +11,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+use datafusion::common::{plan_datafusion_err, Result as DFResult};
+use datafusion::common::plan_err;
+use datafusion::sql::sqlparser::ast::{Expr, SqlOption, Value};
 use tokio::sync::mpsc::Sender;
 use tracing::warn;
 
@@ -69,6 +72,8 @@ pub(crate) async fn send(tx: &mut Sender<TestSourceMessage>, msg: TestSourceMess
         warn!("Test API rx closed while sending message");
     }
 }
+
+
 
 pub(crate) fn pull_opt(name: &str, opts: &mut HashMap<String, String>) -> anyhow::Result<String> {
     opts.remove(name)

--- a/crates/arroyo-connectors/src/lib.rs
+++ b/crates/arroyo-connectors/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail};
 use arroyo_operator::connector::ErasedConnector;
 use arroyo_rpc::api_types::connections::{
     ConnectionSchema, ConnectionType, FieldType, SourceField, SourceFieldType, TestSourceMessage,
@@ -11,9 +11,6 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
-use datafusion::common::{plan_datafusion_err, Result as DFResult};
-use datafusion::common::plan_err;
-use datafusion::sql::sqlparser::ast::{Expr, SqlOption, Value};
 use tokio::sync::mpsc::Sender;
 use tracing::warn;
 

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -14,8 +13,8 @@ use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use arroyo_rpc::var_str::VarStr;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, Event as MqttEvent, EventLoop, Incoming, MqttOptions};
 use rumqttc::Outgoing;
@@ -57,9 +56,7 @@ impl MqttTable {
 }
 
 impl MqttConnector {
-    pub fn connection_from_options(
-        options: &mut ConnectorOptions,
-    ) -> anyhow::Result<MqttConfig> {
+    pub fn connection_from_options(options: &mut ConnectorOptions) -> anyhow::Result<MqttConfig> {
         let url = options.pull_str("url")?;
         let username = options.pull_opt_str("username")?.map(VarStr::new);
         let password = options.pull_opt_str("password")?.map(VarStr::new);
@@ -87,7 +84,8 @@ impl MqttConnector {
 
     pub fn table_from_options(options: &mut ConnectorOptions) -> anyhow::Result<MqttTable> {
         let typ = options.pull_str("type")?;
-        let qos = options.pull_opt_str("qos")?
+        let qos = options
+            .pull_opt_str("qos")?
             .map(|s| match s.as_str() {
                 "AtMostOnce" => Ok(QualityOfService::AtMostOnce),
                 "AtLeastOnce" => Ok(QualityOfService::AtLeastOnce),
@@ -99,9 +97,12 @@ impl MqttConnector {
         let table_type = match typ.as_str() {
             "source" => TableType::Source {},
             "sink" => TableType::Sink {
-                retain: options.pull_opt_str("sink.retain")?
-                    .map(|s| s.parse::<bool>()
-                        .map_err(|_| anyhow!("'sink.retail' must be either 'true' or 'false'")))
+                retain: options
+                    .pull_opt_str("sink.retain")?
+                    .map(|s| {
+                        s.parse::<bool>()
+                            .map_err(|_| anyhow!("'sink.retail' must be either 'true' or 'false'"))
+                    })
                     .transpose()?
                     .unwrap_or(false),
             },

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -15,7 +15,7 @@ use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::{var_str::VarStr, OperatorConfig};
+use arroyo_rpc::{var_str::VarStr, ConnectorOptions, OperatorConfig};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, Event as MqttEvent, EventLoop, Incoming, MqttOptions};
 use rumqttc::Outgoing;
@@ -249,7 +249,7 @@ impl Connector for MqttConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -86,11 +86,8 @@ impl MqttConnector {
         let typ = options.pull_str("type")?;
         let qos = options
             .pull_opt_str("qos")?
-            .map(|s| match s.as_str() {
-                "AtMostOnce" => Ok(QualityOfService::AtMostOnce),
-                "AtLeastOnce" => Ok(QualityOfService::AtLeastOnce),
-                "ExactlyOnce" => Ok(QualityOfService::ExactlyOnce),
-                _ => bail!("invalid value for 'qos': {}", s),
+            .map(|s| {
+                QualityOfService::try_from(s).map_err(|s| anyhow!("invalid value for 'qos': {s}"))
             })
             .transpose()?;
 

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -1,6 +1,5 @@
 use crate::nats::sink::NatsSinkFunc;
 use crate::nats::source::NatsSourceFunc;
-use crate::pull_opt;
 use anyhow::anyhow;
 use anyhow::bail;
 use arroyo_formats::ser::ArrowSerializer;
@@ -10,11 +9,11 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
 use arroyo_rpc::var_str::VarStr;
-use arroyo_rpc::{ConnectorOptions, OperatorConfig};
+use arroyo_rpc::ConnectorOptions;
+use arroyo_rpc::OperatorConfig;
 use async_nats::ServerAddr;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::num::NonZeroU32;
 use tokio::sync::mpsc::Sender;
 use typify::import_types;
@@ -45,15 +44,15 @@ pub struct NatsConnector {}
 
 impl NatsConnector {
     pub fn connection_from_options(
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
     ) -> anyhow::Result<NatsConfig> {
-        let nats_servers = VarStr::new(pull_opt("servers", options)?);
-        let nats_auth = options.remove("auth.type");
+        let nats_servers = VarStr::new(options.pull_str("servers")?);
+        let nats_auth = options.pull_opt_str("auth.type")?;
         let nats_auth: NatsConfigAuthentication = match nats_auth.as_deref() {
             Some("none") | None => NatsConfigAuthentication::None {},
             Some("credentials") => NatsConfigAuthentication::Credentials {
-                username: VarStr::new(pull_opt("auth.username", options)?),
-                password: VarStr::new(pull_opt("auth.password", options)?),
+                username: VarStr::new(options.pull_str("auth.username")?),
+                password: VarStr::new(options.pull_str("auth.password")?),
             },
             Some(other) => bail!("Unknown auth type '{}'", other),
         };
@@ -64,82 +63,68 @@ impl NatsConnector {
         })
     }
 
-    pub fn table_from_options(options: &mut HashMap<String, String>) -> anyhow::Result<NatsTable> {
-        let conn_type = pull_opt("type", options)?;
+    pub fn table_from_options(options: &mut ConnectorOptions) -> anyhow::Result<NatsTable> {
+        let conn_type = options.pull_str("type")?;
         let nats_table_type = match conn_type.as_str() {
             "source" => {
                 let source_type = match (
-                    pull_opt("stream", options).ok(),
-                    pull_opt("subject", options).ok(),
+                    options.pull_str("stream").ok(),
+                    options.pull_str("subject").ok(),
                 ) {
                     (Some(stream), None) => Some(SourceType::Jetstream {
                         stream,
-                        description: options.remove("consumer.description"),
-                        ack_policy: options
-                            .remove("consumer.ack_policy")
+                        description: options.pull_opt_str("consumer.description")?,
+                        ack_policy: options.pull_opt_str("consumer.ack_policy")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(AcknowledgmentPolicy::Explicit),
-                        replay_policy: options
-                            .remove("consumer.replay_policy")
+                        replay_policy: options.pull_opt_str("consumer.replay_policy")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(ReplayPolicy::Instant),
-                        ack_wait: options
-                            .remove("consumer.ack_wait")
+                        ack_wait: options.pull_opt_str("consumer.ack_wait")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(30),
-                        filter_subjects: options
-                            .remove("consumer.filter_subjects")
+                        filter_subjects: options.pull_opt_str("consumer.filter_subjects")?
                             .map_or_else(Vec::new, |s| s.split(',').map(String::from).collect()),
-                        sample_frequency: options
-                            .remove("consumer.sample_frequency")
+                        sample_frequency: options.pull_opt_str("consumer.sample_frequency")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(0),
-                        num_replicas: options
-                            .remove("consumer.num_replicas")
+                        num_replicas: options.pull_opt_str("consumer.num_replicas")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(1),
-                        inactive_threshold: options
-                            .remove("consumer.inactive_threshold")
+                        inactive_threshold: options.pull_opt_str("consumer.inactive_threshold")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(600),
-                        rate_limit: options
-                            .remove("consumer.rate_limit")
+                        rate_limit: options.pull_opt_str("consumer.rate_limit")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_ack_pending: options
-                            .remove("consumer.max_ack_pending")
+                        max_ack_pending: options.pull_opt_str("consumer.max_ack_pending")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_deliver: options
-                            .remove("consumer.max_deliver")
+                        max_deliver: options.pull_opt_str("consumer.max_deliver")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_waiting: options
-                            .remove("consumer.max_waiting")
+                        max_waiting: options.pull_opt_str("consumer.max_waiting")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(1000000),
-                        max_batch: options
-                            .remove("consumer.max_batch")
+                        max_batch: options.pull_opt_str("consumer.max_batch")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(10000),
-                        max_bytes: options
-                            .remove("consumer.max_bytes")
+                        max_bytes: options.pull_opt_str("consumer.max_bytes")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(104857600),
-                        max_expires: options
-                            .remove("consumer.max_expires")
+                        max_expires: options.pull_opt_str("consumer.max_expires")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(300000),
@@ -152,7 +137,7 @@ impl NatsConnector {
                 ConnectorType::Source { source_type }
             }
             "sink" => {
-                let sink_type = match pull_opt("subject", options).ok() {
+                let sink_type = match options.pull_str("subject").ok() {
                     Some(subject) => Some(SinkType::Subject(subject)),
                     None => bail!("`subject` must be set for sink"),
                 };
@@ -161,7 +146,6 @@ impl NatsConnector {
             _ => bail!("Type must be one of 'source' or 'sink'"),
         };
 
-        // TODO: Use parameters with `nats.` prefix for the NATS connection configuration
         Ok(NatsTable {
             connector_type: nats_table_type,
         })
@@ -319,7 +303,7 @@ impl Connector for NatsConnector {
         let connection = profile
             .map(|p| {
                 serde_json::from_value(p.config.clone()).map_err(|e| {
-                    anyhow!("Invalid config for profile '{}' in database: {}", p.id, e)
+                    anyhow!("invalid config for profile '{}' in database: {}", p.id, e)
                 })
             })
             .unwrap_or_else(|| Self::connection_from_options(options))?;

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -43,9 +43,7 @@ pub struct NatsState {
 pub struct NatsConnector {}
 
 impl NatsConnector {
-    pub fn connection_from_options(
-        options: &mut ConnectorOptions,
-    ) -> anyhow::Result<NatsConfig> {
+    pub fn connection_from_options(options: &mut ConnectorOptions) -> anyhow::Result<NatsConfig> {
         let nats_servers = VarStr::new(options.pull_str("servers")?);
         let nats_auth = options.pull_opt_str("auth.type")?;
         let nats_auth: NatsConfigAuthentication = match nats_auth.as_deref() {
@@ -74,57 +72,71 @@ impl NatsConnector {
                     (Some(stream), None) => Some(SourceType::Jetstream {
                         stream,
                         description: options.pull_opt_str("consumer.description")?,
-                        ack_policy: options.pull_opt_str("consumer.ack_policy")?
+                        ack_policy: options
+                            .pull_opt_str("consumer.ack_policy")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(AcknowledgmentPolicy::Explicit),
-                        replay_policy: options.pull_opt_str("consumer.replay_policy")?
+                        replay_policy: options
+                            .pull_opt_str("consumer.replay_policy")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(ReplayPolicy::Instant),
-                        ack_wait: options.pull_opt_str("consumer.ack_wait")?
+                        ack_wait: options
+                            .pull_opt_str("consumer.ack_wait")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(30),
-                        filter_subjects: options.pull_opt_str("consumer.filter_subjects")?
+                        filter_subjects: options
+                            .pull_opt_str("consumer.filter_subjects")?
                             .map_or_else(Vec::new, |s| s.split(',').map(String::from).collect()),
-                        sample_frequency: options.pull_opt_str("consumer.sample_frequency")?
+                        sample_frequency: options
+                            .pull_opt_str("consumer.sample_frequency")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(0),
-                        num_replicas: options.pull_opt_str("consumer.num_replicas")?
+                        num_replicas: options
+                            .pull_opt_str("consumer.num_replicas")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(1),
-                        inactive_threshold: options.pull_opt_str("consumer.inactive_threshold")?
+                        inactive_threshold: options
+                            .pull_opt_str("consumer.inactive_threshold")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(600),
-                        rate_limit: options.pull_opt_str("consumer.rate_limit")?
+                        rate_limit: options
+                            .pull_opt_str("consumer.rate_limit")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_ack_pending: options.pull_opt_str("consumer.max_ack_pending")?
+                        max_ack_pending: options
+                            .pull_opt_str("consumer.max_ack_pending")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_deliver: options.pull_opt_str("consumer.max_deliver")?
+                        max_deliver: options
+                            .pull_opt_str("consumer.max_deliver")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(-1),
-                        max_waiting: options.pull_opt_str("consumer.max_waiting")?
+                        max_waiting: options
+                            .pull_opt_str("consumer.max_waiting")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(1000000),
-                        max_batch: options.pull_opt_str("consumer.max_batch")?
+                        max_batch: options
+                            .pull_opt_str("consumer.max_batch")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(10000),
-                        max_bytes: options.pull_opt_str("consumer.max_bytes")?
+                        max_bytes: options
+                            .pull_opt_str("consumer.max_bytes")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(104857600),
-                        max_expires: options.pull_opt_str("consumer.max_expires")?
+                        max_expires: options
+                            .pull_opt_str("consumer.max_expires")?
                             .unwrap_or_default()
                             .parse()
                             .unwrap_or(300000),

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -10,7 +10,7 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
 use arroyo_rpc::var_str::VarStr;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use async_nats::ServerAddr;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
@@ -312,7 +312,7 @@ impl Connector for NatsConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -74,71 +74,45 @@ impl NatsConnector {
                         description: options.pull_opt_str("consumer.description")?,
                         ack_policy: options
                             .pull_opt_str("consumer.ack_policy")?
-                            .unwrap_or_default()
-                            .parse()
+                            .map(|s| {
+                                s.parse()
+                                    .map_err(|e| anyhow!("invalid consumer.ack_policy: {}", e))
+                            })
+                            .transpose()?
                             .unwrap_or(AcknowledgmentPolicy::Explicit),
                         replay_policy: options
                             .pull_opt_str("consumer.replay_policy")?
-                            .unwrap_or_default()
-                            .parse()
+                            .map(|s| {
+                                s.parse()
+                                    .map_err(|e| anyhow!("invalid consumer.replay_policy: {}", e))
+                            })
+                            .transpose()?
                             .unwrap_or(ReplayPolicy::Instant),
-                        ack_wait: options
-                            .pull_opt_str("consumer.ack_wait")?
-                            .unwrap_or_default()
-                            .parse()
-                            .unwrap_or(30),
+                        ack_wait: options.pull_opt_i64("consumer.ack_wait")?.unwrap_or(30),
                         filter_subjects: options
                             .pull_opt_str("consumer.filter_subjects")?
                             .map_or_else(Vec::new, |s| s.split(',').map(String::from).collect()),
                         sample_frequency: options
-                            .pull_opt_str("consumer.sample_frequency")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.sample_frequency")?
                             .unwrap_or(0),
-                        num_replicas: options
-                            .pull_opt_str("consumer.num_replicas")?
-                            .unwrap_or_default()
-                            .parse()
-                            .unwrap_or(1),
+                        num_replicas: options.pull_opt_i64("consumer.num_replicas")?.unwrap_or(1),
                         inactive_threshold: options
-                            .pull_opt_str("consumer.inactive_threshold")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.inactive_threshold")?
                             .unwrap_or(600),
-                        rate_limit: options
-                            .pull_opt_str("consumer.rate_limit")?
-                            .unwrap_or_default()
-                            .parse()
-                            .unwrap_or(-1),
+                        rate_limit: options.pull_opt_i64("consumer.rate_limit")?.unwrap_or(-1),
                         max_ack_pending: options
-                            .pull_opt_str("consumer.max_ack_pending")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.max_ack_pending")?
                             .unwrap_or(-1),
-                        max_deliver: options
-                            .pull_opt_str("consumer.max_deliver")?
-                            .unwrap_or_default()
-                            .parse()
-                            .unwrap_or(-1),
+                        max_deliver: options.pull_opt_i64("consumer.max_deliver")?.unwrap_or(-1),
                         max_waiting: options
-                            .pull_opt_str("consumer.max_waiting")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.max_waiting")?
                             .unwrap_or(1000000),
-                        max_batch: options
-                            .pull_opt_str("consumer.max_batch")?
-                            .unwrap_or_default()
-                            .parse()
-                            .unwrap_or(10000),
+                        max_batch: options.pull_opt_i64("consumer.max_batch")?.unwrap_or(10000),
                         max_bytes: options
-                            .pull_opt_str("consumer.max_bytes")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.max_bytes")?
                             .unwrap_or(104857600),
                         max_expires: options
-                            .pull_opt_str("consumer.max_expires")?
-                            .unwrap_or_default()
-                            .parse()
+                            .pull_opt_i64("consumer.max_expires")?
                             .unwrap_or(300000),
                     }),
                     (None, Some(subject)) => Some(SourceType::Core { subject }),

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 use typify::import_types;
 
 use crate::nexmark::operator::NexmarkSourceFunc;
-use crate::{pull_opt, EmptyConfig};
+use crate::{EmptyConfig};
 
 const TABLE_SCHEMA: &str = include_str!("./table.json");
 const ICON: &str = include_str!("./nexmark.svg");
@@ -158,16 +158,11 @@ impl Connector for NexmarkConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
-            .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;
+        let event_rate = options.pull_f64("event_rate")?;
 
-        let runtime = options
-            .remove("runtime")
-            .map(|t| f64::from_str(&t))
-            .transpose()
-            .map_err(|_| anyhow!("invalid value for runtime; expected float"))?;
+        let runtime = options.pull_opt_f64("runtime")?;
 
         if let Some(schema) = schema {
             if !schema.fields.is_empty() && schema.fields != nexmark_schema().fields {

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -2,7 +2,7 @@ mod operator;
 #[cfg(test)]
 mod test;
 
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 use arrow::datatypes::{Field, Schema, TimeUnit};
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
@@ -11,12 +11,10 @@ use arroyo_rpc::api_types::connections::{
 };
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::str::FromStr;
 use typify::import_types;
 
 use crate::nexmark::operator::NexmarkSourceFunc;
-use crate::{EmptyConfig};
+use crate::EmptyConfig;
 
 const TABLE_SCHEMA: &str = include_str!("./table.json");
 const ICON: &str = include_str!("./nexmark.svg");

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -9,7 +9,7 @@ use arroyo_operator::operator::ConstructedOperator;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -156,9 +156,9 @@ impl Connector for NexmarkConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let event_rate = f64::from_str(&pull_opt("event_rate", options)?)
             .map_err(|_| anyhow!("invalid value for event_rate; expected float"))?;

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -150,11 +150,12 @@ impl Connector for PollingHTTPConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = options.pull_str("endpoint")?;
         let headers = options.pull_opt_str("headers")?;
-        let method: Option<Method> = options.pull_opt_str("method")?
+        let method: Option<Method> = options
+            .pull_opt_str("method")?
             .map(|s| s.try_into())
             .transpose()
             .map_err(|_| anyhow!("invalid value for 'method'"))?;
@@ -162,7 +163,8 @@ impl Connector for PollingHTTPConnector {
         let body = options.pull_opt_str("body")?;
 
         let interval = options.pull_opt_i64("poll_interval_ms")?;
-        let emit_behavior: Option<EmitBehavior> = options.pull_opt_str("emit_behavior")?
+        let emit_behavior: Option<EmitBehavior> = options
+            .pull_opt_str("emit_behavior")?
             .map(|s| s.try_into())
             .transpose()
             .map_err(|_| anyhow!("invalid value for 'emit_behavior'"))?;

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::anyhow;
-use arroyo_rpc::{var_str::VarStr, OperatorConfig};
+use arroyo_rpc::{var_str::VarStr, ConnectorOptions, OperatorConfig};
 use arroyo_types::string_to_map;
 use reqwest::{Client, Request};
 use tokio::sync::mpsc::Sender;
@@ -149,9 +149,9 @@ impl Connector for PollingHTTPConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -1,6 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -17,7 +16,7 @@ use arroyo_rpc::api_types::connections::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{construct_http_client, pull_opt, pull_option_to_i64, EmptyConfig};
+use crate::{construct_http_client, EmptyConfig};
 
 use crate::polling_http::operator::{PollingHttpSourceFunc, PollingHttpSourceState};
 use arroyo_operator::connector::Connector;
@@ -153,19 +152,17 @@ impl Connector for PollingHTTPConnector {
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let endpoint = pull_opt("endpoint", options)?;
-        let headers = options.remove("headers");
-        let method: Option<Method> = options
-            .remove("method")
+        let endpoint = options.pull_str("endpoint")?;
+        let headers = options.pull_opt_str("headers")?;
+        let method: Option<Method> = options.pull_opt_str("method")?
             .map(|s| s.try_into())
             .transpose()
             .map_err(|_| anyhow!("invalid value for 'method'"))?;
 
-        let body = options.remove("body");
+        let body = options.pull_opt_str("body")?;
 
-        let interval = pull_option_to_i64("poll_interval_ms", options)?;
-        let emit_behavior: Option<EmitBehavior> = options
-            .remove("emit_behavior")
+        let interval = options.pull_opt_i64("poll_interval_ms")?;
+        let emit_behavior: Option<EmitBehavior> = options.pull_opt_str("emit_behavior")?
             .map(|s| s.try_into())
             .transpose()
             .map_err(|_| anyhow!("invalid value for 'emit_behavior'"))?;

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -1,7 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
-
 use anyhow::{anyhow, bail};
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
@@ -67,10 +65,10 @@ impl Connector for PreviewConnector {
 
     fn from_options(
         &self,
-        name: &str,
-        options: &mut ConnectorOptions,
-        schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: &str,
+        _: &mut ConnectorOptions,
+        _: Option<&ConnectionSchema>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         bail!("Preview connector cannot be created in SQL");
     }

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -3,7 +3,7 @@ mod operator;
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail};
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::api_types::connections::{
@@ -67,10 +67,10 @@ impl Connector for PreviewConnector {
 
     fn from_options(
         &self,
-        _: &str,
-        _: &mut HashMap<String, String>,
-        _: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        name: &str,
+        options: &mut ConnectorOptions,
+        schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         bail!("Preview connector cannot be created in SQL");
     }

--- a/crates/arroyo-connectors/src/rabbitmq/mod.rs
+++ b/crates/arroyo-connectors/src/rabbitmq/mod.rs
@@ -1,12 +1,12 @@
 use anyhow::{anyhow, bail};
 use arroyo_operator::connector::{Connection, Connector};
 use arroyo_operator::operator::ConstructedOperator;
-use arroyo_rpc::{api_types::connections::TestSourceMessage, OperatorConfig};
+use arroyo_rpc::{api_types::connections::TestSourceMessage, ConnectorOptions, OperatorConfig};
 use rabbitmq_stream_client::types::OffsetSpecification;
 use rabbitmq_stream_client::{Environment, TlsConfiguration};
 use serde::{Deserialize, Serialize};
 use typify::import_types;
-
+use arroyo_rpc::api_types::connections::{ConnectionProfile, ConnectionSchema};
 use crate::rabbitmq::source::RabbitmqStreamSourceFunc;
 use crate::{pull_opt, ConnectionType};
 
@@ -92,10 +92,10 @@ impl Connector for RabbitmqConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut std::collections::HashMap<String, String>,
-        schema: Option<&arroyo_rpc::api_types::connections::ConnectionSchema>,
-        profile: Option<&arroyo_rpc::api_types::connections::ConnectionProfile>,
-    ) -> anyhow::Result<arroyo_operator::connector::Connection> {
+        options: &mut ConnectorOptions,
+        schema: Option<&ConnectionSchema>,
+        profile: Option<&ConnectionProfile>,
+    ) -> anyhow::Result<Connection> {
         let connection_config = match profile {
             Some(connection_profile) => {
                 serde_json::from_value(connection_profile.config.clone())

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -16,7 +16,7 @@ use arroyo_rpc::api_types::connections::{
 };
 use arroyo_rpc::schema_resolver::FailingSchemaResolver;
 use arroyo_rpc::var_str::VarStr;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use redis::aio::ConnectionManager;
 use redis::cluster::ClusterClient;
 use redis::{Client, ConnectionInfo, IntoConnectionInfo};
@@ -235,8 +235,8 @@ impl Connector for RedisConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
-        s: Option<&ConnectionSchema>,
+        options: &mut ConnectorOptions,
+        schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let connection_config = match profile {
@@ -279,7 +279,7 @@ impl Connector for RedisConnector {
 
         let typ = pull_opt("type", options)?;
 
-        let schema = s
+        let schema = schema
             .as_ref()
             .ok_or_else(|| anyhow!("No schema defined for Redis connection"))?;
 
@@ -379,7 +379,7 @@ impl Connector for RedisConnector {
             RedisTable {
                 connector_type: sink,
             },
-            s,
+            schema,
         )
     }
 

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -20,7 +20,6 @@ use redis::aio::ConnectionManager;
 use redis::cluster::ClusterClient;
 use redis::{Client, ConnectionInfo, IntoConnectionInfo};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::oneshot::Receiver;
 use typify::import_types;
@@ -278,8 +277,7 @@ impl Connector for RedisConnector {
 
         let typ = options.pull_str("type")?;
 
-        let schema = s
-            .ok_or_else(|| anyhow!("No schema defined for Redis connection"))?;
+        let schema = s.ok_or_else(|| anyhow!("No schema defined for Redis connection"))?;
 
         fn validate_column(
             schema: &ConnectionSchema,
@@ -323,7 +321,8 @@ impl Connector for RedisConnector {
                             .pull_opt_str("target.key_column")?
                             .map(|name| validate_column(schema, name, "target.key_column"))
                             .transpose()?,
-                        ttl_secs: options.pull_opt_u64("target.ttl_secs")?
+                        ttl_secs: options
+                            .pull_opt_u64("target.ttl_secs")?
                             .map(|t| t.try_into())
                             .transpose()
                             .map_err(|_| anyhow!("target.ttl_secs must be greater than 0"))?,
@@ -334,7 +333,8 @@ impl Connector for RedisConnector {
                             .pull_opt_str("target.key_column")?
                             .map(|name| validate_column(schema, name, "target.key_column"))
                             .transpose()?,
-                        max_length: options.pull_opt_u64("target.max_length")?
+                        max_length: options
+                            .pull_opt_u64("target.max_length")?
                             .map(|t| t.try_into())
                             .transpose()
                             .map_err(|_| anyhow!("target.max_length must be greater than 0"))?,

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, bail, Result};
 use arroyo_formats::ser::ArrowSerializer;
-use std::collections::HashMap;
 use typify::import_types;
 
 use arroyo_operator::connector::Connection;
@@ -10,7 +9,7 @@ use arroyo_rpc::api_types::connections::{
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
-use crate::{EmptyConfig};
+use crate::EmptyConfig;
 
 use crate::single_file::sink::SingleFileSink;
 use crate::single_file::source::SingleFileSourceFunc;
@@ -122,15 +121,14 @@ impl Connector for SingleFileConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let path = options.pull_str("path")?;
         let Ok(table_type) = options.pull_str("type")?.try_into() else {
             bail!("'type' must be 'source' or 'sink'");
         };
 
-        let wait_for_control = options
-            .pull_opt_bool("wait_for_control")?;
+        let wait_for_control = options.pull_opt_bool("wait_for_control")?;
 
         self.from_config(
             None,

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -7,7 +7,7 @@ use arroyo_operator::connector::Connection;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
 use crate::{pull_opt, EmptyConfig};
@@ -120,9 +120,9 @@ impl Connector for SingleFileConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let path = pull_opt("path", options)?;
         let Ok(table_type) = pull_opt("type", options)?.try_into() else {

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -10,7 +10,7 @@ use arroyo_rpc::api_types::connections::{
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use serde::{Deserialize, Serialize};
 
-use crate::{pull_opt, EmptyConfig};
+use crate::{EmptyConfig};
 
 use crate::single_file::sink::SingleFileSink;
 use crate::single_file::source::SingleFileSourceFunc;
@@ -124,18 +124,13 @@ impl Connector for SingleFileConnector {
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let path = pull_opt("path", options)?;
-        let Ok(table_type) = pull_opt("type", options)?.try_into() else {
+        let path = options.pull_str("path")?;
+        let Ok(table_type) = options.pull_str("type")?.try_into() else {
             bail!("'type' must be 'source' or 'sink'");
         };
 
         let wait_for_control = options
-            .remove("wait_for_control")
-            .map(|s| {
-                s.parse()
-                    .map_err(|_| anyhow!("'wait_for_control' must be a boolean"))
-            })
-            .transpose()?;
+            .pull_opt_bool("wait_for_control")?;
 
         self.from_config(
             None,

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -19,7 +19,7 @@ use arroyo_rpc::api_types::connections::{
 use serde::{Deserialize, Serialize};
 
 use crate::sse::operator::SSESourceFunc;
-use crate::{pull_opt, EmptyConfig};
+use crate::{EmptyConfig};
 
 use arroyo_operator::connector::Connector;
 
@@ -126,11 +126,11 @@ impl Connector for SSEConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let endpoint = pull_opt("endpoint", options)?;
-        let headers = options.remove("headers");
-        let events = options.remove("events");
+        let endpoint = options.pull_str("endpoint")?;
+        let headers = options.pull_opt_str("headers")?;
+        let events = options.pull_opt_str("events")?;
 
         self.from_config(
             None,

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -1,6 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
@@ -19,7 +18,7 @@ use arroyo_rpc::api_types::connections::{
 use serde::{Deserialize, Serialize};
 
 use crate::sse::operator::SSESourceFunc;
-use crate::{EmptyConfig};
+use crate::EmptyConfig;
 
 use arroyo_operator::connector::Connector;
 

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
-use arroyo_rpc::{var_str::VarStr, OperatorConfig};
+use arroyo_rpc::{var_str::VarStr, ConnectorOptions, OperatorConfig};
 use arroyo_types::string_to_map;
 use eventsource_client::Client;
 use futures::StreamExt;
@@ -124,9 +124,9 @@ impl Connector for SSEConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -3,7 +3,7 @@ mod operator;
 use std::collections::HashMap;
 
 use anyhow::anyhow;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use tokio::io::BufWriter;
 
 use arroyo_formats::ser::ArrowSerializer;
@@ -73,9 +73,9 @@ impl Connector for StdoutConnector {
     fn from_options(
         &self,
         name: &str,
-        _options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema)
     }

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -1,7 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
-
 use anyhow::anyhow;
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use tokio::io::BufWriter;

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -73,9 +73,9 @@ impl Connector for StdoutConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut ConnectorOptions,
+        _options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         self.from_config(None, name, EmptyConfig {}, EmptyConfig {}, schema)
     }

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::anyhow;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
 use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::connector::Connection;
@@ -179,9 +179,9 @@ impl Connector for WebhookConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
 

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -1,6 +1,5 @@
 mod operator;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -20,7 +19,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, Semaphore};
 use typify::import_types;
 
-use crate::{construct_http_client, pull_opt, EmptyConfig};
+use crate::{construct_http_client, EmptyConfig};
 
 use crate::webhook::operator::WebhookSinkFunc;
 use arroyo_operator::connector::Connector;
@@ -181,11 +180,11 @@ impl Connector for WebhookConnector {
         name: &str,
         options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        profile: Option<&ConnectionProfile>,
+        _profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
-        let endpoint = pull_opt("endpoint", options)?;
+        let endpoint = options.pull_str("endpoint")?;
 
-        let headers = options.remove("headers").map(VarStr::new);
+        let headers = options.pull_opt_str("headers")?.map(VarStr::new);
 
         let table = WebhookTable {
             endpoint: VarStr::new(endpoint),

--- a/crates/arroyo-connectors/src/websocket/mod.rs
+++ b/crates/arroyo-connectors/src/websocket/mod.rs
@@ -8,7 +8,7 @@ use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
 use arroyo_rpc::var_str::VarStr;
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use arroyo_types::string_to_map;
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -266,9 +266,9 @@ impl Connector for WebsocketConnector {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
-        _profile: Option<&ConnectionProfile>,
+        profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {
         let endpoint = pull_opt("endpoint", options)?;
         let headers = options.remove("headers");

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -5,7 +5,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, TestSourceMessage,
 };
-use arroyo_rpc::OperatorConfig;
+use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use arroyo_types::{DisplayAsSql, SourceError};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -100,7 +100,7 @@ pub trait Connector: Send {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection>;
@@ -186,7 +186,7 @@ pub trait ErasedConnector: Send {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection>;
@@ -290,7 +290,7 @@ impl<C: Connector> ErasedConnector for C {
     fn from_options(
         &self,
         name: &str,
-        options: &mut HashMap<String, String>,
+        options: &mut ConnectorOptions,
         schema: Option<&ConnectionSchema>,
         profile: Option<&ConnectionProfile>,
     ) -> anyhow::Result<Connection> {

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -65,7 +65,7 @@ use arroyo_datastream::logical::LogicalProgram;
 use arroyo_datastream::optimizers::ChainingOptimizer;
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::df::ArroyoSchema;
-use arroyo_rpc::TIMESTAMP_FIELD;
+use arroyo_rpc::{duration_from_sql, TIMESTAMP_FIELD};
 use arroyo_udf_host::parse::{inner_type, UdfDef};
 use arroyo_udf_host::ParsedUdfFile;
 use arroyo_udf_python::PythonUDF;
@@ -705,24 +705,8 @@ fn try_handle_set_variable(
             return plan_err!("invalid `SET updating_ttl` call; expected exactly one expression");
         }
 
-        let sqlparser::ast::Expr::Value(sqlparser::ast::Value::SingleQuotedString(s)) =
-            value.first().unwrap()
-        else {
-            return plan_err!(
-                "invalid `SET updating_ttl`; expected a singly-quoted string argument"
-            );
-        };
+        schema_provider.planning_options.ttl = duration_from_sql(value[0].clone())?;
 
-        let interval = parse_interval_day_time(s).map_err(|_| {
-            DataFusionError::Plan(format!(
-                "could not parse '{}' as an interval in `SET updating_ttl` statement",
-                s
-            ))
-        })?;
-
-        schema_provider.planning_options.ttl =
-            Duration::from_secs(interval.days as u64 * 24 * 60 * 60)
-                + Duration::from_millis(interval.milliseconds as u64);
         return Ok(true);
     }
 

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -31,7 +31,7 @@ use datafusion::prelude::SessionConfig;
 
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::parser::{Parser, ParserError};
-use datafusion::sql::{planner::ContextProvider, sqlparser, TableReference};
+use datafusion::sql::{planner::ContextProvider, TableReference};
 
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{
@@ -60,7 +60,6 @@ use crate::functions::{is_json_union, serialize_outgoing_json};
 use crate::rewriters::{SourceMetadataVisitor, TimeWindowUdfChecker, UnnestRewriter};
 
 use crate::udafs::EmptyUdaf;
-use arrow::compute::kernels::cast_utils::parse_interval_day_time;
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_datastream::optimizers::ChainingOptimizer;
 use arroyo_operator::connector::Connection;

--- a/crates/arroyo-planner/src/test/queries/basic_tumble_aggregate.sql
+++ b/crates/arroyo-planner/src/test/queries/basic_tumble_aggregate.sql
@@ -1,6 +1,6 @@
 CREATE TABLE nexmark WITH (
     connector = 'nexmark',
-    event_rate = '10'
+    event_rate = 10
 );
 
 SELECT

--- a/crates/arroyo-planner/src/test/queries/create_table_updating.sql
+++ b/crates/arroyo-planner/src/test/queries/create_table_updating.sql
@@ -12,7 +12,7 @@ CREATE TABLE nexmark (
     type = 'source',
     path = '/home/data',
     'source.regex-pattern' = '00001-000.parquet',
-    event_time_field = 'datetime'
+    event_time_field = datetime
 );
 
 CREATE TABLE counts as (SELECT count(*) FROM nexmark);

--- a/crates/arroyo-planner/src/test/queries/custom_ttls.sql
+++ b/crates/arroyo-planner/src/test/queries/custom_ttls.sql
@@ -14,6 +14,6 @@ CREATE VIEW tags AS (
     WHERE tag is not null
 );
 
-set updating_ttl = '5 seconds';
+set updating_ttl = interval '5' second;
 
 select count(distinct tag) from tags;

--- a/crates/arroyo-planner/src/test/queries/lookup_join.sql
+++ b/crates/arroyo-planner/src/test/queries/lookup_join.sql
@@ -20,8 +20,8 @@ create temporary table customers (
     format = 'raw_string',
     address = 'redis://localhost:6379',
     format = 'json',
-    'lookup.cache.max_bytes' = '1000000',
-    'lookup.cache.ttl' = '5 second'
+    'lookup.cache.max_bytes' = 1000000,
+    'lookup.cache.ttl' = interval '5' second
 );
 
 SELECT  e.event_id,  e.timestamp,  e.customer_id,  e.event_type, c.customer_name, c.plan

--- a/crates/arroyo-planner/src/test/queries/no_updating_joins.sql
+++ b/crates/arroyo-planner/src/test/queries/no_updating_joins.sql
@@ -13,7 +13,7 @@ CREATE TABLE nexmark (
     type = 'source',
     path = '/home/data',
     'source.regex-pattern' = '00001-000.parquet',
-    event_time_field = 'datetime'
+    event_time_field = datetime
 );
 
 CREATE TABLE counts as (SELECT count(*) as counts, bidder FROM nexmark GROUP BY 2);

--- a/crates/arroyo-rpc/Cargo.toml
+++ b/crates/arroyo-rpc/Cargo.toml
@@ -36,7 +36,7 @@ k8s-openapi = { workspace = true, features = ["v1_30"] }
 url = { version = "2", features = ["serde"] }
 dirs = "5.0.1"
 arc-swap = "1.7.1"
-datafusion-common = { workspace = true }
+datafusion = { workspace = true }
 rand = "0.8.5"
 percent-encoding = "2.3.1"
 

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -10,7 +10,7 @@ worker-heartbeat-timeout = "30s"
 healthy-duration = "2m"
 worker-startup-time = "10m"
 task-startup-time = "2m"
-chaining.enabled = false
+chaining.enabled = true
 
 [pipeline.compaction]
 enabled = false

--- a/crates/arroyo-rpc/src/df.rs
+++ b/crates/arroyo-rpc/src/df.rs
@@ -12,10 +12,10 @@ use arrow_ord::cmp::gt_eq;
 use arrow_ord::partition::partition;
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arroyo_types::to_nanos;
+use datafusion::common::{DataFusionError, Result as DFResult};
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::SystemTime;
-use datafusion::common::{DataFusionError, Result as DFResult};
 
 pub type ArroyoSchemaRef = Arc<ArroyoSchema>;
 
@@ -168,10 +168,7 @@ impl ArroyoSchema {
         })
     }
 
-    pub fn from_schema_keys(
-        schema: Arc<Schema>,
-        key_indices: Vec<usize>,
-    ) -> DFResult<Self> {
+    pub fn from_schema_keys(schema: Arc<Schema>, key_indices: Vec<usize>) -> DFResult<Self> {
         let timestamp_index = schema
             .column_with_name(TIMESTAMP_FIELD)
             .ok_or_else(|| {

--- a/crates/arroyo-rpc/src/df.rs
+++ b/crates/arroyo-rpc/src/df.rs
@@ -12,10 +12,10 @@ use arrow_ord::cmp::gt_eq;
 use arrow_ord::partition::partition;
 use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arroyo_types::to_nanos;
-use datafusion_common::DataFusionError;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::SystemTime;
+use datafusion::common::{DataFusionError, Result as DFResult};
 
 pub type ArroyoSchemaRef = Arc<ArroyoSchema>;
 
@@ -150,7 +150,7 @@ impl ArroyoSchema {
         Self::from_schema_keys(Arc::new(Schema::new(fields)), vec![]).unwrap()
     }
 
-    pub fn from_schema_unkeyed(schema: Arc<Schema>) -> datafusion_common::Result<Self> {
+    pub fn from_schema_unkeyed(schema: Arc<Schema>) -> DFResult<Self> {
         let timestamp_index = schema
             .column_with_name(TIMESTAMP_FIELD)
             .ok_or_else(|| {
@@ -171,7 +171,7 @@ impl ArroyoSchema {
     pub fn from_schema_keys(
         schema: Arc<Schema>,
         key_indices: Vec<usize>,
-    ) -> datafusion_common::Result<Self> {
+    ) -> DFResult<Self> {
         let timestamp_index = schema
             .column_with_name(TIMESTAMP_FIELD)
             .ok_or_else(|| {

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -6,6 +6,8 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::OnceLock;
 use utoipa::ToSchema;
+use crate::ConnectorOptions;
+use datafusion::common::{plan_datafusion_err, plan_err, Result as DFResult};
 
 #[derive(
     Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, Hash, PartialOrd, ToSchema,
@@ -55,31 +57,28 @@ pub struct JsonFormat {
 }
 
 impl JsonFormat {
-    fn from_opts(debezium: bool, opts: &mut HashMap<String, String>) -> Result<Self, String> {
+    fn from_opts(debezium: bool, opts: &mut ConnectorOptions) -> DFResult<Self> {
         let confluent_schema_registry = opts
-            .remove("json.confluent_schema_registry")
-            .filter(|t: &String| t == "true")
-            .is_some();
+            .pull_opt_bool("json.confluent_schema_registry")?
+            .unwrap_or(false);
 
         let include_schema = opts
-            .remove("json.include_schema")
-            .filter(|t| t == "true")
-            .is_some();
+            .pull_opt_bool("json.include_schema")?
+            .unwrap_or(false);
 
         if include_schema && confluent_schema_registry {
-            return Err("can't include schema in message if using schema registry".to_string());
+            return plan_err!("at most one of `json.confluent_schema_registry` and `json.include_schema` may be set");
         }
 
         let unstructured = opts
-            .remove("json.unstructured")
-            .filter(|t| t == "true")
-            .is_some();
+            .pull_opt_bool("json.unstructured")?
+            .unwrap_or(false);
 
         let timestamp_format: TimestampFormat = opts
-            .remove("json.timestamp_format")
+            .pull_opt_str("json.timestamp_format")?
             .map(|t| t.as_str().try_into())
             .transpose()
-            .map_err(|_| "json.timestamp_format".to_string())?
+            .map_err(|_| plan_datafusion_err!("invalid value for `json.timestamp_format`"))?
             .unwrap_or_else(|| {
                 if debezium {
                     TimestampFormat::UnixMillis
@@ -200,17 +199,11 @@ impl AvroFormat {
         }
     }
 
-    pub fn from_opts(opts: &mut HashMap<String, String>) -> Result<Self, String> {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Self> {
         Ok(Self::new(
-            opts.remove("avro.confluent_schema_registry")
-                .filter(|t| t == "true")
-                .is_some(),
-            opts.remove("avro.raw_datums")
-                .filter(|t| t == "true")
-                .is_some(),
-            opts.remove("avro.into_unstructured_json")
-                .filter(|t| t == "true")
-                .is_some(),
+            opts.pull_opt_bool("avro.confluent_schema_registry")?.unwrap_or(false),
+            opts.pull_opt_bool("avro.raw_datums")?.unwrap_or(false),
+            opts.pull_opt_bool("avro.into_unstructured_json")?.unwrap_or(false),
         ))
     }
 
@@ -247,8 +240,8 @@ pub struct ProtobufFormat {
 }
 
 impl ProtobufFormat {
-    pub fn from_opts(_opts: &mut HashMap<String, String>) -> Result<Self, String> {
-        Err("Protobuf is not yet supported in CREATE TABLE statements".to_string())
+    pub fn from_opts(_opts: &mut ConnectorOptions) -> DFResult<Self> {
+        plan_err!("Protobuf is not yet supported in CREATE TABLE statements")
     }
 }
 
@@ -264,8 +257,8 @@ pub enum Format {
 }
 
 impl Format {
-    pub fn from_opts(opts: &mut HashMap<String, String>) -> Result<Option<Self>, String> {
-        let Some(name) = opts.remove("format") else {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Option<Self>> {
+        let Some(name) = opts.pull_opt_str("format")? else {
             return Ok(None);
         };
 
@@ -277,7 +270,7 @@ impl Format {
             "raw_string" => Format::RawString(RawStringFormat {}),
             "raw_bytes" => Format::RawBytes(RawBytesFormat {}),
             "parquet" => Format::Parquet(ParquetFormat {}),
-            f => return Err(format!("Unknown format '{}'", f)),
+            f => return plan_err!("unknown format '{}'", f),
         }))
     }
 
@@ -308,15 +301,15 @@ impl Default for BadData {
 }
 
 impl BadData {
-    pub fn from_opts(opts: &mut HashMap<String, String>) -> Result<Option<Self>, String> {
-        let Some(method) = opts.remove("bad_data") else {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Option<Self>> {
+        let Some(method) = opts.pull_opt_str("bad_data")? else {
             return Ok(None);
         };
 
         let method = match method.as_str() {
             "drop" => BadData::Drop {},
             "fail" => BadData::Fail {},
-            f => return Err(format!("Unknown invalid data behavior '{}'", f)),
+            f => return plan_err!("invalid value for 'bad_data': `{}`; expected one of 'drop' or 'fail'", f),
         };
 
         Ok(Some(method))
@@ -330,14 +323,14 @@ pub struct Framing {
 }
 
 impl Framing {
-    pub fn from_opts(opts: &mut HashMap<String, String>) -> Result<Option<Self>, String> {
-        let Some(method) = opts.remove("framing") else {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Option<Self>> {
+        let Some(method) = opts.pull_opt_str("framing")? else {
             return Ok(None);
         };
 
         let method = match method.as_str() {
             "newline" => FramingMethod::Newline(NewlineDelimitedFraming::from_opts(opts)?),
-            f => return Err(format!("Unknown framing method '{}'", f)),
+            f => return plan_err!("Unknown framing method '{}'", f),
         };
 
         Ok(Some(Framing { method }))
@@ -351,15 +344,9 @@ pub struct NewlineDelimitedFraming {
 }
 
 impl NewlineDelimitedFraming {
-    pub fn from_opts(opts: &mut HashMap<String, String>) -> Result<Self, String> {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Self> {
         let max_line_length = opts
-            .remove("framing.newline.max_length")
-            .map(|t| u64::from_str(&t))
-            .transpose()
-            .map_err(|_| {
-                "invalid value for framing.newline.max_length; must be an unsigned integer"
-                    .to_string()
-            })?;
+            .pull_opt_u64("framing.newline.max_length")?;
 
         Ok(NewlineDelimitedFraming { max_line_length })
     }

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -1,13 +1,11 @@
+use crate::ConnectorOptions;
+use datafusion::common::{plan_datafusion_err, plan_err, Result as DFResult};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::str::FromStr;
 use std::sync::OnceLock;
 use utoipa::ToSchema;
-use crate::ConnectorOptions;
-use datafusion::common::{plan_datafusion_err, plan_err, Result as DFResult};
 
 #[derive(
     Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, Hash, PartialOrd, ToSchema,
@@ -62,17 +60,13 @@ impl JsonFormat {
             .pull_opt_bool("json.confluent_schema_registry")?
             .unwrap_or(false);
 
-        let include_schema = opts
-            .pull_opt_bool("json.include_schema")?
-            .unwrap_or(false);
+        let include_schema = opts.pull_opt_bool("json.include_schema")?.unwrap_or(false);
 
         if include_schema && confluent_schema_registry {
             return plan_err!("at most one of `json.confluent_schema_registry` and `json.include_schema` may be set");
         }
 
-        let unstructured = opts
-            .pull_opt_bool("json.unstructured")?
-            .unwrap_or(false);
+        let unstructured = opts.pull_opt_bool("json.unstructured")?.unwrap_or(false);
 
         let timestamp_format: TimestampFormat = opts
             .pull_opt_str("json.timestamp_format")?
@@ -201,9 +195,11 @@ impl AvroFormat {
 
     pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Self> {
         Ok(Self::new(
-            opts.pull_opt_bool("avro.confluent_schema_registry")?.unwrap_or(false),
+            opts.pull_opt_bool("avro.confluent_schema_registry")?
+                .unwrap_or(false),
             opts.pull_opt_bool("avro.raw_datums")?.unwrap_or(false),
-            opts.pull_opt_bool("avro.into_unstructured_json")?.unwrap_or(false),
+            opts.pull_opt_bool("avro.into_unstructured_json")?
+                .unwrap_or(false),
         ))
     }
 
@@ -309,7 +305,12 @@ impl BadData {
         let method = match method.as_str() {
             "drop" => BadData::Drop {},
             "fail" => BadData::Fail {},
-            f => return plan_err!("invalid value for 'bad_data': `{}`; expected one of 'drop' or 'fail'", f),
+            f => {
+                return plan_err!(
+                    "invalid value for 'bad_data': `{}`; expected one of 'drop' or 'fail'",
+                    f
+                )
+            }
         };
 
         Ok(Some(method))
@@ -345,8 +346,7 @@ pub struct NewlineDelimitedFraming {
 
 impl NewlineDelimitedFraming {
     pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Self> {
-        let max_line_length = opts
-            .pull_opt_u64("framing.newline.max_length")?;
+        let max_line_length = opts.pull_opt_u64("framing.newline.max_length")?;
 
         Ok(NewlineDelimitedFraming { max_line_length })
     }

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -15,6 +15,8 @@ use anyhow::Result;
 use arrow::row::{OwnedRow, RowConverter, Rows, SortField};
 use arrow_array::{Array, ArrayRef, BooleanArray};
 use arrow_schema::{DataType, Field, Fields};
+use datafusion::common::{plan_datafusion_err, plan_err, Result as DFResult};
+use datafusion::sql::sqlparser::ast::{Expr, SqlOption, Value as SqlValue};
 use arroyo_types::{CheckpointBarrier, HASH_SEEDS};
 use grpc::rpc::{StopMode, TableCheckpointMetadata, TaskCheckpointEventType};
 use serde::{Deserialize, Serialize};
@@ -339,6 +341,101 @@ impl Converter {
 pub fn get_hasher() -> ahash::RandomState {
     ahash::RandomState::with_seeds(HASH_SEEDS[0], HASH_SEEDS[1], HASH_SEEDS[2], HASH_SEEDS[3])
 }
+
+pub struct ConnectorOptions {
+    options: HashMap<String, Expr>
+}
+
+impl TryFrom<&Vec<SqlOption>> for ConnectorOptions {
+    type Error = datafusion::error::DataFusionError;
+
+    fn try_from(value: &Vec<SqlOption>) -> Result<Self, Self::Error> {
+        let mut options = HashMap::new();
+
+        for option in value {
+            let SqlOption::KeyValue { key, value } = &option else {
+                return plan_err!("invalid with option: '{}'; expected an `=` delimited key-value pair", option);
+            };
+
+            options.insert(key.value.to_string(), value.clone());
+        }
+
+        Ok(Self {
+            options,
+        })
+    }
+}
+
+impl ConnectorOptions {
+    pub fn pull_opt_str(&mut self, name: &str) -> DFResult<Option<String>> {
+        match self.options.remove(name) {
+            Some(Expr::Value(SqlValue::SingleQuotedString(s))) => {
+                Ok(Some(s))
+            }
+            Some(e) => {
+                plan_err!("expected with option '{}' to be a single-quoted string, but it was `{:?}`", name, e)
+            }
+            None => {
+                Ok(None)
+            }
+        }
+    }
+
+    pub fn pull_str(&mut self, name: &str) -> DFResult<String> {
+        self.pull_opt_str(name)?
+            .ok_or_else(|| plan_datafusion_err!("required option '{}' not set", name))
+    }
+    
+    pub fn pull_opt_bool(&mut self, name: &str) -> DFResult<Option<bool>> {
+        match self.options.remove(name) {
+            Some(Expr::Value(SqlValue::Boolean(b))) => {
+                Ok(Some(b))
+            }
+            Some(Expr::Value(SqlValue::SingleQuotedString(s))) => {
+                match s.as_str() {
+                    "true" | "yes" => Ok(Some(true)),
+                    "false" | "no" => Ok(Some(false)),
+                    _ => plan_err!("expected with option '{}' to be a boolean, but it was `'{}'`", name, s),
+                }
+            }
+            Some(e) => {
+                plan_err!("expected with option '{}' to be a boolean, but it was `{:?}`", name, e)
+            }
+            None => {
+                Ok(None)
+            }
+        }
+    }
+    
+    pub fn pull_opt_u64(&mut self, name: &str) -> DFResult<Option<u64>> {
+        match self.options.remove(name) {
+            Some(Expr::Value(SqlValue::Number(s, _))) | Some(Expr::Value(SqlValue::SingleQuotedString(s))) => {
+                s.parse::<u64>()
+                    .map(|i| Some(i))
+                    .map_err(|_| plan_datafusion_err!("expected with option '{}' to be an unsigned integer, but it was `{}`", name, s))
+            }
+            Some(e) => {
+                plan_err!("expected with option '{}' to be an unsigned integer, but it was `{:?}`", name, e)
+            }
+            None => {
+                Ok(None)
+            }
+        }
+    }
+    
+    pub fn insert_str(&mut self, name: impl Into<String>, value: impl Into<String>) -> DFResult<Option<String>> {
+        let name = name.into();
+        let value = value.into();
+        let existing = self.pull_opt_str(&name)?;
+        self.options.insert(name, Expr::Value(SqlValue::SingleQuotedString(value)));
+        Ok(existing)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.options.is_empty()
+    }
+}
+
 
 #[macro_export]
 macro_rules! retry {

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -7,7 +7,7 @@ pub mod var_str;
 use crate::api_types::connections::PrimitiveType;
 use crate::formats::{BadData, Format, Framing};
 use crate::grpc::rpc::{LoadCompactedDataReq, SubtaskCheckpointMetadata};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use arrow::compute::kernels::cast_utils::parse_interval_day_time;
 use arrow::row::{OwnedRow, RowConverter, Rows, SortField};
 use arrow_array::{Array, ArrayRef, BooleanArray};
@@ -15,13 +15,10 @@ use arrow_schema::{DataType, Field, Fields};
 use arroyo_types::{CheckpointBarrier, HASH_SEEDS};
 use datafusion::catalog_common::TableReference;
 use datafusion::common::{
-    not_impl_err, plan_datafusion_err, plan_err, DFSchema, DFSchemaRef, Result as DFResult,
-    ScalarValue,
+    not_impl_err, plan_datafusion_err, plan_err, DFSchema, Result as DFResult, ScalarValue,
 };
 use datafusion::config::ConfigOptions;
-use datafusion::logical_expr::planner::PlannerResult;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
-use datafusion::prelude::SessionContext;
 use datafusion::sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion::sql::sqlparser::ast::{Expr, SqlOption, Value as SqlValue};
 use grpc::rpc::{StopMode, TableCheckpointMetadata, TaskCheckpointEventType};
@@ -29,7 +26,6 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use std::{fs, time::SystemTime};


### PR DESCRIPTION
Connectors tables in Arroyo are configured via key/value pairs in the WITH clause of the DDL statement. Previously, the values of all of these options needed to be strings, which would be parsed in various ways to typed values, like numbers or bools, by connectors.

This PR moves away from that approach to one that stores the actual sqlparser Exprs and then converts them into strings/numbers/bools/etc. as needed. This has a number of benefits in simplifying how connectors interact with the options, but also allows more expressivity and makes things feel more SQL-native since we're no longer inventing our own stringified language for the values. For example:

```sql
CREATE TABLE example (
   ...
) WITH (
  rollover_seconds = 60
  time_partition_pattern = '%Y/%m/%d/%H',
  'json.include_schema' = true,
  'event_time_field' = datetime,
  'flush_interval' = interval '5' seconds
);
```

In a follow-up PR, this will also allow us to support expressions within within the with clause, letting us move away from the pattern of defining a generated field in order to use it for configuration.