### PR TITLE
Fix NATS consumer conflict

### DIFF
--- a/crates/arroyo-connectors/src/nats/source/mod.rs
+++ b/crates/arroyo-connectors/src/nats/source/mod.rs
@@ -192,7 +192,7 @@ impl NatsSourceFunc {
         };
 
         let consumer_name = format!(
-            "{}-{}",
+            "{}-{}-{}",
             match &self.source_type {
                 SourceType::Jetstream { stream, .. } => {
                     stream
@@ -201,7 +201,8 @@ impl NatsSourceFunc {
                     subject
                 }
             },
-            &ctx.task_info.operator_id.replace("operator_", "")
+            &ctx.task_info.operator_id.replace("operator_", ""),
+            &ctx.task_info.job_id.replace("job_", "")
         );
 
         let consumer_config = match &self.source_type {


### PR DESCRIPTION
When multiple pipelines connect to the same NATS stream, they create consumers with identical names, resulting in "consumer deleted" error:

`ERROR arroyo_server_common: panicked at crates/arroyo-connectors/src/nats/source/mod.rs:69:17:
NATS message error: consumer deleted panic.file="crates/arroyo-connectors/src/nats/source/mod.rs" panic.line=69 panic.column=17
INFO arroyo_connectors::nats::source: >> Existing consumer deleted. Recreating consumer with new `start_sequence`.`

Adding the job ID to the consumer name prevents this conflict