### PR TITLE
Introduce METADATA and WATERMARK syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,6 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "datafusion"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2732,7 +2731,6 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2746,7 +2744,6 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2770,7 +2767,6 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "log",
  "tokio",
@@ -2779,7 +2775,6 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "chrono",
@@ -2799,7 +2794,6 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2822,7 +2816,6 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2833,7 +2826,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2859,7 +2851,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2879,7 +2870,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2903,7 +2893,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2925,7 +2914,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -2939,7 +2927,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2948,7 +2935,6 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2967,7 +2953,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2994,7 +2979,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -3008,7 +2992,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3023,7 +3006,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "ahash",
  "arrow",
@@ -3057,7 +3039,6 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "chrono",
@@ -3072,7 +3053,6 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "chrono",
@@ -3084,7 +3064,6 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
-source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#13dc2395f367909a0b36cc74ae1b13203b3a4d1e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -8416,7 +8395,6 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.51.0"
-source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#65c1537c0a18be7f9c61d36980a893931ca1143c"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8425,7 +8403,6 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.2.2"
-source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#65c1537c0a18be7f9c61d36980a893931ca1143c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "datafusion"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2731,6 +2732,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2744,6 +2746,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2767,6 +2770,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "log",
  "tokio",
@@ -2775,6 +2779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "chrono",
@@ -2794,6 +2799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2816,6 +2822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2826,6 +2833,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2851,6 +2859,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2870,6 +2879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2893,6 +2903,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2914,6 +2925,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -2927,6 +2939,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2935,6 +2948,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2953,6 +2967,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2979,6 +2994,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2992,6 +3008,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3006,6 +3023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "ahash",
  "arrow",
@@ -3039,6 +3057,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "chrono",
@@ -3053,6 +3072,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "chrono",
@@ -3064,6 +3084,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
+source = "git+https://github.com/ArroyoSystems/arrow-datafusion?branch=43.0.0%2Farroyo#069a24f5b56878fd5ca2b3d1066165b1d604702f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -6842,8 +6863,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6876,7 +6897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6957,7 +6978,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -8342,7 +8363,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -8395,6 +8416,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.51.0"
+source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#a81b36c1b72b0948a415d996f19a63f5ec995c95"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8403,6 +8425,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.2.2"
+source = "git+https://github.com/ArroyoSystems/sqlparser-rs?branch=0.51.0%2Farroyo#a81b36c1b72b0948a415d996f19a63f5ec995c95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9890,7 +9913,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,23 +81,17 @@ deltalake = { git = 'https://github.com/delta-io/delta-rs', rev = '25ce38956e257
 typify = { git = 'https://github.com/ArroyoSystems/typify.git', branch = 'arroyo' }
 parquet = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '53.2.0/parquet_bytes'}
 arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '53.2.0/json'}
-datafusion = { path = "../arrow-datafusion/datafusion/core" }
-datafusion-common = { path = "../arrow-datafusion/datafusion/common" }
-datafusion-execution = { path = "../arrow-datafusion/datafusion/execution" }
-datafusion-expr = { path = "../arrow-datafusion/datafusion/expr" }
-datafusion-expr-common = { path = "../arrow-datafusion/datafusion/expr-common" }
-datafusion-physical-expr = { path = "../arrow-datafusion/datafusion/physical-expr" }
-datafusion-physical-plan = { path = "../arrow-datafusion/datafusion/physical-plan" }
-datafusion-proto = { path = "../arrow-datafusion/datafusion/proto" }
-datafusion-functions = { path = "../arrow-datafusion/datafusion/functions" }
-datafusion-functions-aggregate = { path = "../arrow-datafusion/datafusion/functions-aggregate" }
-datafusion-functions-window = { path = "../arrow-datafusion/datafusion/functions-window" }
+datafusion = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-common = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-execution = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-physical-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-physical-plan = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-proto = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-functions = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion-functions-window = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
 datafusion-functions-json = {git = 'https://github.com/ArroyoSystems/datafusion-functions-json', branch = 'datafusion_43'}
-
-
-
-# sqlparser = { git = "https://github.com/ArroyoSystems/sqlparser-rs", branch = "0.51.0/arroyo" }
-sqlparser = { path = "../datafusion-sqlparser-rs" }
+sqlparser = { git = "https://github.com/ArroyoSystems/sqlparser-rs", branch = "0.51.0/arroyo" }
 
 
 object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,17 +81,23 @@ deltalake = { git = 'https://github.com/delta-io/delta-rs', rev = '25ce38956e257
 typify = { git = 'https://github.com/ArroyoSystems/typify.git', branch = 'arroyo' }
 parquet = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '53.2.0/parquet_bytes'}
 arrow-json = {git = 'https://github.com/ArroyoSystems/arrow-rs', branch = '53.2.0/json'}
-datafusion = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-common = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-execution = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-physical-expr = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-physical-plan = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-proto = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-functions = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
-datafusion-functions-window = {git = 'https://github.com/ArroyoSystems/arrow-datafusion', branch = '43.0.0/arroyo'}
+datafusion = { path = "../arrow-datafusion/datafusion/core" }
+datafusion-common = { path = "../arrow-datafusion/datafusion/common" }
+datafusion-execution = { path = "../arrow-datafusion/datafusion/execution" }
+datafusion-expr = { path = "../arrow-datafusion/datafusion/expr" }
+datafusion-expr-common = { path = "../arrow-datafusion/datafusion/expr-common" }
+datafusion-physical-expr = { path = "../arrow-datafusion/datafusion/physical-expr" }
+datafusion-physical-plan = { path = "../arrow-datafusion/datafusion/physical-plan" }
+datafusion-proto = { path = "../arrow-datafusion/datafusion/proto" }
+datafusion-functions = { path = "../arrow-datafusion/datafusion/functions" }
+datafusion-functions-aggregate = { path = "../arrow-datafusion/datafusion/functions-aggregate" }
+datafusion-functions-window = { path = "../arrow-datafusion/datafusion/functions-window" }
 datafusion-functions-json = {git = 'https://github.com/ArroyoSystems/datafusion-functions-json', branch = 'datafusion_43'}
-sqlparser = { git = "https://github.com/ArroyoSystems/sqlparser-rs", branch = "0.51.0/arroyo" }
+
+
+
+# sqlparser = { git = "https://github.com/ArroyoSystems/sqlparser-rs", branch = "0.51.0/arroyo" }
+sqlparser = { path = "../datafusion-sqlparser-rs" }
 
 
 object_store = { git = 'http://github.com/ArroyoSystems/arrow-rs', branch = 'object_store_0.11.1/arroyo' }

--- a/crates/arroyo-connectors/src/redis/mod.rs
+++ b/crates/arroyo-connectors/src/redis/mod.rs
@@ -304,7 +304,7 @@ impl Connector for RedisConnector {
                     {
                         bail!(
                             "Redis lookup tables must have a PRIMARY KEY field defined as \
-                        `field_name TEXT GENERATED ALWAYS AS (metadata('key')) STORED`"
+                        `field_name TEXT METADATA FROM 'key'`"
                         );
                     }
                 }

--- a/crates/arroyo-planner/src/builder.rs
+++ b/crates/arroyo-planner/src/builder.rs
@@ -319,7 +319,7 @@ impl PlanToGraphVisitor<'_> {
 
         let NodeWithIncomingEdges { node, edges } = extension
             .plan_node(&self.planner, self.graph.node_count(), input_schemas)
-            .map_err(|e| e.context(format!("planning extension {:?}", extension)))?;
+            .map_err(|e| e.context(format!("planning operator {:?}", extension)))?;
 
         let node_index = self.graph.add_node(node);
         self.add_index_to_traversal(node_index);
@@ -395,8 +395,7 @@ impl TreeNodeVisitor<'_> for PlanToGraphVisitor<'_> {
         let arroyo_extension: &dyn ArroyoExtension = node
             .try_into()
             .map_err(|e: DataFusionError| e.context("converting extension"))?;
-        self.build_extension(input_nodes, arroyo_extension)
-            .map_err(|e| e.context("building extension"))?;
+        self.build_extension(input_nodes, arroyo_extension)?;
 
         Ok(TreeNodeRecursion::Continue)
     }

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -5,7 +5,7 @@ use crate::{
     fields_with_qualifiers, multifield_partial_ord, parse_sql, ArroyoSchemaProvider, DFField,
 };
 use crate::{rewrite_plan, DEFAULT_IDLE_TIME};
-use arrow_schema::{DataType, Field, FieldRef, Schema};
+use arrow_schema::{DataType, Field, FieldRef, Schema, TimeUnit};
 use arroyo_connectors::connector_for_type;
 use arroyo_datastream::default_sink;
 use arroyo_operator::connector::Connection;
@@ -17,11 +17,13 @@ use arroyo_rpc::grpc::api::ConnectorOp;
 use arroyo_rpc::ConnectorOptions;
 use arroyo_types::ArroyoExtensionType;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
-use datafusion::common::{config::ConfigOptions, DFSchema, Result, ScalarValue};
+use datafusion::common::{
+    config::ConfigOptions, plan_datafusion_err, DFSchema, Result, ScalarValue,
+};
 use datafusion::common::{plan_err, Column, DataFusionError};
 use datafusion::logical_expr::{
-    CreateMemoryTable, CreateView, DdlStatement, DmlStatement, Expr, Extension, LogicalPlan,
-    WriteOp,
+    CreateMemoryTable, CreateView, DdlStatement, DmlStatement, Expr, ExprSchemable, Extension,
+    LogicalPlan, WriteOp,
 };
 use datafusion::optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
 use datafusion::optimizer::decorrelate_predicate_subquery::DecorrelatePredicateSubquery;
@@ -53,8 +55,13 @@ use datafusion::{
         sqlparser::ast::{ColumnDef, ColumnOption, Statement},
     },
 };
+use itertools::Itertools;
+use sqlparser::ast;
+use sqlparser::ast::TableConstraint;
+use std::ptr::null;
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConnectorTable {
@@ -230,8 +237,10 @@ impl ConnectorTable {
         temporary: bool,
         mut fields: Vec<FieldSpec>,
         primary_keys: Vec<String>,
+        watermark: Option<(String, Option<ast::Expr>)>,
         options: &mut ConnectorOptions,
         connection_profile: Option<&ConnectionProfile>,
+        schema_provider: &ArroyoSchemaProvider,
     ) -> Result<Self> {
         // TODO: a more principled way of letting connectors dictate types to use
         if "delta" == connector {
@@ -335,8 +344,66 @@ impl ConnectorTable {
             table.fields = fields;
         }
 
-        table.event_time_field = options.pull_opt_field("event_time_field")?;
-        table.watermark_field = options.pull_opt_field("watermark_field")?;
+        if let Some(event_time_field) = options.pull_opt_field("event_time_field")? {
+            warn!("`event_time_field` WITH option is deprecated; use WATERMARK FOR syntax");
+            table.event_time_field = Some(event_time_field);
+        }
+
+        if let Some(watermark_field) = options.pull_opt_field("watermark_field")? {
+            warn!("`watermark_field` WITH option is deprecated; use WATERMARK FOR syntax");
+            table.watermark_field = Some(watermark_field);
+        }
+
+        if let Some((time_field, watermark_expr)) = watermark {
+            let schema =
+                DFSchema::try_from_qualified_schema(&table.name, &table.physical_schema())?;
+
+            let field = table
+                .fields
+                .iter()
+                .find(|f| f.field().name().as_str() == time_field)
+                .ok_or_else(|| {
+                    plan_datafusion_err!(
+                        "WATERMARK FOR field `{}` does not exist in table",
+                        time_field
+                    )
+                })?;
+
+            if !matches!(field.field().data_type(), DataType::Timestamp(_, None)) {
+                return plan_err!(
+                    "WATERMARK FOR field `{:?}` has type {}, but expected TIMESTAMP",
+                    time_field,
+                    field.field().data_type()
+                );
+            }
+
+            table.event_time_field = Some(time_field.clone());
+
+            if let Some(expr) = watermark_expr {
+                let logical_expr =
+                    plan_generating_expr(&expr, &table.name, &schema, schema_provider)
+                        .map_err(|e| e.context("could not plan watermark expression"))?;
+
+                let (data_type, nullable) = logical_expr.data_type_and_nullable(&schema)?;
+                if !matches!(data_type, DataType::Timestamp(_, _)) {
+                    return plan_err!(
+                        "the type of the WATERMARK FOR expression must be TIMESTAMP, but was {}",
+                        data_type
+                    );
+                }
+                if nullable {
+                    return plan_err!("the type of the WATERMARK FOR expression must be NOT NULL");
+                }
+
+                table.fields.push(FieldSpec::Virtual {
+                    field: Field::new("__watermark", logical_expr.get_type(&schema)?, false),
+                    expression: logical_expr,
+                });
+                table.watermark_field = Some("__watermark".to_string());
+            } else {
+                table.watermark_field = Some(time_field);
+            }
+        }
 
         table.idle_time = options
             .pull_opt_i64("idle_micros")?
@@ -681,6 +748,7 @@ impl Table {
             with_options,
             query: None,
             temporary,
+            constraints,
             ..
         }) = statement
         {
@@ -745,14 +813,32 @@ impl Table {
                             ),
                             None => None,
                         };
+
+                    let watermark_constraints: Vec<_> = constraints
+                        .iter()
+                        .map(|c| match c {
+                            TableConstraint::Watermark {
+                                column_name,
+                                watermark_expr,
+                            } => Ok((column_name.to_string(), watermark_expr.clone())),
+                            c => Err(plan_datafusion_err!("Unsupported table constraint `{}`", c)),
+                        })
+                        .try_collect()?;
+
+                    if watermark_constraints.len() > 1 {
+                        return plan_err!("Only one WATERMARK FOR constraint is allowed per table");
+                    }
+
                     let table = ConnectorTable::from_options(
                         &name,
                         connector,
                         *temporary,
                         fields,
                         primary_keys,
+                        watermark_constraints.into_iter().next(),
                         &mut connector_opts,
                         connection_profile,
+                        schema_provider,
                     )
                     .map_err(|e| e.context(format!("Failed to create table {}", name)))?;
 

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -230,6 +230,7 @@ fn to_debezium_fields(fields: Vec<FieldRef>) -> Vec<Field> {
 }
 
 impl ConnectorTable {
+    #[allow(clippy::too_many_arguments)]
     fn from_options(
         name: &str,
         connector: &str,

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -747,7 +747,7 @@ impl Table {
                             key,
                         }
                     } else {
-                        FieldSpec::Struct(struct_field)                        
+                        FieldSpec::Struct(struct_field)
                     })
                 }
             })

--- a/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
+++ b/crates/arroyo-planner/src/test/queries/error_lookup_join_non_primary_key.sql
@@ -5,7 +5,7 @@ create table impulse with (
 );
 
 create temporary table lookup (
-    key TEXT GENERATED ALWAYS AS (metadata('key')) STORED PRIMARY KEY,
+    key TEXT METADATA FROM 'key' PRIMARY KEY,
     value TEXT,
     len INT
 ) with (
@@ -13,7 +13,7 @@ create temporary table lookup (
     format = 'raw_string',
     address = 'redis://localhost:6379',
     format = 'json',
-    'lookup.cache.max_bytes' = '100000'
+    'lookup.cache.max_bytes' = 100000
 );
 
 select A.counter, B.key, B.value, len

--- a/crates/arroyo-planner/src/test/queries/error_missing_redis_key.sql
+++ b/crates/arroyo-planner/src/test/queries/error_missing_redis_key.sql
@@ -1,4 +1,4 @@
---fail=Redis lookup tables must have a PRIMARY KEY field defined as `field_name TEXT GENERATED ALWAYS AS (metadata('key')) STORED`
+--fail=Redis lookup tables must have a PRIMARY KEY field defined as `field_name TEXT METADATA FROM 'key'`
 create table impulse with (
     connector = 'impulse',
     event_rate = '2'

--- a/crates/arroyo-planner/src/test/queries/kafka_metadata_udf.sql
+++ b/crates/arroyo-planner/src/test/queries/kafka_metadata_udf.sql
@@ -1,9 +1,9 @@
 create table users (
     id TEXT,
     name TEXT,
-    offset BIGINT GENERATED ALWAYS AS (metadata('offset_id')) STORED,
-    topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED,
-    partition INT GENERATED ALWAYS AS (metadata('partition')) STORED
+    offset BIGINT METADATA FROM 'offset_id',
+    topic TEXT METADATA FROM 'topic',
+    partition INT METADATA FROM 'partition'
 ) with (
     connector = 'kafka',
     topic = 'order_topic',

--- a/crates/arroyo-planner/src/test/queries/lookup_join.sql
+++ b/crates/arroyo-planner/src/test/queries/lookup_join.sql
@@ -12,7 +12,7 @@ CREATE TABLE events (
 );
 
 create temporary table customers (
-    customer_id TEXT PRIMARY KEY GENERATED ALWAYS AS (metadata('key')) STORED,
+    customer_id TEXT METADATA FROM 'key' PRIMARY KEY,
     customer_name TEXT,
     plan TEXT
 ) with (

--- a/crates/arroyo-planner/src/test/queries/metadata_error.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_error.sql
@@ -2,7 +2,7 @@
 create table mqtt (
     name TEXT,
     value INT,
-    topic INT GENERATED ALWAYS AS (metadata('topic')) STORED
+    topic INT METADATA FROM 'topic'
 ) with (
     connector = 'mqtt',
     url = 'tcp://localhost:1883',

--- a/crates/arroyo-planner/src/test/queries/metadata_fields.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_fields.sql
@@ -1,7 +1,7 @@
 create table mqtt (
     name TEXT,
     value INT,
-    my_topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED
+    my_topic TEXT METADATA FROM 'topic'
 ) with (
     connector = 'mqtt',
     url = 'tcp://localhost:1883',

--- a/crates/arroyo-planner/src/test/queries/metadata_raw_string.sql
+++ b/crates/arroyo-planner/src/test/queries/metadata_raw_string.sql
@@ -1,6 +1,6 @@
 create table mqtt (
     value TEXT,
-    my_topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED
+    my_topic TEXT METADATA FROM 'topic'
 ) with (
     connector = 'mqtt',
     url = 'tcp://localhost:1883',

--- a/crates/arroyo-planner/src/test/queries/no_virtual_fields_updating.sql
+++ b/crates/arroyo-planner/src/test/queries/no_virtual_fields_updating.sql
@@ -6,7 +6,7 @@ CREATE table debezium_source (
     initial_bid int,
     date_string text,
     datetime datetime GENERATED ALWAYS AS (CAST(date_string as timestamp)) STORED,
-    watermark datetime GENERATED ALWAYS AS (CAST(date_string as timestamp) - interval '1 second') STORED
+    "watermark" datetime GENERATED ALWAYS AS (CAST(date_string as timestamp) - interval '1 second') STORED
   ) WITH (
     connector = 'kafka',
     bootstrap_servers = 'localhost:9092',

--- a/crates/arroyo-planner/src/test/queries/parse_log.sql
+++ b/crates/arroyo-planner/src/test/queries/parse_log.sql
@@ -1,8 +1,8 @@
 create table logs (
     value TEXT NOT NULL,
-    parsed TEXT GENERATED ALWAYS AS (parse_log(value)) stored,
+    parsed TEXT GENERATED ALWAYS AS (parse_log(value)),
     event_time TIMESTAMP GENERATED ALWAYS AS
-        (CAST(extract_json_string(parse_log(value), '$.timestamp') as TIMESTAMP)) stored
+        (CAST(extract_json_string(parse_log(value), '$.timestamp') as TIMESTAMP))
 ) with (
     connector = 'kafka',
     type = 'source',

--- a/crates/arroyo-planner/src/test/queries/watermarks.sql
+++ b/crates/arroyo-planner/src/test/queries/watermarks.sql
@@ -1,0 +1,28 @@
+CREATE TABLE orders (
+  customer_id INT,
+  order_id INT,
+  date_string TEXT,
+  timestamp TIMESTAMP GENERATED ALWAYS AS (CAST(date_string as TIMESTAMP)),
+  watermark FOR timestamp as timestamp - INTERVAL '5 seconds'
+) WITH (
+  connector = 'kafka',
+  format = 'json',
+  type = 'source',
+  bootstrap_servers = 'localhost:9092',
+  topic = 'order_topic'
+);
+
+CREATE TABLE users (
+  customer_id INT,
+  timestamp TIMESTAMP,
+  watermark FOR timestamp
+) WITH (
+  connector = 'kafka',
+  format = 'json',
+  type = 'source',
+  bootstrap_servers = 'localhost:9092',
+  topic = 'order_topic'
+);
+
+
+select * from orders;

--- a/crates/arroyo-planner/src/test/queries/watermarks.sql
+++ b/crates/arroyo-planner/src/test/queries/watermarks.sql
@@ -1,9 +1,9 @@
 CREATE TABLE orders (
   customer_id INT,
   order_id INT,
-  date_string TEXT,
+  date_string TEXT NOT NULL,
   timestamp TIMESTAMP GENERATED ALWAYS AS (CAST(date_string as TIMESTAMP)),
-  watermark FOR timestamp as timestamp - INTERVAL '5 seconds'
+  watermark FOR timestamp as CAST(date_string as TIMESTAMP) - INTERVAL '5 seconds'
 ) WITH (
   connector = 'kafka',
   format = 'json',

--- a/crates/arroyo-sql-testing/src/test/queries/active_drivers.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/active_drivers.sql
@@ -3,14 +3,13 @@ CREATE TABLE cars(
       timestamp TIMESTAMP,
       driver_id BIGINT,
       event_type TEXT,
-      location TEXT
+      location TEXT,
+      WATERMARK for timestamp             
     ) WITH (
       connector = 'single_file',
       path = '$input_dir/cars.json',
       format = 'json',
-      type = 'source',
-      event_time_field = timestamp,
-      watermark_field = timestamp
+      type = 'source'
     );
 
 CREATE TABLE active_drivers (

--- a/crates/arroyo-sql-testing/src/test/queries/every_aggregate.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/every_aggregate.sql
@@ -1,17 +1,15 @@
 --pk=event_type
 CREATE TABLE cars (
-      timestamp TIMESTAMP,
+      timestamp TIMESTAMP NOT NULL,
       driver_id BIGINT,
       event_type TEXT,
       location TEXT,
-      watermark timestamp GENERATED ALWAYS AS (timestamp - interval '1 hour') STORED
+      watermark for timestamp AS (timestamp - interval '1 hour')
 ) WITH (
       connector = 'single_file',
       path = '$input_dir/cars.json',
       format = 'json',
-      type = 'source',
-      event_time_field = 'timestamp',
-      watermark_field = 'watermark'
+      type = 'source'
 );
 
 CREATE TABLE every_aggregate WITH (

--- a/crates/arroyo-sql-testing/src/test/queries/month_loose_watermark.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/month_loose_watermark.sql
@@ -1,16 +1,14 @@
 CREATE TABLE cars(
-          timestamp TIMESTAMP,
+          timestamp TIMESTAMP NOT NULL,
           driver_id BIGINT,
           event_type TEXT,
           location TEXT,
-          watermark TIMESTAMP GENERATED ALWAYS AS (timestamp - INTERVAL '1 minute') STORED
+          watermark for timestamp AS (timestamp - INTERVAL '1 minute')
         ) WITH (
           connector = 'single_file',
           path = '$input_dir/cars.json',
           format = 'json',
-          type = 'source',
-          event_time_field = 'timestamp',
-          watermark_field = 'watermark'
+          type = 'source'
         );
         CREATE TABLE group_by_aggregate (
           month TIMESTAMP,

--- a/crates/arroyo-sql-testing/src/test/queries/most_active_driver_last_hour.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/most_active_driver_last_hour.sql
@@ -1,16 +1,14 @@
 CREATE TABLE cars (
-          timestamp TIMESTAMP,
+          timestamp TIMESTAMP NOT NULL,
           driver_id BIGINT,
           event_type TEXT,
           location TEXT,
-          watermark timestamp GENERATED ALWAYS AS (timestamp - interval '1 hour') STORED
+          watermark for timestamp AS (timestamp - interval '1 hour')
         ) WITH (
           connector = 'single_file',
           path = '$input_dir/cars.json',
           format = 'json',
-          type = 'source',
-          event_time_field = 'timestamp',
-          watermark_field = 'watermark'
+          type = 'source'
         );
         CREATE TABLE most_active_driver (
           start TIMESTAMP,

--- a/crates/arroyo-sql-testing/src/test/queries/offset_impulse_join.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/offset_impulse_join.sql
@@ -1,27 +1,25 @@
 CREATE TABLE impulse_source (
-  timestamp TIMESTAMP,
+  timestamp TIMESTAMP NOT NULL,
   counter bigint unsigned not null,
-  subtask_index bigint unsigned not null
+  subtask_index bigint unsigned not null,
+  WATERMARK FOR timestamp
 ) WITH (
   connector = 'single_file',
   path = '$input_dir/impulse.json',
   format = 'json',
-  type = 'source',
-  event_time_field = 'timestamp'
+  type = 'source'
 );
 
 CREATE TABLE delayed_impulse_source (
-  timestamp TIMESTAMP,
+  timestamp TIMESTAMP NOT NULL,
   counter bigint unsigned not null,
   subtask_index bigint unsigned not null,
-  watermark timestamp GENERATED ALWAYS AS (timestamp - INTERVAL '10 minute') STORED
+  watermark for timestamp AS (timestamp - INTERVAL '10 minute')
 ) WITH (
   connector = 'single_file',
   path = '$input_dir/impulse.json',
   format = 'json',
-  type = 'source',
-  event_time_field = 'timestamp',
-  watermark_field = 'watermark'
+  type = 'source'
 );
 
 CREATE TABLE offset_output (

--- a/crates/arroyo-sql-testing/src/test/queries/tight_watermark.sql
+++ b/crates/arroyo-sql-testing/src/test/queries/tight_watermark.sql
@@ -2,14 +2,13 @@ CREATE TABLE cars(
   timestamp TIMESTAMP,
   driver_id BIGINT,
   event_type TEXT,
-  location TEXT
+  location TEXT,
+  WATERMARK for timestamp 
 ) WITH (
   connector = 'single_file',
   path = '$input_dir/cars.json',
   format = 'json',
-  type = 'source',
-  event_time_field = 'timestamp',
-  watermark_field = 'timestamp'
+  type = 'source'
 );
 CREATE TABLE group_by_aggregate (
   timestamp TIMESTAMP,


### PR DESCRIPTION
This PR introduces two new syntax elements to improve our SQL UX, and also makes the meaningless STORED keyword optional for generated fields. The sqlparser side of these changes is in https://github.com/ArroyoSystems/sqlparser-rs/pull/1.

## WATERMARK FOR

Allows users to configure the event-time column and watermark generation expression without needing to create and then reference virtual fields:

```
WATERMARK FOR fieldname [AS watermark_expr]
```

for example,

```sql
CREATE TABLE logs (
  timestamp TIMESTAMP NOT NULL,
  id INT,
  WATERMARK FOR timestamp AS timestamp - INTERVAL '5 seconds'
) WITH (
  ...
)
```

Previously, this would have been written

```sql
CREATE TABLE logs (
  timestamp TIMESTAMP NOT NULL,
  id INT,
  watermark TIMESTAMP GENERATED ALWAYS AS (timestamp - INTERVAL '5 seconds') STORED
) WITH (
  event_time_field = timestamp,
  watermark_field = watermark
)
```

## METADATA FROM

Allow users to configure a column to have metadata injected from the source:

```
field_name TYPE METADATA FROM 'key'
```

example:

```sql
CREATE TABLE logs (
    id TEXT,
    kafka_topic TEXT METADATA FROM 'topic',
    log TEXT
)
```

Previous, this would have been written using a special function

```sql
CREATE TABLE logs (
    id TEXT,
    kafka_topic TEXT GENERATED ALWAYS AS (metadata('topic')) STORED,
    log TEXT
)
```

## Breaking changes

Existing syntax for both features is still supported, but are deprecated and will be removed in 0.15. However, as WATERMARK is now a keyword, unquoted fields named watermark will now produce an error.
