### PR TITLE
Add support for inline struct definitions in DDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,12 +758,14 @@ dependencies = [
  "datafusion-proto",
  "futures",
  "glob",
+ "itertools 0.14.0",
  "petgraph 0.7.1",
  "prost 0.13.4",
  "rstest 0.23.0",
  "serde",
  "serde_json",
  "serde_json_path",
+ "sqlparser",
  "syn 2.0.96",
  "test-log",
  "tokio",
@@ -8328,8 +8330,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
+source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#65c1537c0a18be7f9c61d36980a893931ca1143c"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8338,8 +8339,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
+source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#65c1537c0a18be7f9c61d36980a893931ca1143c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ reqwest = "0.12"
 rusqlite = "0.31"
 apache-avro = "0.17.0"
 k8s-openapi = "0.24.0"
+sqlparser = "0.51.0"
 
 [profile.release]
 debug = 1
@@ -89,8 +90,8 @@ datafusion-physical-plan = {git = 'https://github.com/ArroyoSystems/arrow-datafu
 datafusion-proto = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
 datafusion-functions = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
 datafusion-functions-window = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-
 datafusion-functions-json = {git = 'https://github.com/ArroyoSystems/datafusion-functions-json', branch = 'datafusion_43'}
+sqlparser = { git = "https://github.com/ArroyoSystems/sqlparser-rs", branch = "0.51.0/arroyo" }
 
 object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }
 

--- a/crates/arroyo-planner/Cargo.toml
+++ b/crates/arroyo-planner/Cargo.toml
@@ -38,6 +38,9 @@ tracing = "0.1.37"
 serde_json_path = "0.7"
 unicase = "2.7.0"
 xxhash-rust = { version = "0.8.12", features = ["xxh3", "std"] }
+itertools = "0.14.0"
+
+sqlparser = { workspace = true}
 
 [dev-dependencies]
 test-log = {version = "0.2.15", default-features = false, features = ["trace"]}

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -31,8 +31,6 @@ use datafusion::datasource::DefaultTableSource;
 #[allow(deprecated)]
 use datafusion::prelude::SessionConfig;
 
-use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
-use datafusion::sql::sqlparser::parser::{Parser, ParserError};
 use datafusion::sql::{planner::ContextProvider, TableReference};
 
 use datafusion::logical_expr::expr::ScalarFunction;
@@ -76,7 +74,9 @@ use datafusion::logical_expr;
 use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
 use datafusion::logical_expr::planner::ExprPlanner;
 use datafusion::optimizer::Analyzer;
-use datafusion::sql::sqlparser::ast::{OneOrManyWithParens, Statement};
+use sqlparser::ast::{OneOrManyWithParens, Statement};
+use sqlparser::dialect::ArroyoDialect;
+use sqlparser::parser::{Parser, ParserError};
 use std::any::Any;
 use std::time::{Duration, SystemTime};
 use std::{collections::HashMap, sync::Arc};
@@ -769,8 +769,7 @@ fn try_handle_set_variable(
 }
 
 pub(crate) fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
-    let dialect = PostgreSqlDialect {};
-    Parser::parse_sql(&dialect, sql)
+    Parser::parse_sql(&ArroyoDialect {}, sql)
 }
 
 pub async fn parse_and_get_arrow_program(

--- a/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
+++ b/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
@@ -5,7 +5,7 @@ create table impulse with (
 );
 
 create temporary table lookup (
-    key TEXT PRIMARY KEY GENERATED ALWAYS AS (metadata('key')) STORED, 
+    key TEXT GENERATED ALWAYS AS (metadata('key')) STORED PRIMARY KEY,
     value TEXT,
     len INT
 ) with (

--- a/crates/arroyo-planner/src/test/queries/struct_ddl.sql
+++ b/crates/arroyo-planner/src/test/queries/struct_ddl.sql
@@ -1,0 +1,12 @@
+create table users (
+    id TEXT,
+    t struct<a int, x struct<b text>>
+) with (
+    connector = 'kafka',
+    format = 'json',
+    bootstrap_servers = 'localhost:9092',
+    type = 'source',
+    topic = 'structs'
+);
+
+select id, t.a, t.x.b from users;


### PR DESCRIPTION
This PR introduces struct syntax for data types. This is particularly useful in DDL, making it now possible to define (potentially nested) structs for source and sink fields. Previously, this was only possible using external schema definitions (e.g., from json schema or avro). 

The new syntax looks like this:

```sql
create table events (
    id TEXT,
    t struct<a int, x struct<b text>>
) with (
    connector = 'kafka',
    format = 'json',
    bootstrap_servers = 'localhost:9092',
    type = 'source',
    topic = 'structs'
);

select id, t.a, t.x.b from events;
```

There are several inline-struct syntaxes out there; this one (`struct<(name type,)+>` comes originally (as far as I know) from Hive, and is also used in various other analytical query systems like BigQuery and Spark.

As part of this change, we have also finally made the step of forking sqlparser-rs to add our own ArroyoDialect. We've had a good run working around the limitations of the postgres dialect, but having our own will give us much more flexibility in choosing our desired syntax going forward. 