### PR TITLE
Support NATS JWT auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "glob",
  "governor",
  "itertools 0.14.0",
+ "nkeys 0.3.2",
  "object_store",
  "parquet",
  "prost",
@@ -1195,7 +1196,7 @@ dependencies = [
  "bytes",
  "futures",
  "memchr",
- "nkeys",
+ "nkeys 0.4.4",
  "nuid",
  "once_cell",
  "pin-project",
@@ -5828,6 +5829,22 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nkeys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.15",
+ "log",
+ "rand 0.8.5",
+ "signatory",
 ]
 
 [[package]]

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -88,6 +88,7 @@ rustls = "0.22"
 
 # NATS
 async-nats = "0.38.0"
+nkeys = "0.3.0"
 
 [build-dependencies]
 glob = "0.3"

--- a/crates/arroyo-connectors/src/nats/profile.json
+++ b/crates/arroyo-connectors/src/nats/profile.json
@@ -40,16 +40,18 @@
         {
           "type": "object",
           "title": "Jwt",
-          "required": ["jwt", "nkey_seed"],
-          "sensitive": ["jwt", "nkey_seed"],
+          "required": ["jwt", "nkeySeed"],
+          "sensitive": ["jwt", "nkeySeed"],
           "properties": {
             "jwt": {
               "type": "string",
+              "title": "JWT",
               "description": "The JWT to use for authentication",
               "format": "var-str"
             },
-            "nkey_seed": {
+            "nkeySeed": {
               "type": "string",
+              "title": "NKey Seed",
               "description": "The NKey seed to use for authentication",
               "format": "var-str"
             }

--- a/crates/arroyo-connectors/src/nats/profile.json
+++ b/crates/arroyo-connectors/src/nats/profile.json
@@ -1,56 +1,63 @@
 {
-    "type": "object",
-    "title": "NatsConfig",
-    "properties": {
-        "servers": {
-            "type": "string",
-            "title": "NATS Servers",
-            "format": "var-str",
-            "description": "Comma-separated list of NATS servers to connect to",
-            "examples": [
-                "nats-1:4222,nats-2:4222"
-            ]
-        },
-        "authentication": {
-            "type": "object",
-            "oneOf": [
-                {
-                    "type": "object",
-                    "title": "None",
-                    "properties": {
-                    },
-                    "additionalProperties": false
-                },
-                {
-                    "type": "object",
-                    "title": "Credentials",
-                    "required": [
-                        "username",
-                        "password"
-                    ],
-                    "sensitive": [
-                        "user",
-                        "password"
-                    ],
-                    "properties": {
-                        "username": {
-                            "type": "string",
-                            "description": "The username to use for authentication",
-                            "format": "var-str"
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "The password to use for authentication",
-                            "format": "var-str"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        }
+  "type": "object",
+  "title": "NatsConfig",
+  "properties": {
+    "servers": {
+      "type": "string",
+      "title": "NATS Servers",
+      "format": "var-str",
+      "description": "Comma-separated list of NATS servers to connect to",
+      "examples": ["nats-1:4222,nats-2:4222"]
     },
-    "required": [
-        "servers",
-        "authentication"
-    ]
+    "authentication": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "None",
+          "properties": {},
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "Credentials",
+          "required": ["username", "password"],
+          "sensitive": ["user", "password"],
+          "properties": {
+            "username": {
+              "type": "string",
+              "description": "The username to use for authentication",
+              "format": "var-str"
+            },
+            "password": {
+              "type": "string",
+              "description": "The password to use for authentication",
+              "format": "var-str"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "Jwt",
+          "required": ["jwt", "nkey_seed"],
+          "sensitive": ["jwt", "nkey_seed"],
+          "properties": {
+            "jwt": {
+              "type": "string",
+              "description": "The JWT to use for authentication",
+              "format": "var-str"
+            },
+            "nkey_seed": {
+              "type": "string",
+              "description": "The NKey seed to use for authentication",
+              "format": "var-str"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "required": ["servers", "authentication"]
 }


### PR DESCRIPTION
Adds JWT/NKey auth for NATS. This auth type is required to use Arroyo with the Synadia NATS cloud service.

Thanks for this project - looking forward to your feedback!