### PR TITLE
Improve JSON decoding speed by up to 40%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "53.2.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=53.2.0%2Fjson#24c93dff8203e766ea30cdd0461d06c10608f53c"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=53.2.0%2Fjson#9cb387d4f5529d89e3d8dd8243fc5ea3aba2e258"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -338,9 +338,11 @@ dependencies = [
  "half",
  "indexmap",
  "lexical-core",
+ "memchr",
  "num",
  "serde",
  "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -6843,7 +6845,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -8251,6 +8253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8327,7 +8335,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.96",


### PR DESCRIPTION
Pulls in changes from https://github.com/apache/arrow-rs/pull/7157 (rebased on our arrow-json fork as  https://github.com/ArroyoSystems/arrow-rs/commit/9cb387d4f55), which significantly improves JSON decoding performance.

This table shows performance improvements across various JSON documents (from [ArroyoSystems/json-benchmarks](https://github.com/ArroyoSystems/json-benchmarks/tree/main/arroyo)):

| Benchmark                | BufIter (%) | memchr2 (%) | simdutf8 (%) | Total (%) |
|--------------------------|--------------------|--------------------|--------------------|------------------|
| logs_json                | -13.49%            | -12.61%            | -0.83%             | -25.03%          |
| logs_pretty_json         | -20.63%            | -10.77%            | -1.22%             | -30.04%          |
| nexmark_json             | -30.01%            | -16.01%            | -0.42%             | -41.46%          |
| nexmark_pretty_json      | -21.35%            | -15.76%            | -1.09%             | -34.47%          |
| nexmark_bids_json        | -26.64%            | -22.20%            | -3.01%             | -44.64%          |
| nexmark_bids_pretty_json | -26.26%            | -22.16%            | -2.64%             | -44.12%          |
| tweets_json              | -20.36%            | -18.97%            | -14.85%            | -45.05%          |
| tweets_pretty_json       | -22.61%            | -15.10%            | -11.04%            | -41.55%          |
| **Average**              |                    |                    |                    | **-38.29%**      |
