### PR TITLE
Restrict chrono dependency to fix arrow build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,11 +937,12 @@ dependencies = [
 
 [[package]]
 name = "arroyo-udf-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arrow",
  "async-ffi",
+ "chrono",
  "regex",
  "serde",
  "syn 2.0.98",

--- a/crates/arroyo-api/src/udfs.rs
+++ b/crates/arroyo-api/src/udfs.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use tonic::transport::Channel;
 use tracing::error;
 
-const PLUGIN_VERSION: &str = "=0.2.0";
+const PLUGIN_VERSION: &str = "^0.2.0";
 
 const LOCAL_UDF_LIB_CRATE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arroyo-udf-common"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Arroyo Systems <support@arroyo.systems>"]
 license = "MIT OR Apache-2.0"
@@ -20,3 +20,4 @@ syn = { version = "2", features = ["full"] }
 anyhow = "1.0.82"
 regex = "1.10.3"
 serde = { version = "1.0.197", features = ["derive"] }
+chrono = ">=0.4.34,<0.4.40"


### PR DESCRIPTION
Restricts the chrono dependency to `>=0.4.34,<0.4.40` to fix https://github.com/apache/arrow-rs/issues/7196. This was not impacting arroyo itself, as we use a lockfile, but it did impact UDF compilation for new deployments. This was fixed by pushing an arroyo-udf-common update (0.2.1) with the chrono dependency, although users who ended up with a lockfile from the past two days may need to manually clean out their UDF build directory.

This change also remove the fixed version on arroyo-udf-plugin that we generate in the UDF compilation crate, which will give us more tools to respond to these sorts of upstream breakages in the future.