### PR TITLE
Add support for mqtt v3

### DIFF
--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -15,9 +15,9 @@ use arroyo_rpc::api_types::connections::{
 };
 use arroyo_rpc::var_str::VarStr;
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
-use rumqttc::v5::mqttbytes::QoS;
-use rumqttc::v5::{AsyncClient, Event as MqttEvent, EventLoop, Incoming, MqttOptions};
+use rumqttc::mqttbytes::QoS;
 use rumqttc::Outgoing;
+use rumqttc::{AsyncClient, Event as MqttEvent, EventLoop, Incoming, MqttOptions};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls_native_certs::load_native_certs;
 use serde::{Deserialize, Serialize};

--- a/crates/arroyo-connectors/src/mqtt/sink/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/mod.rs
@@ -9,9 +9,9 @@ use arroyo_formats::ser::ArrowSerializer;
 use arroyo_operator::context::{Collector, OperatorContext};
 use arroyo_operator::operator::ArrowOperator;
 use arroyo_rpc::formats::Format;
-use rumqttc::v5::mqttbytes::QoS;
-use rumqttc::v5::AsyncClient;
-use rumqttc::v5::ConnectionError;
+use rumqttc::mqttbytes::QoS;
+use rumqttc::AsyncClient;
+use rumqttc::ConnectionError;
 
 #[cfg(test)]
 mod test;
@@ -57,10 +57,7 @@ impl ArrowOperator for MqttSinkFunc {
                             match eventloop.poll().await {
                                 Ok(_) => (),
                                 Err(err) => match err {
-                                    ConnectionError::Timeout(_) => (),
-                                    ConnectionError::MqttState(rumqttc::v5::StateError::Io(
-                                        err,
-                                    ))
+                                    ConnectionError::MqttState(rumqttc::StateError::Io(err))
                                     | ConnectionError::Io(err)
                                         if err.kind() == std::io::ErrorKind::ConnectionAborted
                                             || err.kind()

--- a/crates/arroyo-connectors/src/mqtt/sink/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/mod.rs
@@ -48,7 +48,11 @@ impl ArrowOperator for MqttSinkFunc {
     async fn on_start(&mut self, ctx: &mut OperatorContext) {
         let mut attempts = 0;
         while attempts < 20 {
-            match super::create_connection(&self.config, ctx.task_info.task_index as usize) {
+            match super::create_connection(
+                &self.config,
+                &ctx.task_info.operator_id,
+                ctx.task_info.task_index as usize,
+            ) {
                 Ok((client, mut eventloop)) => {
                     self.client = Some(client);
                     let stopped = self.stopped.clone();

--- a/crates/arroyo-connectors/src/mqtt/sink/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/test.rs
@@ -15,10 +15,7 @@ use arroyo_rpc::{
 };
 use arroyo_types::get_test_task_info;
 use parquet::data_type::AsBytes;
-use rumqttc::{
-    v5::{mqttbytes::QoS, Event, Incoming},
-    Outgoing,
-};
+use rumqttc::{mqttbytes::QoS, Event, Incoming, Outgoing};
 use serde::Deserialize;
 use tokio::sync::mpsc::channel;
 
@@ -60,7 +57,7 @@ impl MqttTopicTester {
         }
     }
 
-    async fn get_client(&self) -> (rumqttc::v5::AsyncClient, rumqttc::v5::EventLoop) {
+    async fn get_client(&self) -> (rumqttc::AsyncClient, rumqttc::EventLoop) {
         let config = self.get_config();
         create_connection(&config, 0).expect("Failed to create connection")
     }

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -10,9 +10,9 @@ use arroyo_rpc::formats::{BadData, Format, Framing};
 use arroyo_rpc::{grpc::rpc::StopMode, ControlMessage, MetadataField};
 use arroyo_types::{SignalMessage, UserError, Watermark};
 use governor::{Quota, RateLimiter as GovernorRateLimiter};
-use rumqttc::v5::mqttbytes::QoS;
-use rumqttc::v5::{ConnectionError, Event as MqttEvent, Incoming};
+use rumqttc::mqttbytes::QoS;
 use rumqttc::Outgoing;
+use rumqttc::{Event as MqttEvent, Incoming};
 
 use crate::mqtt::{create_connection, MqttConfig};
 use arroyo_operator::context::{SourceCollector, SourceContext};
@@ -148,7 +148,7 @@ impl MqttSourceFunc {
                 event = eventloop.poll() => {
                     match event {
                         Ok(MqttEvent::Incoming(Incoming::Publish(p))) => {
-                            let topic = String::from_utf8_lossy(&p.topic).to_string();
+                            let topic = String::from_utf8_lossy(p.topic.as_bytes()).to_string();
 
                             let connector_metadata = if !self.metadata_fields.is_empty() {
                                 let mut connector_metadata = HashMap::new();
@@ -171,9 +171,6 @@ impl MqttSourceFunc {
                         }
                         Ok(_) => (),
                         Err(err) => {
-                            if let ConnectionError::Timeout(_) = err {
-                                continue;
-                            }
                             tracing::error!("Failed to poll mqtt eventloop: {}", err);
                             if let Err(err) = client
                                 .subscribe(

--- a/crates/arroyo-connectors/src/mqtt/source/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/mod.rs
@@ -115,16 +115,19 @@ impl MqttSourceFunc {
                 .await;
         }
 
-        let (client, mut eventloop) =
-            match create_connection(&self.config, ctx.task_info.task_index as usize) {
-                Ok(c) => c,
-                Err(e) => {
-                    return Err(UserError {
-                        name: "MqttSourceError".to_string(),
-                        details: format!("Failed to create connection: {}", e),
-                    });
-                }
-            };
+        let (client, mut eventloop) = match create_connection(
+            &self.config,
+            &ctx.task_info.operator_id,
+            ctx.task_info.task_index as usize,
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(UserError {
+                    name: "MqttSourceError".to_string(),
+                    details: format!("Failed to create connection: {}", e),
+                });
+            }
+        };
 
         match client.subscribe(self.topic.clone(), self.qos).await {
             Ok(_) => (),

--- a/crates/arroyo-connectors/src/mqtt/source/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/test.rs
@@ -15,7 +15,7 @@ use arroyo_rpc::var_str::VarStr;
 use arroyo_rpc::{ControlMessage, ControlResp};
 use arroyo_types::{ArrowMessage, ChainInfo, TaskInfo};
 use rand::random;
-use rumqttc::v5::mqttbytes::QoS;
+use rumqttc::mqttbytes::QoS;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
@@ -98,7 +98,7 @@ impl MqttTopicTester {
         }
     }
 
-    async fn get_client(&self) -> rumqttc::v5::AsyncClient {
+    async fn get_client(&self) -> rumqttc::AsyncClient {
         let config = self.get_config();
         let (client, mut eventloop) =
             create_connection(&config, 0).expect("Failed to create connection");


### PR DESCRIPTION
Previously we only supported protocol v5, because we were using the v5 versions of the rumqttc packages. However, we weren't actually using any of the v5 features. This PR uses the `rumqttc::*` packages instead of the `rumqttc::v5::*` ones.