### PR TITLE
Add support to length delimited protobuf messages

### DIFF
--- a/crates/arroyo-formats/src/proto/de.rs
+++ b/crates/arroyo-formats/src/proto/de.rs
@@ -19,6 +19,12 @@ pub(crate) fn deserialize_proto(
         })?;
     }
 
+    if proto.length_delimited {
+        read_varint(&mut msg).map_err(|e| {
+            SourceError::bad_data(format!("invalid protobuf varint: {:?}", e))
+        })?;
+    }
+
     let message = proto.message_name.as_ref().expect("no message name");
     let descriptor = pool.get_message_by_name(message).expect("no descriptor");
 

--- a/crates/arroyo-formats/src/proto/de.rs
+++ b/crates/arroyo-formats/src/proto/de.rs
@@ -20,9 +20,8 @@ pub(crate) fn deserialize_proto(
     }
 
     if proto.length_delimited {
-        read_varint(&mut msg).map_err(|e| {
-            SourceError::bad_data(format!("invalid protobuf varint: {:?}", e))
-        })?;
+        read_varint(&mut msg)
+            .map_err(|e| SourceError::bad_data(format!("invalid protobuf varint: {:?}", e)))?;
     }
 
     let message = proto.message_name.as_ref().expect("no message name");

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -233,6 +233,9 @@ pub struct ProtobufFormat {
 
     #[serde(default)]
     pub confluent_schema_registry: bool,
+
+    #[serde(default)]
+    pub length_delimited: bool,
 }
 
 impl ProtobufFormat {

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -62,7 +62,7 @@ export interface paths {
     /** List all pipelines */
     get: operations["get_pipelines"];
     /**
-     * Create a new pipeline 
+     * Create a new pipeline
      * @description The API will create a single job for the pipeline.
      */
     post: operations["create_pipeline"];
@@ -154,7 +154,7 @@ export interface components {
       startTime: number;
     };
     CheckpointCollection: {
-      data: (components["schemas"]["Checkpoint"])[];
+      data: components["schemas"]["Checkpoint"][];
     };
     CheckpointEventSpan: {
       description: string;
@@ -168,7 +168,7 @@ export interface components {
     CheckpointSpanType: "alignment" | "sync" | "async" | "committing";
     ConnectionAutocompleteResp: {
       values: {
-        [key: string]: (string)[] | undefined;
+        [key: string]: string[];
       };
     };
     ConnectionProfile: {
@@ -179,7 +179,7 @@ export interface components {
       name: string;
     };
     ConnectionProfileCollection: {
-      data: (components["schemas"]["ConnectionProfile"])[];
+      data: components["schemas"]["ConnectionProfile"][];
     };
     ConnectionProfilePost: {
       config: unknown;
@@ -189,10 +189,11 @@ export interface components {
     ConnectionSchema: {
       badData?: components["schemas"]["BadData"] | null;
       definition?: components["schemas"]["SchemaDefinition"] | null;
-      fields: (components["schemas"]["SourceField"])[];
+      fields: components["schemas"]["SourceField"][];
       format?: components["schemas"]["Format"] | null;
       framing?: components["schemas"]["Framing"] | null;
       inferred?: boolean | null;
+      primaryKeys?: string[];
       structName?: string | null;
     };
     ConnectionTable: {
@@ -209,7 +210,7 @@ export interface components {
       tableType: components["schemas"]["ConnectionType"];
     };
     ConnectionTableCollection: {
-      data: (components["schemas"]["ConnectionTable"])[];
+      data: components["schemas"]["ConnectionTable"][];
       hasMore: boolean;
     };
     ConnectionTablePost: {
@@ -220,7 +221,7 @@ export interface components {
       schema?: components["schemas"]["ConnectionSchema"] | null;
     };
     /** @enum {string} */
-    ConnectionType: "source" | "sink";
+    ConnectionType: "source" | "sink" | "lookup";
     Connector: {
       connectionConfig?: string | null;
       customSchemas: boolean;
@@ -236,7 +237,7 @@ export interface components {
       testing: boolean;
     };
     ConnectorCollection: {
-      data: (components["schemas"]["Connector"])[];
+      data: components["schemas"]["Connector"][];
     };
     ErrorResp: {
       error: string;
@@ -248,19 +249,19 @@ export interface components {
     }, {
       list: components["schemas"]["SourceField"];
     }]>;
-    Format: OneOf<[{
+    Format: {
       json: components["schemas"]["JsonFormat"];
-    }, {
+    } | {
       avro: components["schemas"]["AvroFormat"];
-    }, {
+    } | {
       protobuf: components["schemas"]["ProtobufFormat"];
-    }, {
+    } | {
       parquet: components["schemas"]["ParquetFormat"];
-    }, {
+    } | {
       raw_string: components["schemas"]["RawStringFormat"];
-    }, {
+    } | {
       raw_bytes: components["schemas"]["RawBytesFormat"];
-    }]>;
+    };
     Framing: {
       method: components["schemas"]["FramingMethod"];
     };
@@ -281,7 +282,7 @@ export interface components {
       updatedAt: number;
     };
     GlobalUdfCollection: {
-      data: (components["schemas"]["GlobalUdf"])[];
+      data: components["schemas"]["GlobalUdf"][];
     };
     Job: {
       /** Format: int64 */
@@ -300,7 +301,7 @@ export interface components {
       tasks?: number | null;
     };
     JobCollection: {
-      data: (components["schemas"]["Job"])[];
+      data: components["schemas"]["Job"][];
     };
     /** @enum {string} */
     JobLogLevel: "info" | "warn" | "error";
@@ -316,7 +317,7 @@ export interface components {
       taskIndex?: number | null;
     };
     JobLogMessageCollection: {
-      data: (components["schemas"]["JobLogMessage"])[];
+      data: components["schemas"]["JobLogMessage"][];
       hasMore: boolean;
     };
     JsonFormat: {
@@ -336,7 +337,7 @@ export interface components {
     };
     MetricGroup: {
       name: components["schemas"]["MetricName"];
-      subtasks: (components["schemas"]["SubtaskMetrics"])[];
+      subtasks: components["schemas"]["SubtaskMetrics"][];
     };
     /** @enum {string} */
     MetricName: "bytes_recv" | "bytes_sent" | "messages_recv" | "messages_sent" | "backpressure" | "tx_queue_size" | "tx_queue_rem";
@@ -348,18 +349,18 @@ export interface components {
       /** Format: int64 */
       bytes: number;
       operatorId: string;
-      subtasks: (components["schemas"]["SubtaskCheckpointGroup"])[];
+      subtasks: components["schemas"]["SubtaskCheckpointGroup"][];
     };
     OperatorCheckpointGroupCollection: {
-      data: (components["schemas"]["OperatorCheckpointGroup"])[];
+      data: components["schemas"]["OperatorCheckpointGroup"][];
     };
     OperatorMetricGroup: {
-      metricGroups: (components["schemas"]["MetricGroup"])[];
+      metricGroups: components["schemas"]["MetricGroup"][];
       /** Format: int32 */
       nodeId: number;
     };
     OperatorMetricGroupCollection: {
-      data: (components["schemas"]["OperatorMetricGroup"])[];
+      data: components["schemas"]["OperatorMetricGroup"][];
     };
     OutputData: {
       batch: string;
@@ -368,7 +369,7 @@ export interface components {
       startId: number;
       /** Format: int32 */
       subtaskIdx: number;
-      timestamps: (number)[];
+      timestamps: number[];
     };
     PaginationQueryParams: {
       /** Format: int32 */
@@ -390,10 +391,10 @@ export interface components {
       preview: boolean;
       query: string;
       stop: components["schemas"]["StopType"];
-      udfs: (components["schemas"]["Udf"])[];
+      udfs: components["schemas"]["Udf"][];
     };
     PipelineCollection: {
-      data: (components["schemas"]["Pipeline"])[];
+      data: components["schemas"]["Pipeline"][];
       hasMore: boolean;
     };
     PipelineEdge: {
@@ -406,8 +407,8 @@ export interface components {
       valueType: string;
     };
     PipelineGraph: {
-      edges: (components["schemas"]["PipelineEdge"])[];
-      nodes: (components["schemas"]["PipelineNode"])[];
+      edges: components["schemas"]["PipelineEdge"][];
+      nodes: components["schemas"]["PipelineNode"][];
     };
     PipelineNode: {
       description: string;
@@ -431,7 +432,7 @@ export interface components {
       /** Format: int64 */
       parallelism: number;
       query: string;
-      udfs?: (components["schemas"]["Udf"])[] | null;
+      udfs?: components["schemas"]["Udf"][] | null;
     };
     PipelineRestart: {
       force?: boolean | null;
@@ -439,7 +440,7 @@ export interface components {
     PreviewPost: {
       enableSinks?: boolean;
       query: string;
-      udfs?: (components["schemas"]["Udf"])[] | null;
+      udfs?: components["schemas"]["Udf"][] | null;
     };
     /** @enum {string} */
     PrimitiveType: "Int32" | "Int64" | "UInt32" | "UInt64" | "F32" | "F64" | "Bool" | "String" | "Bytes" | "UnixMillis" | "UnixMicros" | "UnixNanos" | "DateTime" | "Json";
@@ -448,10 +449,11 @@ export interface components {
       compiledSchema?: string | null;
       confluentSchemaRegistry?: boolean;
       intoUnstructuredJson?: boolean;
+      lengthDelimited?: boolean;
       messageName?: string | null;
     };
     QueryValidationResult: {
-      errors: (string)[];
+      errors: string[];
       graph?: components["schemas"]["PipelineGraph"] | null;
     };
     RawBytesFormat: Record<string, never>;
@@ -461,7 +463,7 @@ export interface components {
     }, {
       protobuf_schema: {
         dependencies?: {
-          [key: string]: string | undefined;
+          [key: string]: string;
         };
         schema: string;
       };
@@ -483,20 +485,20 @@ export interface components {
     /** @enum {string} */
     StopType: "none" | "checkpoint" | "graceful" | "immediate" | "force";
     StructType: {
-      fields: (components["schemas"]["SourceField"])[];
+      fields: components["schemas"]["SourceField"][];
       name?: string | null;
     };
     SubtaskCheckpointGroup: {
       /** Format: int64 */
       bytes: number;
-      eventSpans: (components["schemas"]["CheckpointEventSpan"])[];
+      eventSpans: components["schemas"]["CheckpointEventSpan"][];
       /** Format: int32 */
       index: number;
     };
     SubtaskMetrics: {
       /** Format: int32 */
       index: number;
-      metrics: (components["schemas"]["Metric"])[];
+      metrics: components["schemas"]["Metric"][];
     };
     TestSourceMessage: {
       done: boolean;
@@ -518,12 +520,12 @@ export interface components {
       prefix: string;
     };
     UdfValidationResult: {
-      errors: (string)[];
+      errors: string[];
       udfName?: string | null;
     };
     ValidateQueryPost: {
       query: string;
-      udfs?: (components["schemas"]["Udf"])[] | null;
+      udfs?: components["schemas"]["Udf"][] | null;
     };
     ValidateUdfPost: {
       definition: string;
@@ -536,6 +538,8 @@ export interface components {
   headers: never;
   pathItems: never;
 }
+
+export type $defs = Record<string, never>;
 
 export type external = Record<string, never>;
 
@@ -594,7 +598,9 @@ export interface operations {
     };
     responses: {
       /** @description Deleted connection profile */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** Get autocomplete suggestions for a connection profile */
@@ -656,7 +662,9 @@ export interface operations {
     };
     responses: {
       /** @description Schema is valid */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** Test a Connection Table */
@@ -668,7 +676,9 @@ export interface operations {
     };
     responses: {
       /** @description Job output as 'text/event-stream' */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** Delete a Connection Table */
@@ -681,7 +691,9 @@ export interface operations {
     };
     responses: {
       /** @description Deleted connection table */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** List all connectors */
@@ -710,7 +722,9 @@ export interface operations {
   ping: {
     responses: {
       /** @description Ping endpoint */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** List all pipelines */
@@ -731,7 +745,7 @@ export interface operations {
     };
   };
   /**
-   * Create a new pipeline 
+   * Create a new pipeline
    * @description The API will create a single job for the pipeline.
    */
   create_pipeline: {
@@ -820,7 +834,9 @@ export interface operations {
     };
     responses: {
       /** @description Deleted pipeline */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** Update a pipeline */
@@ -980,7 +996,9 @@ export interface operations {
     };
     responses: {
       /** @description Job output as 'text/event-stream' */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** Get Global UDFs */
@@ -1036,7 +1054,9 @@ export interface operations {
     };
     responses: {
       /** @description Deleted UDF */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
 }

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -62,7 +62,7 @@ export interface paths {
     /** List all pipelines */
     get: operations["get_pipelines"];
     /**
-     * Create a new pipeline
+     * Create a new pipeline 
      * @description The API will create a single job for the pipeline.
      */
     post: operations["create_pipeline"];
@@ -154,7 +154,7 @@ export interface components {
       startTime: number;
     };
     CheckpointCollection: {
-      data: components["schemas"]["Checkpoint"][];
+      data: (components["schemas"]["Checkpoint"])[];
     };
     CheckpointEventSpan: {
       description: string;
@@ -168,7 +168,7 @@ export interface components {
     CheckpointSpanType: "alignment" | "sync" | "async" | "committing";
     ConnectionAutocompleteResp: {
       values: {
-        [key: string]: string[];
+        [key: string]: (string)[] | undefined;
       };
     };
     ConnectionProfile: {
@@ -179,7 +179,7 @@ export interface components {
       name: string;
     };
     ConnectionProfileCollection: {
-      data: components["schemas"]["ConnectionProfile"][];
+      data: (components["schemas"]["ConnectionProfile"])[];
     };
     ConnectionProfilePost: {
       config: unknown;
@@ -189,11 +189,10 @@ export interface components {
     ConnectionSchema: {
       badData?: components["schemas"]["BadData"] | null;
       definition?: components["schemas"]["SchemaDefinition"] | null;
-      fields: components["schemas"]["SourceField"][];
+      fields: (components["schemas"]["SourceField"])[];
       format?: components["schemas"]["Format"] | null;
       framing?: components["schemas"]["Framing"] | null;
       inferred?: boolean | null;
-      primaryKeys?: string[];
       structName?: string | null;
     };
     ConnectionTable: {
@@ -210,7 +209,7 @@ export interface components {
       tableType: components["schemas"]["ConnectionType"];
     };
     ConnectionTableCollection: {
-      data: components["schemas"]["ConnectionTable"][];
+      data: (components["schemas"]["ConnectionTable"])[];
       hasMore: boolean;
     };
     ConnectionTablePost: {
@@ -221,7 +220,7 @@ export interface components {
       schema?: components["schemas"]["ConnectionSchema"] | null;
     };
     /** @enum {string} */
-    ConnectionType: "source" | "sink" | "lookup";
+    ConnectionType: "source" | "sink";
     Connector: {
       connectionConfig?: string | null;
       customSchemas: boolean;
@@ -237,7 +236,7 @@ export interface components {
       testing: boolean;
     };
     ConnectorCollection: {
-      data: components["schemas"]["Connector"][];
+      data: (components["schemas"]["Connector"])[];
     };
     ErrorResp: {
       error: string;
@@ -249,19 +248,19 @@ export interface components {
     }, {
       list: components["schemas"]["SourceField"];
     }]>;
-    Format: {
+    Format: OneOf<[{
       json: components["schemas"]["JsonFormat"];
-    } | {
+    }, {
       avro: components["schemas"]["AvroFormat"];
-    } | {
+    }, {
       protobuf: components["schemas"]["ProtobufFormat"];
-    } | {
+    }, {
       parquet: components["schemas"]["ParquetFormat"];
-    } | {
+    }, {
       raw_string: components["schemas"]["RawStringFormat"];
-    } | {
+    }, {
       raw_bytes: components["schemas"]["RawBytesFormat"];
-    };
+    }]>;
     Framing: {
       method: components["schemas"]["FramingMethod"];
     };
@@ -282,7 +281,7 @@ export interface components {
       updatedAt: number;
     };
     GlobalUdfCollection: {
-      data: components["schemas"]["GlobalUdf"][];
+      data: (components["schemas"]["GlobalUdf"])[];
     };
     Job: {
       /** Format: int64 */
@@ -301,7 +300,7 @@ export interface components {
       tasks?: number | null;
     };
     JobCollection: {
-      data: components["schemas"]["Job"][];
+      data: (components["schemas"]["Job"])[];
     };
     /** @enum {string} */
     JobLogLevel: "info" | "warn" | "error";
@@ -317,7 +316,7 @@ export interface components {
       taskIndex?: number | null;
     };
     JobLogMessageCollection: {
-      data: components["schemas"]["JobLogMessage"][];
+      data: (components["schemas"]["JobLogMessage"])[];
       hasMore: boolean;
     };
     JsonFormat: {
@@ -337,7 +336,7 @@ export interface components {
     };
     MetricGroup: {
       name: components["schemas"]["MetricName"];
-      subtasks: components["schemas"]["SubtaskMetrics"][];
+      subtasks: (components["schemas"]["SubtaskMetrics"])[];
     };
     /** @enum {string} */
     MetricName: "bytes_recv" | "bytes_sent" | "messages_recv" | "messages_sent" | "backpressure" | "tx_queue_size" | "tx_queue_rem";
@@ -349,18 +348,18 @@ export interface components {
       /** Format: int64 */
       bytes: number;
       operatorId: string;
-      subtasks: components["schemas"]["SubtaskCheckpointGroup"][];
+      subtasks: (components["schemas"]["SubtaskCheckpointGroup"])[];
     };
     OperatorCheckpointGroupCollection: {
-      data: components["schemas"]["OperatorCheckpointGroup"][];
+      data: (components["schemas"]["OperatorCheckpointGroup"])[];
     };
     OperatorMetricGroup: {
-      metricGroups: components["schemas"]["MetricGroup"][];
+      metricGroups: (components["schemas"]["MetricGroup"])[];
       /** Format: int32 */
       nodeId: number;
     };
     OperatorMetricGroupCollection: {
-      data: components["schemas"]["OperatorMetricGroup"][];
+      data: (components["schemas"]["OperatorMetricGroup"])[];
     };
     OutputData: {
       batch: string;
@@ -369,7 +368,7 @@ export interface components {
       startId: number;
       /** Format: int32 */
       subtaskIdx: number;
-      timestamps: number[];
+      timestamps: (number)[];
     };
     PaginationQueryParams: {
       /** Format: int32 */
@@ -391,10 +390,10 @@ export interface components {
       preview: boolean;
       query: string;
       stop: components["schemas"]["StopType"];
-      udfs: components["schemas"]["Udf"][];
+      udfs: (components["schemas"]["Udf"])[];
     };
     PipelineCollection: {
-      data: components["schemas"]["Pipeline"][];
+      data: (components["schemas"]["Pipeline"])[];
       hasMore: boolean;
     };
     PipelineEdge: {
@@ -407,8 +406,8 @@ export interface components {
       valueType: string;
     };
     PipelineGraph: {
-      edges: components["schemas"]["PipelineEdge"][];
-      nodes: components["schemas"]["PipelineNode"][];
+      edges: (components["schemas"]["PipelineEdge"])[];
+      nodes: (components["schemas"]["PipelineNode"])[];
     };
     PipelineNode: {
       description: string;
@@ -432,7 +431,7 @@ export interface components {
       /** Format: int64 */
       parallelism: number;
       query: string;
-      udfs?: components["schemas"]["Udf"][] | null;
+      udfs?: (components["schemas"]["Udf"])[] | null;
     };
     PipelineRestart: {
       force?: boolean | null;
@@ -440,7 +439,7 @@ export interface components {
     PreviewPost: {
       enableSinks?: boolean;
       query: string;
-      udfs?: components["schemas"]["Udf"][] | null;
+      udfs?: (components["schemas"]["Udf"])[] | null;
     };
     /** @enum {string} */
     PrimitiveType: "Int32" | "Int64" | "UInt32" | "UInt64" | "F32" | "F64" | "Bool" | "String" | "Bytes" | "UnixMillis" | "UnixMicros" | "UnixNanos" | "DateTime" | "Json";
@@ -453,7 +452,7 @@ export interface components {
       messageName?: string | null;
     };
     QueryValidationResult: {
-      errors: string[];
+      errors: (string)[];
       graph?: components["schemas"]["PipelineGraph"] | null;
     };
     RawBytesFormat: Record<string, never>;
@@ -463,7 +462,7 @@ export interface components {
     }, {
       protobuf_schema: {
         dependencies?: {
-          [key: string]: string;
+          [key: string]: string | undefined;
         };
         schema: string;
       };
@@ -485,20 +484,20 @@ export interface components {
     /** @enum {string} */
     StopType: "none" | "checkpoint" | "graceful" | "immediate" | "force";
     StructType: {
-      fields: components["schemas"]["SourceField"][];
+      fields: (components["schemas"]["SourceField"])[];
       name?: string | null;
     };
     SubtaskCheckpointGroup: {
       /** Format: int64 */
       bytes: number;
-      eventSpans: components["schemas"]["CheckpointEventSpan"][];
+      eventSpans: (components["schemas"]["CheckpointEventSpan"])[];
       /** Format: int32 */
       index: number;
     };
     SubtaskMetrics: {
       /** Format: int32 */
       index: number;
-      metrics: components["schemas"]["Metric"][];
+      metrics: (components["schemas"]["Metric"])[];
     };
     TestSourceMessage: {
       done: boolean;
@@ -520,12 +519,12 @@ export interface components {
       prefix: string;
     };
     UdfValidationResult: {
-      errors: string[];
+      errors: (string)[];
       udfName?: string | null;
     };
     ValidateQueryPost: {
       query: string;
-      udfs?: components["schemas"]["Udf"][] | null;
+      udfs?: (components["schemas"]["Udf"])[] | null;
     };
     ValidateUdfPost: {
       definition: string;
@@ -538,8 +537,6 @@ export interface components {
   headers: never;
   pathItems: never;
 }
-
-export type $defs = Record<string, never>;
 
 export type external = Record<string, never>;
 
@@ -598,9 +595,7 @@ export interface operations {
     };
     responses: {
       /** @description Deleted connection profile */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** Get autocomplete suggestions for a connection profile */
@@ -662,9 +657,7 @@ export interface operations {
     };
     responses: {
       /** @description Schema is valid */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** Test a Connection Table */
@@ -676,9 +669,7 @@ export interface operations {
     };
     responses: {
       /** @description Job output as 'text/event-stream' */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** Delete a Connection Table */
@@ -691,9 +682,7 @@ export interface operations {
     };
     responses: {
       /** @description Deleted connection table */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** List all connectors */
@@ -722,9 +711,7 @@ export interface operations {
   ping: {
     responses: {
       /** @description Ping endpoint */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** List all pipelines */
@@ -745,7 +732,7 @@ export interface operations {
     };
   };
   /**
-   * Create a new pipeline
+   * Create a new pipeline 
    * @description The API will create a single job for the pipeline.
    */
   create_pipeline: {
@@ -834,9 +821,7 @@ export interface operations {
     };
     responses: {
       /** @description Deleted pipeline */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** Update a pipeline */
@@ -996,9 +981,7 @@ export interface operations {
     };
     responses: {
       /** @description Job output as 'text/event-stream' */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
   /** Get Global UDFs */
@@ -1054,9 +1037,7 @@ export interface operations {
     };
     responses: {
       /** @description Deleted UDF */
-      200: {
-        content: never;
-      };
+      200: never;
     };
   };
 }

--- a/webui/src/routes/connections/SchemaEditor.tsx
+++ b/webui/src/routes/connections/SchemaEditor.tsx
@@ -142,9 +142,7 @@ export function SchemaEditor({
             >
               Length delimited
             </Checkbox>
-            <FormHelperText>
-              Use length delimited decoding for the protobuf message
-            </FormHelperText>
+            <FormHelperText>Use length delimited decoding for the protobuf message</FormHelperText>
           </FormControl>
         </Box>
         <Box maxW={'lg'}>

--- a/webui/src/routes/connections/SchemaEditor.tsx
+++ b/webui/src/routes/connections/SchemaEditor.tsx
@@ -37,6 +37,7 @@ export function SchemaEditor({
   const [tested, setTested] = useState<string | undefined>();
   const [rawDatum, setRawDatum] = useState<boolean>(false);
   const [messageName, setMessageName] = useState<string>('');
+  const [lengthDelimited, setLengthDelimited] = useState<boolean>(false);
 
   const valid = tested == editor?.getValue() && errors?.length == 0;
 
@@ -56,6 +57,8 @@ export function SchemaEditor({
     if (format == 'protobuf') {
       // @ts-ignore
       state.schema!.format['protobuf']!.messageName = messageName;
+      // @ts-ignore
+      state.schema!.format['protobuf']!.lengthDelimited = lengthDelimited;
       // update the state
       setState({
         ...state,
@@ -128,21 +131,38 @@ export function SchemaEditor({
 
   if (format == 'protobuf') {
     formatOptions = (
-      <Box maxW={'lg'}>
-        <FormControl>
-          <FormLabel>Message name</FormLabel>
-          <Input
-            value={messageName}
-            onChange={e => {
-              console.log('message name', e.target.value);
-              setMessageName(e.target.value);
-            }}
-          />
-          <FormHelperText>
-            The name of the protobuf message for the data in this table
-          </FormHelperText>
-        </FormControl>
-      </Box>
+      <>
+        <Box maxW={'lg'}>
+          <FormControl>
+            <Checkbox
+              onChange={e => {
+                setLengthDelimited(e.target.checked);
+              }}
+              isChecked={lengthDelimited}
+            >
+              Length delimited
+            </Checkbox>
+            <FormHelperText>
+              Use length delimited decoding for the protobuf message
+            </FormHelperText>
+          </FormControl>
+        </Box>
+        <Box maxW={'lg'}>
+          <FormControl>
+            <FormLabel>Message name</FormLabel>
+            <Input
+              value={messageName}
+              onChange={e => {
+                console.log('message name', e.target.value);
+                setMessageName(e.target.value);
+              }}
+            />
+            <FormHelperText>
+              The name of the protobuf message for the data in this table
+            </FormHelperText>
+          </FormControl>
+        </Box>
+      </>
     );
   }
 


### PR DESCRIPTION
Hi,

I tried to read protobuf messages with a length-delimited prefix, and I got the following error:

![Screenshot 2025-04-28 121948](https://github.com/user-attachments/assets/199680a4-23df-4246-b223-8078d2874df4)

To fix the problem I think it is necessary to add a new field to the schema configuration to determine whether the producer sends messages with a length-delimited prefix or not:

![Screenshot 2025-04-28 121741](https://github.com/user-attachments/assets/8efe091b-80d4-4719-bfba-27926c0a71ed)

---

My topic listens to messages sent by GoFlow, this is my docker-compose.yml (I added nflow-generator for the demo):

```yaml
services:
  kafka:
    image: bitnami/kafka:4.0.0
    restart: always
    ports:
      - "9092:9092"
    environment:
      - KAFKA_DELETE_TOPIC_ENABLE=true
      - KAFKA_KRAFT_CLUSTER_ID=AAAAAAAAAAAAAAAAAAAAAA
      - ALLOW_PLAINTEXT_LISTENER=yes
      - KAFKA_ENABLE_KRAFT=yes
      - KAFKA_CFG_NODE_ID=1
      - KAFKA_CFG_BROKER_ID=1
      - KAFKA_CFG_PROCESS_ROLES=broker,controller
      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
      - KAFKA_CFG_LISTENERS=CONTROLLER://localhost:9091,HOST://0.0.0.0:9092,INTERNAL://0.0.0.0:9093
      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,HOST:PLAINTEXT
      - KAFKA_CFG_ADVERTISED_LISTENERS=HOST://127.0.0.1:9092,INTERNAL://kafka:9093
      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:9091

  goflow2:
    image: netsampler/goflow2:latest
    ports:
      - "6343:6343/udp"
      - "2055:2055/udp"
      - "8080:8080"
    restart: always
    command:
      - -transport.kafka.brokers=kafka:9093
      - -transport=kafka
      - -transport.kafka.topic=flows
      - -format=bin
    depends_on:
      - kafka

  nflow-generator:
    image: networkstatic/nflow-generator
    restart: always
    command: -p 2055 -t goflow2
    depends_on:
      - goflow2

  arroyo:
    image: ghcr.io/arroyosystems/arroyo:latest
    restart: always
    ports:
      - "5115:5115"
    depends_on:
      - kafka

```