### PR TITLE
Fix: Support Vec<&str> args in UDAFs

### DIFF
--- a/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
@@ -158,8 +158,7 @@ fn arg_vars(parsed: &ParsedUdf) -> (Vec<TokenStream>, Vec<TokenStream>) {
                         quote!(.filter_map(|x| x))
                     } else {
                         quote!()
-                    };
-                        
+                    };                   
                     match field.data_type() {
                         DataType::Utf8 => {
                             quote!(

--- a/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
+++ b/crates/arroyo-udf/arroyo-udf-macros/src/lib.rs
@@ -158,7 +158,7 @@ fn arg_vars(parsed: &ParsedUdf) -> (Vec<TokenStream>, Vec<TokenStream>) {
                         quote!(.filter_map(|x| x))
                     } else {
                         quote!()
-                    };                   
+                    };
                     match field.data_type() {
                         DataType::Utf8 => {
                             quote!(


### PR DESCRIPTION
**What's Fixed:**

* Previously, UDAFs couldn't handle `Vec<&str>`  arguments correctly, especially alongside other vector types like `Vec<f64>`.
* This PR updates the UDAF handling logic to properly support `Vec<&str>` arguments.

**Testing Note:**

* When testing local changes to UDF code, you **need** to set `'use-local-udf-crate': true` (either as an environment variable or in the `config`).
* The default build process uses global dependencies, which won't pick up your local modifications otherwise.

**Suggestion:**

* It would be really helpful to highlight the `'use-local-udf-crate': true` setting in the Developer Setup docs ([https://doc.arroyo.dev/developing/dev-setup](https://doc.arroyo.dev/developing/dev-setup)).
* This setting is **critical** for developers working locally on the UDF system and could save them significant debugging time.

Also thanks to @RatulDawar for helping me.

this fix solves the issue: https://github.com/ArroyoSystems/arroyo/issues/861