### PR TITLE
Add shuffle_by_partition option to filesystem sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ debug = 1
 [profile.dev]
 split-debuginfo = "unpacked"
 
-
 [patch.crates-io]
 deltalake = { git = 'https://github.com/delta-io/delta-rs', rev = '25ce38956e25722ba7a6cbc0f5a7dba6b3361554' }
 typify = { git = 'https://github.com/ArroyoSystems/typify.git', branch = 'arroyo' }

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -101,17 +101,15 @@ impl Connector for BlackholeConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Sink,
-            schema: s
-                .cloned()
-                .ok_or_else(|| anyhow!("no schema for blackhole sink"))?,
-            config: serde_json::to_string(&config).unwrap(),
+            self.name(),
+            name.to_string(),
+            ConnectionType::Sink,
+            s.cloned().ok_or_else(|| anyhow!("no schema for blackhole sink"))?,
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/blackhole/mod.rs
+++ b/crates/arroyo-connectors/src/blackhole/mod.rs
@@ -106,7 +106,8 @@ impl Connector for BlackholeConnector {
             self.name(),
             name.to_string(),
             ConnectionType::Sink,
-            s.cloned().ok_or_else(|| anyhow!("no schema for blackhole sink"))?,
+            s.cloned()
+                .ok_or_else(|| anyhow!("no schema for blackhole sink"))?,
             &config,
             description,
         ))

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -8,7 +8,8 @@ use arroyo_rpc::api_types::connections::{
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 
 use crate::filesystem::{
-    file_system_sink_from_options, CommitStyle, FileSystemTable, FormatSettings, TableType,
+    file_system_sink_from_options, CommitStyle, FileSettings, FileSystemTable, FormatSettings,
+    PartitionShuffleSettings, Partitioning, TableType,
 };
 use crate::EmptyConfig;
 
@@ -81,6 +82,7 @@ impl Connector for DeltaLakeConnector {
             write_path,
             file_settings,
             format_settings,
+            shuffle_by_partition,
             ..
         } = &table.table_type
         else {
@@ -99,6 +101,24 @@ impl Connector for DeltaLakeConnector {
 
         let backend_config = BackendConfig::parse_url(write_path, true)?;
         let is_local = backend_config.is_local();
+
+        let partition_fields = match (shuffle_by_partition, file_settings) {
+            (
+                Some(PartitionShuffleSettings {
+                    enabled: Some(true),
+                    ..
+                }),
+                Some(FileSettings {
+                    partitioning:
+                        Some(Partitioning {
+                            partition_fields, ..
+                        }),
+                    ..
+                }),
+            ) => Some(partition_fields.clone()),
+            _ => None,
+        };
+
         let description = match (&format_settings, is_local) {
             (Some(FormatSettings::Parquet { .. }), true) => "LocalDeltaLake<Parquet>".to_string(),
             (Some(FormatSettings::Parquet { .. }), false) => "DeltaLake<Parquet>".to_string(),
@@ -133,7 +153,8 @@ impl Connector for DeltaLakeConnector {
             schema,
             &config,
             description,
-        ))    
+        )
+        .with_partition_fields(partition_fields))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/filesystem/delta.rs
+++ b/crates/arroyo-connectors/src/filesystem/delta.rs
@@ -125,15 +125,15 @@ impl Connector for DeltaLakeConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Sink,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Sink,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))    
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -117,6 +117,7 @@ impl<R: MultiPartWriter + Send + 'static> FileSystemSink<R> {
             file_settings,
             format_settings: _,
             storage_options,
+            ..
         } = self.table.clone().table_type
         else {
             unreachable!("multi-part writer can only be used as sink");

--- a/crates/arroyo-connectors/src/filesystem/table.json
+++ b/crates/arroyo-connectors/src/filesystem/table.json
@@ -192,7 +192,18 @@
                 }
               },
               "additionalProperties": false
-            }
+            },
+            "shuffleByPartition": {
+              "title": "Partition shuffle settings",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Enable partition shuffling",
+                  "type": "boolean",
+                  "description": "If enabled, we will shuffle by the partition keys, which can reduce the number of file sink produces; however this may cause backlog if data is skewed"
+                }
+              }
+            } 
           },
           "required": [
             "writePath"

--- a/crates/arroyo-connectors/src/fluvio/mod.rs
+++ b/crates/arroyo-connectors/src/fluvio/mod.rs
@@ -156,15 +156,15 @@ impl Connector for FluvioConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: typ,
+            self.name(),
+            name.to_string(),
+            typ,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: desc,
-        })
+            &config,
+            desc,
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/impulse/mod.rs
+++ b/crates/arroyo-connectors/src/impulse/mod.rs
@@ -158,15 +158,15 @@ impl Connector for ImpulseConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Source,
-            schema: impulse_schema(),
-            config: serde_json::to_string(&config).unwrap(),
+            self.name(),
+            name.to_string(),
+            ConnectionType::Source,
+            impulse_schema(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -232,15 +232,15 @@ impl Connector for KafkaConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: typ,
+            self.name(),
+            name.to_string(),
+            typ,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: desc,
-        })
+            &config,
+            desc,
+        ))
     }
 
     fn get_autocomplete(

--- a/crates/arroyo-connectors/src/kinesis/mod.rs
+++ b/crates/arroyo-connectors/src/kinesis/mod.rs
@@ -114,15 +114,15 @@ impl Connector for KinesisConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
+            self.name(),
+            name.to_string(),
             connection_type,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -181,15 +181,15 @@ impl Connector for MqttConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: typ,
+            self.name(),
+            name.to_string(),
+            typ,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: desc,
-        })
+            &config,
+            desc,
+        ))
     }
 
     fn test_profile(&self, profile: Self::ProfileT) -> Option<Receiver<TestSourceMessage>> {

--- a/crates/arroyo-connectors/src/nats/mod.rs
+++ b/crates/arroyo-connectors/src/nats/mod.rs
@@ -268,15 +268,15 @@ impl Connector for NatsConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
+            self.name(),
+            name.to_string(),
             connection_type,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: desc,
-        })
+            &config,
+            desc,
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/nexmark/mod.rs
+++ b/crates/arroyo-connectors/src/nexmark/mod.rs
@@ -208,15 +208,15 @@ impl Connector for NexmarkConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Source,
-            schema: nexmark_schema(),
-            config: serde_json::to_string(&config).unwrap(),
+            self.name(),
+            name.to_string(),
+            ConnectionType::Source,
+            nexmark_schema(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/polling_http/mod.rs
+++ b/crates/arroyo-connectors/src/polling_http/mod.rs
@@ -224,15 +224,15 @@ impl Connector for PollingHTTPConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Source,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Source,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/preview/mod.rs
+++ b/crates/arroyo-connectors/src/preview/mod.rs
@@ -97,15 +97,15 @@ impl Connector for PreviewConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Sink,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Sink,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/rabbitmq/mod.rs
+++ b/crates/arroyo-connectors/src/rabbitmq/mod.rs
@@ -206,15 +206,15 @@ impl Connector for RabbitmqConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: typ,
+            self.name(),
+            name.to_string(),
+            typ,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: desc,
-        })
+            &config,
+            desc,
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -416,15 +416,15 @@ impl Connector for RedisConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
+            self.name(),
+             name.to_string(),
             connection_type,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: description.to_string(),
-        })
+            &config,
+            description.to_string(),
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -419,7 +419,7 @@ impl Connector for RedisConnector {
         Ok(Connection::new(
             id,
             self.name(),
-             name.to_string(),
+            name.to_string(),
             connection_type,
             schema,
             &config,

--- a/crates/arroyo-connectors/src/single_file/mod.rs
+++ b/crates/arroyo-connectors/src/single_file/mod.rs
@@ -105,15 +105,15 @@ impl Connector for SingleFileConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
+            self.name(),
+            name.to_string(),
             connection_type,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
-            description: "Single File Source".to_string(),
-        })
+            &config,
+            "Single File Source".to_string(),
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/sse/mod.rs
+++ b/crates/arroyo-connectors/src/sse/mod.rs
@@ -109,15 +109,15 @@ impl Connector for SSEConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Source,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Source,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/stdout/mod.rs
+++ b/crates/arroyo-connectors/src/stdout/mod.rs
@@ -108,15 +108,15 @@ impl Connector for StdoutConnector {
             metadata_fields: vec![],
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Sink,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Sink,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn make_operator(

--- a/crates/arroyo-connectors/src/webhook/mod.rs
+++ b/crates/arroyo-connectors/src/webhook/mod.rs
@@ -164,15 +164,15 @@ impl Connector for WebhookConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Sink,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Sink,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-connectors/src/websocket/mod.rs
+++ b/crates/arroyo-connectors/src/websocket/mod.rs
@@ -251,15 +251,15 @@ impl Connector for WebsocketConnector {
             metadata_fields: schema.metadata_fields(),
         };
 
-        Ok(Connection {
+        Ok(Connection::new(
             id,
-            connector: self.name(),
-            name: name.to_string(),
-            connection_type: ConnectionType::Source,
+            self.name(),
+            name.to_string(),
+            ConnectionType::Source,
             schema,
-            config: serde_json::to_string(&config).unwrap(),
+            &config,
             description,
-        })
+        ))
     }
 
     fn from_options(

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::value::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -25,7 +25,7 @@ pub struct Connection {
     pub schema: ConnectionSchema,
     pub config: String,
     pub description: String,
-    pub partition_fields: HashSet<String>,
+    pub partition_fields: Option<Vec<String>>,
 }
 
 impl Connection {
@@ -46,11 +46,11 @@ impl Connection {
             schema,
             config: serde_json::to_string(config).unwrap(),
             description,
-            partition_fields: HashSet::new(),
+            partition_fields: None,
         }
     }
-    
-    pub fn with_partition_fields(&mut self, partition_fields: HashSet<String>) -> &mut Self {
+
+    pub fn with_partition_fields(mut self, partition_fields: Option<Vec<String>>) -> Self {
         self.partition_fields = partition_fields;
         self
     }

--- a/crates/arroyo-operator/src/connector.rs
+++ b/crates/arroyo-operator/src/connector.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::value::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
@@ -25,6 +25,35 @@ pub struct Connection {
     pub schema: ConnectionSchema,
     pub config: String,
     pub description: String,
+    pub partition_fields: HashSet<String>,
+}
+
+impl Connection {
+    pub fn new(
+        id: Option<i64>,
+        connector: &'static str,
+        name: String,
+        connection_type: ConnectionType,
+        schema: ConnectionSchema,
+        config: &impl Serialize,
+        description: String,
+    ) -> Self {
+        Connection {
+            id,
+            connector,
+            name,
+            connection_type,
+            schema,
+            config: serde_json::to_string(config).unwrap(),
+            description,
+            partition_fields: HashSet::new(),
+        }
+    }
+    
+    pub fn with_partition_fields(&mut self, partition_fields: HashSet<String>) -> &mut Self {
+        self.partition_fields = partition_fields;
+        self
+    }
 }
 
 pub struct MetadataDef {

--- a/crates/arroyo-planner/src/extension/sink.rs
+++ b/crates/arroyo-planner/src/extension/sink.rs
@@ -86,9 +86,8 @@ impl SinkExtension {
         })
     }
 
-    /* The input to a sink needs to be a non-transparent logical plan extension.
-      If it isn't, wrap the input in a RemoteTableExtension.
-    */
+    // The input to a sink needs to be a non-transparent logical plan extension.
+    // If it isn't, wrap the input in a RemoteTableExtension.
     pub fn add_remote_if_necessary(schema: &DFSchemaRef, input: &mut Arc<LogicalPlan>) {
         if let LogicalPlan::Extension(node) = input.as_ref() {
             let arroyo_extension: &dyn ArroyoExtension = (&node.node).try_into().unwrap();
@@ -171,15 +170,13 @@ impl ArroyoExtension for SinkExtension {
         let edges = input_schemas
             .into_iter()
             .map(|input_schema| {
-                LogicalEdge::project_all(LogicalEdgeType::Forward, (*input_schema).clone())
+                LogicalEdge::project_all(LogicalEdgeType::Shuffle, (*input_schema).clone())
             })
             .collect();
         Ok(NodeWithIncomingEdges { node, edges })
     }
 
     fn output_schema(&self) -> ArroyoSchema {
-        // this is kinda fake?
-        ArroyoSchema::from_schema_keys(Arc::new(self.inputs[0].schema().as_ref().into()), vec![])
-            .unwrap()
+        ArroyoSchema::from_fields(vec![])
     }
 }

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -669,12 +669,12 @@ fn rewrite_sinks(extensions: Vec<LogicalPlan>) -> Result<Vec<LogicalPlan>> {
     let mut sink_inputs = build_sink_inputs(&extensions);
     let mut new_extensions = vec![];
     for extension in extensions {
-        let mut is_rewrited = false;
+        let mut is_rewritten = false;
         let result = extension.rewrite(&mut SinkInputRewriter::new(
             &mut sink_inputs,
-            &mut is_rewrited,
+            &mut is_rewritten,
         ))?;
-        if !(is_rewrited) {
+        if !is_rewritten {
             new_extensions.push(result.data);
         }
     }

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -19,7 +19,6 @@ use arroyo_rpc::TIMESTAMP_FIELD;
 use arroyo_rpc::UPDATING_META_FIELD;
 use datafusion::logical_expr::UserDefinedLogicalNode;
 
-use crate::extension::key_calculation::KeyCalculationExtension;
 use crate::extension::lookup::LookupSource;
 use crate::extension::AsyncUDFExtension;
 use arroyo_udf_host::parse::{AsyncOptions, UdfType};
@@ -27,8 +26,7 @@ use datafusion::common::tree_node::{
     Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor,
 };
 use datafusion::common::{
-    plan_datafusion_err, plan_err, Column, DataFusionError, Result as DFResult, ScalarValue,
-    TableReference,
+    plan_err, Column, DataFusionError, Result as DFResult, ScalarValue, TableReference,
 };
 use datafusion::logical_expr;
 use datafusion::logical_expr::expr::ScalarFunction;

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -53,7 +53,6 @@ use datafusion::{
         sqlparser::ast::{ColumnDef, ColumnOption, Statement},
     },
 };
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 

--- a/crates/arroyo-planner/src/test/queries/analytics_ingest.sql
+++ b/crates/arroyo-planner/src/test/queries/analytics_ingest.sql
@@ -1,0 +1,41 @@
+-- from https://www.arroyo.dev/blog/building-a-real-time-data-lake
+create table events (
+    id TEXT PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    ip TEXT,
+    user_id TEXT,
+    platform TEXT,
+    app_version TEXT,
+    type TEXT NOT NULL,
+    properties JSON
+) with (
+    connector = 'kafka',
+    bootstrap_servers = 'localhost:9092',
+    topic = 'analytics',
+    format = 'json',
+    type = 'source'
+);
+
+create table account_created_sink with (
+    connector = 'delta',
+    path = 's3://my-s3-bucket/data/account_created',
+    format = 'parquet',
+    'filename.strategy' = 'uuid',
+    parquet_compression = 'zstd',
+    time_partition_pattern = '%Y/%m/%d/%H',
+    rollover_seconds = 6000
+);
+
+INSERT INTO account_created_sink
+SELECT
+	id,
+	timestamp,
+	ip,
+	user_id,
+	platform,
+	app_version,
+	properties->>'signup_method' as signup_method,
+	properties->>'campaign_id' as campaign_id,
+	properties->>'product' as product
+FROM events
+WHERE type = 'account_created';

--- a/crates/arroyo-planner/src/test/queries/filesystem_invalid_partition.sql
+++ b/crates/arroyo-planner/src/test/queries/filesystem_invalid_partition.sql
@@ -1,0 +1,40 @@
+--fail=Failed to create table events_sink caused by Error during planning: partition field 'not_a_real_field' does not exist in the schema
+create table events (
+    id TEXT PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    ip TEXT,
+    user_id TEXT,
+    platform TEXT,
+    app_version TEXT,
+    type TEXT NOT NULL,
+    properties JSON
+) with (
+    connector = 'kafka',
+    bootstrap_servers = 'localhost:9092',
+    topic = 'analytics',
+    format = 'json',
+    type = 'source'
+);
+
+create table events_sink (
+     id TEXT,
+     timestamp TIMESTAMP NOT NULL,
+     ip TEXT,
+     user_id TEXT,
+     platform TEXT,
+     app_version TEXT,
+     type TEXT NOT NULL,
+     properties JSON    
+) with (
+    connector = 'delta',
+    path = 's3://my-s3-bucket/data/events',
+    format = 'parquet',
+    'filename.strategy' = 'uuid',
+    parquet_compression = 'zstd',
+    time_partition_pattern = '%Y/%m/%d/%H',
+    partition_fields = [type, not_a_real_field],
+    rollover_seconds = 6000
+);
+
+INSERT INTO events
+SELECT * from events;

--- a/crates/arroyo-planner/src/test/queries/filesystem_partition.sql
+++ b/crates/arroyo-planner/src/test/queries/filesystem_partition.sql
@@ -1,0 +1,39 @@
+create table events (
+    id TEXT PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL,
+    ip TEXT,
+    user_id TEXT,
+    platform TEXT,
+    app_version TEXT,
+    type TEXT NOT NULL,
+    properties JSON
+) with (
+    connector = 'kafka',
+    bootstrap_servers = 'localhost:9092',
+    topic = 'analytics',
+    format = 'json',
+    type = 'source'
+);
+
+create table events_sink (
+     id TEXT,
+     timestamp TIMESTAMP NOT NULL,
+     ip TEXT,
+     user_id TEXT,
+     platform TEXT,
+     app_version TEXT,
+     type TEXT NOT NULL,
+     properties JSON    
+) with (
+    connector = 'delta',
+    path = 's3://my-s3-bucket/data/events',
+    format = 'parquet',
+    'filename.strategy' = 'uuid',
+    parquet_compression = 'zstd',
+    time_partition_pattern = '%Y/%m/%d/%H',
+    partition_fields = [type, app_version],
+    rollover_seconds = 6000
+);
+
+INSERT INTO events
+SELECT * from events;

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -15,8 +15,7 @@ use arrow_schema::{DataType, Field, Fields};
 use arroyo_types::{CheckpointBarrier, HASH_SEEDS};
 use datafusion::catalog_common::TableReference;
 use datafusion::common::{
-    not_impl_err, plan_datafusion_err, plan_err, DFSchema, Result as DFResult,
-    ScalarValue,
+    not_impl_err, plan_datafusion_err, plan_err, DFSchema, Result as DFResult, ScalarValue,
 };
 use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
@@ -721,6 +720,7 @@ macro_rules! retry {
     }};
 }
 
+#[cfg(test)]
 mod tests {
     use crate::parse_expr;
 

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -15,12 +15,15 @@ use arrow_schema::{DataType, Field, Fields};
 use arroyo_types::{CheckpointBarrier, HASH_SEEDS};
 use datafusion::catalog_common::TableReference;
 use datafusion::common::{
-    not_impl_err, plan_datafusion_err, plan_err, DFSchema, Result as DFResult, ScalarValue,
+    not_impl_err, plan_datafusion_err, plan_err, DFSchema, Result as DFResult,
+    ScalarValue,
 };
 use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
 use datafusion::sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion::sql::sqlparser::ast::{Expr, SqlOption, Value as SqlValue};
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+use datafusion::sql::sqlparser::parser::Parser;
 use grpc::rpc::{StopMode, TableCheckpointMetadata, TaskCheckpointEventType};
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -351,7 +354,7 @@ pub fn get_hasher() -> ahash::RandomState {
 }
 
 #[derive(Default)]
-struct EmptyContextProvider {
+pub struct EmptyContextProvider {
     config: ConfigOptions,
 }
 impl ContextProvider for EmptyContextProvider {
@@ -392,10 +395,17 @@ impl ContextProvider for EmptyContextProvider {
     }
 }
 
-pub fn contextless_sql_to_expr(expr: Expr) -> DFResult<datafusion::logical_expr::Expr> {
+pub fn contextless_sql_to_expr(
+    expr: Expr,
+    schema: Option<&DFSchema>,
+) -> DFResult<datafusion::logical_expr::Expr> {
     let provider = EmptyContextProvider::default();
     let s = SqlToRel::new(&provider);
-    s.sql_to_expr(expr, &DFSchema::empty(), &mut PlannerContext::new())
+    s.sql_to_expr(
+        expr,
+        schema.unwrap_or(&DFSchema::empty()),
+        &mut PlannerContext::new(),
+    )
 }
 
 pub fn duration_from_sql(expr: Expr) -> DFResult<Duration> {
@@ -409,7 +419,7 @@ pub fn duration_from_sql(expr: Expr) -> DFResult<Duration> {
                 .map_err(|_| plan_datafusion_err!("expected an interval, but found `{}`", s))?
         }
         expr => {
-            let expr = contextless_sql_to_expr(expr)
+            let expr = contextless_sql_to_expr(expr, None)
                 .map_err(|e| plan_datafusion_err!("invalid expression: {}", e))?;
 
             match expr {
@@ -627,6 +637,17 @@ impl ConnectorOptions {
         }
     }
 
+    pub fn pull_opt_array(&mut self, name: &str) -> Option<Vec<Expr>> {
+        Some(match self.options.remove(name)? {
+            Expr::Value(SqlValue::SingleQuotedString(s)) => s
+                .split(",")
+                .map(|p| Expr::Value(SqlValue::SingleQuotedString(p.to_string())))
+                .collect(),
+            Expr::Array(a) => a.elem,
+            e => vec![e],
+        })
+    }
+
     pub fn keys(&self) -> impl Iterator<Item = &String> {
         self.options.keys()
     }
@@ -663,6 +684,13 @@ impl ConnectorOptions {
     }
 }
 
+pub fn parse_expr(sql: &str) -> anyhow::Result<Expr> {
+    let dialect = PostgreSqlDialect {};
+    let parser = Parser::new(&dialect);
+    let mut parser = parser.try_with_sql(sql)?;
+    Ok(parser.parse_expr()?)
+}
+
 #[macro_export]
 macro_rules! retry {
     ($e:expr, $max_retries:expr, $base:expr, $max_delay:expr, |$err_var: ident| $error_handler:expr) => {{
@@ -691,4 +719,15 @@ macro_rules! retry {
             }
         }
     }};
+}
+
+mod tests {
+    
+
+    #[test]
+    fn test_parse_expr() {
+        let sql = "concat(1 + hello, 'blah')";
+        let parsed = parse_expr(sql).unwrap();
+        assert_eq!(parsed.to_string(), sql);
+    }
 }

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -722,7 +722,7 @@ macro_rules! retry {
 }
 
 mod tests {
-    
+    use crate::parse_expr;
 
     #[test]
     fn test_parse_expr() {

--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -490,6 +490,8 @@ async fn start_node() {
 }
 
 async fn visualize(query: Input, open: bool) {
+    let _guard = arroyo_server_common::init_logging(&"visualize");
+
     let query = std::io::read_to_string(query).expect("Failed to read query");
 
     let schema_provider = ArroyoSchemaProvider::new();

--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -490,7 +490,7 @@ async fn start_node() {
 }
 
 async fn visualize(query: Input, open: bool) {
-    let _guard = arroyo_server_common::init_logging(&"visualize");
+    let _guard = arroyo_server_common::init_logging("visualize");
 
     let query = std::io::read_to_string(query).expect("Failed to read query");
 


### PR DESCRIPTION
This PR adds the option `shuffle_by_partition.enabled` to the filesystem sink. If enabled (and there's at least one partition_field) the planner will add a key-by and a shuffle before the sink. This ensures that all events with a particular value for a partition field end up in the same subtask.

This is useful to reduce the number of files written; imagine if you have 100 event types and 10 partitions—each partition will write a file for some or all of the event types, causing up to 1,000 files to be written every rollover_seconds period. By partitioning by the event type, we would get at most 100 files.

However, if the key distribution is very skewed this can cause backlogs. For example, if 90% of your data is under one partition key that will now all go to a single task which may get overwhelmed. As a result, this behavior is configurable and by default off.

In addition, this PR also adds plan-time validation for the partition fields, which prevents the potential for execution-time errors.