### PR TITLE
Ensure all non-final multipart uploads in filesystem sink are the same size

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -26,6 +26,8 @@ use self::sink::{
     JsonFileSystemSink, LocalJsonFileSystemSink, LocalParquetFileSystemSink, ParquetFileSystemSink,
 };
 
+const MINIMUM_PART_SIZE: i64 = 5 * 1024 * 1024;
+
 const TABLE_SCHEMA: &str = include_str!("./table.json");
 const ICON: &str = include_str!("./filesystem.svg");
 
@@ -330,6 +332,13 @@ pub fn file_system_sink_from_options(
     let rollover_seconds = opts.pull_opt_i64("rollover_seconds")?;
     let target_file_size = opts.pull_opt_i64("target_file_size")?;
     let target_part_size = opts.pull_opt_i64("target_part_size")?;
+
+    if let Some(target_part_size) = target_part_size {
+        if target_part_size < MINIMUM_PART_SIZE {
+            bail!("target_part_size must be at least {}", MINIMUM_PART_SIZE);
+        }
+    }
+
     let prefix = opts.pull_opt_str("filename.prefix")?;
     let suffix = opts.pull_opt_str("filename.suffix")?;
     let strategy = opts

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -411,14 +411,14 @@ pub fn file_system_sink_from_options(
     ))? {
         Format::Parquet(..) => {
             let compression = opts
-                .pull_opt_str("parquet_compression")?
+                .pull_opt_str("parquet.compression")?
                 .map(|value| {
                     Compression::try_from(&value).map_err(|_err| {
-                        anyhow!("{} is not a valid parquet_compression argument", value)
+                        anyhow!("{} is not a valid parquet.compression argument", value)
                     })
                 })
                 .transpose()?;
-            let row_group_size_bytes = opts.pull_opt_nonzero_u64("parquet_row_group_size_bytes")?;
+            let row_group_size_bytes = opts.pull_opt_nonzero_u64("parquet.row_group_size_bytes")?;
             Some(FormatSettings::Parquet {
                 compression,
                 row_batch_size: None,

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -418,12 +418,12 @@ pub fn file_system_sink_from_options(
                     })
                 })
                 .transpose()?;
-            let row_batch_size = opts.pull_opt_i64("parquet_row_batch_size")?;
-            let row_group_size = opts.pull_opt_i64("parquet_row_group_size")?;
+            let row_group_size_bytes = opts.pull_opt_nonzero_u64("parquet_row_group_size_bytes")?;
             Some(FormatSettings::Parquet {
                 compression,
-                row_batch_size,
-                row_group_size,
+                row_batch_size: None,
+                row_group_size: None,
+                row_group_size_bytes,
             })
         }
         Format::Json(..) => Some(FormatSettings::Json {

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -129,6 +129,7 @@ impl LocalWriter for JsonLocalWriter {
                 representative_timestamp: representitive_timestamp(
                     batch.column(self.schema.timestamp_index),
                 )?,
+                part_size: None,
             });
         } else {
             self.stats.as_mut().unwrap().last_write_at = Instant::now();

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -17,11 +17,7 @@ pub struct JsonWriter {
 }
 
 impl BatchBufferingWriter for JsonWriter {
-    fn new(
-        _: &super::FileSystemTable,
-        format: Option<Format>,
-        _schema: ArroyoSchemaRef,
-    ) -> Self {
+    fn new(_: &super::FileSystemTable, format: Option<Format>, _schema: ArroyoSchemaRef) -> Self {
         Self {
             current_buffer: BytesMut::new(),
             serializer: ArrowSerializer::new(format.expect("should have format")),
@@ -42,7 +38,7 @@ impl BatchBufferingWriter for JsonWriter {
         self.current_buffer.len()
     }
 
-    fn split_at(&mut self, pos: usize) -> Bytes {
+    fn split_to(&mut self, pos: usize) -> Bytes {
         self.current_buffer.split_to(pos).freeze()
     }
 

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -699,6 +699,7 @@ impl RollingPolicy {
 pub struct MultiPartWriterStats {
     bytes_written: usize,
     parts_written: usize,
+    part_size: Option<usize>,
     last_write_at: Instant,
     first_write_at: Instant,
     representative_timestamp: SystemTime,
@@ -1417,6 +1418,7 @@ impl<BBW: BatchBufferingWriter> MultiPartWriter for BatchMultipartWriter<BBW> {
             self.stats = Some(MultiPartWriterStats {
                 bytes_written: 0,
                 parts_written: 0,
+                part_size: None,
                 last_write_at: Instant::now(),
                 first_write_at: Instant::now(),
                 representative_timestamp,

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -19,7 +19,7 @@ use parquet::{
     basic::{GzipLevel, ZstdLevel},
     file::properties::WriterProperties,
 };
-
+use tracing::debug;
 use super::{
     local::{CurrentFileRecovery, FilePreCommit, LocalWriter},
     BatchBufferingWriter, FileSettings, FileSystemTable, MultiPartWriterStats, TableType,
@@ -108,6 +108,9 @@ impl BatchBufferingWriter for RecordBatchBufferingWriter {
         } else {
             5 * 1024 * 1024
         };
+        
+        debug!("target part size = {}", target_part_size);
+        
         let shared_buffer = SharedBuffer::new(target_part_size);
         let writer_properties = writer_properties_from_table(config);
         let writer = ArrowWriter::try_new(
@@ -231,6 +234,7 @@ impl LocalWriter for ParquetLocalWriter {
                 representative_timestamp: representitive_timestamp(
                     batch.column(self.schema.timestamp_index),
                 )?,
+                part_size: None,
             });
         } else {
             self.stats.as_mut().unwrap().last_write_at = Instant::now();

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -150,9 +150,9 @@ impl BatchBufferingWriter for RecordBatchBufferingWriter {
         self.buffer.buffer.lock().unwrap().get_ref().len()
     }
 
-    fn split_at(&mut self, pos: usize) -> Bytes {
+    fn split_to(&mut self, pos: usize) -> Bytes {
         let mut buf = self.buffer.buffer.lock().unwrap();
-        buf.get_mut().split_off(pos).freeze()
+        buf.get_mut().split_to(pos).freeze()
     }
 
     fn get_trailing_bytes_for_checkpoint(&mut self) -> Option<Vec<u8>> {

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -250,7 +250,7 @@ impl LocalWriter for ParquetLocalWriter {
         self.schema.remove_timestamp_column(&mut batch);
         let writer = self.writer.as_mut().unwrap();
         writer.write(&batch)?;
-        if writer.bytes_written() >= self.row_group_size_bytes {
+        if writer.in_progress_size() >= self.row_group_size_bytes {
             writer.flush()?;
         }
         Ok(())

--- a/crates/arroyo-connectors/src/filesystem/table.json
+++ b/crates/arroyo-connectors/src/filesystem/table.json
@@ -123,7 +123,8 @@
                 "targetPartSize": {
                   "title": "Target Part Size",
                   "type": "integer",
-                  "description": "Target size for each part of the multipart upload, in bytes"
+                  "description": "Target size for each part of the multipart upload, in bytes",
+                  "minimum": 5242880
                 },
                 "maxParts": {
                   "title": "Max Parts",

--- a/crates/arroyo-connectors/src/filesystem/table.json
+++ b/crates/arroyo-connectors/src/filesystem/table.json
@@ -81,11 +81,21 @@
                     },
                     "rowBatchSize": {
                       "title": "Row Batch Size",
-                      "type": "integer"
+                      "type": "integer",
+                      "deprecated": true,
+                      "hidden": true
                     },
                     "rowGroupSize": {
                       "title": "Row Group Size",
-                      "type": "integer"
+                      "type": "integer",
+                      "deprecated": true,
+                      "hidden": true
+                    },
+                    "rowGroupSizeBytes": {
+                      "title": "Row Group Bytes",
+                      "type": "integer",
+                      "description": "Target number of bytes for each Parquet Row Group",
+                      "minimum": 1
                     }
                   },
                   "additionalProperties": false

--- a/crates/arroyo-connectors/src/filesystem/table.json
+++ b/crates/arroyo-connectors/src/filesystem/table.json
@@ -82,14 +82,12 @@
                     "rowBatchSize": {
                       "title": "Row Batch Size",
                       "type": "integer",
-                      "deprecated": true,
-                      "hidden": true
+                      "deprecated": true
                     },
                     "rowGroupSize": {
                       "title": "Row Group Size",
                       "type": "integer",
-                      "deprecated": true,
-                      "hidden": true
+                      "deprecated": true
                     },
                     "rowGroupSizeBytes": {
                       "title": "Row Group Bytes",

--- a/crates/arroyo-planner/src/test/queries/analytics_ingest.sql
+++ b/crates/arroyo-planner/src/test/queries/analytics_ingest.sql
@@ -21,7 +21,7 @@ create table account_created_sink with (
     path = 's3://my-s3-bucket/data/account_created',
     format = 'parquet',
     'filename.strategy' = 'uuid',
-    parquet_compression = 'zstd',
+    'parquet.compression' = 'zstd',
     time_partition_pattern = '%Y/%m/%d/%H',
     rollover_seconds = 6000
 );

--- a/crates/arroyo-planner/src/test/queries/filesystem_invalid_partition.sql
+++ b/crates/arroyo-planner/src/test/queries/filesystem_invalid_partition.sql
@@ -30,7 +30,7 @@ create table events_sink (
     path = 's3://my-s3-bucket/data/events',
     format = 'parquet',
     'filename.strategy' = 'uuid',
-    parquet_compression = 'zstd',
+    'parquet.compression' = 'zstd',
     time_partition_pattern = '%Y/%m/%d/%H',
     partition_fields = [type, not_a_real_field],
     rollover_seconds = 6000

--- a/crates/arroyo-planner/src/test/queries/filesystem_partition.sql
+++ b/crates/arroyo-planner/src/test/queries/filesystem_partition.sql
@@ -29,7 +29,7 @@ create table events_sink (
     path = 's3://my-s3-bucket/data/events',
     format = 'parquet',
     'filename.strategy' = 'uuid',
-    parquet_compression = 'zstd',
+    'parquet.compression' = 'zstd',
     time_partition_pattern = '%Y/%m/%d/%H',
     partition_fields = [type, app_version],
     rollover_seconds = 6000

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -28,6 +28,7 @@ use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::num::{NonZero, NonZeroU64};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use std::{fs, time::SystemTime};
@@ -544,6 +545,14 @@ impl ConnectorOptions {
                     e
                 )
             }
+            None => Ok(None),
+        }
+    }
+
+    pub fn pull_opt_nonzero_u64(&mut self, name: &str) -> DFResult<Option<NonZero<u64>>> {
+        match self.pull_opt_u64(name)? {
+            Some(0) => plan_err!("expected with option '{name}' to be greater than 0, but it was 0"),
+            Some(i) => Ok(Some(NonZeroU64::new(i).unwrap())),
             None => Ok(None),
         }
     }

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -551,7 +551,9 @@ impl ConnectorOptions {
 
     pub fn pull_opt_nonzero_u64(&mut self, name: &str) -> DFResult<Option<NonZero<u64>>> {
         match self.pull_opt_u64(name)? {
-            Some(0) => plan_err!("expected with option '{name}' to be greater than 0, but it was 0"),
+            Some(0) => {
+                plan_err!("expected with option '{name}' to be greater than 0, but it was 0")
+            }
             Some(i) => Ok(Some(NonZeroU64::new(i).unwrap())),
             None => Ok(None),
         }

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -591,12 +591,9 @@ impl StorageProvider {
             storage_options: HashMap::new(),
         })
     }
-    
+
     pub fn requires_same_part_sizes(&self) -> bool {
-        match self.config {
-            BackendConfig::R2(_) => true,
-            _ => false,
-        }
+        matches!(self.config, BackendConfig::R2(_))
     }
 
     pub async fn list(
@@ -644,7 +641,7 @@ impl StorageProvider {
 
         Ok(bytes)
     }
- 
+
     pub async fn get_if_present(
         &self,
         path: impl Into<Path>,
@@ -773,8 +770,12 @@ impl StorageProvider {
         let id = storage_retry!(self.get_multipart().create_multipart(path).await)
             .map_err(Into::<StorageError>::into)?;
 
-        debug!(message = "started multipart upload", path=path.as_ref(), id=id.as_str());
-        
+        debug!(
+            message = "started multipart upload",
+            path = path.as_ref(),
+            id = id.as_str()
+        );
+
         Ok(id)
     }
 
@@ -791,9 +792,15 @@ impl StorageProvider {
                 .await
         )
         .map_err(Into::<StorageError>::into)?;
-        
-        debug!(message = "added part", path=path.as_ref(), id=multipart_id.as_str(), part_number, size=bytes.len());
-        
+
+        debug!(
+            message = "added part",
+            path = path.as_ref(),
+            id = multipart_id.as_str(),
+            part_number,
+            size = bytes.len()
+        );
+
         Ok(part_id)
     }
 
@@ -803,8 +810,13 @@ impl StorageProvider {
         multipart_id: &MultipartId,
         parts: Vec<PartId>,
     ) -> Result<(), StorageError> {
-        debug!(message = "closing multipart", path=path.as_ref(), id=multipart_id.as_str(), parts=parts.len());
-        
+        debug!(
+            message = "closing multipart",
+            path = path.as_ref(),
+            id = multipart_id.as_str(),
+            parts = parts.len()
+        );
+
         storage_retry!(
             self.get_multipart()
                 .complete_multipart(path, multipart_id, parts.clone())


### PR DESCRIPTION
R2 requires that all parts of a multipart upload (aside from the last one) be the same size. This PR changes how the pieces of the FilesystemSink work together to meet that requirement, while also simplifying the logic around multipart handling.

The FilesystemSink has a few major traits, which each have several implementations to abstract over json/parquet and object store/local filesystem:

* BatchBufferingWriter, which handles the construction and buffering of a particular format (parquet or json)
* BatchMultipartWriter, which coordinates the multipart writing process
* MultipartManager, which manages a single multipart upload

Previously, the BatchBufferingWriters were "multipart aware"—they were responsible for deciding when to break up a batch into a new multipart write. For parquet, this would happen in the following process:

1. A batch gets inserted into the ArrowWriter (which converts Arrow to parquet)
2. If the batch exceeds the maximum number of rows for a row group, the ArrowWriter would flush the bytes for the row group into a buffer
3. If the buffer exceeds the max part size, the BatchBufferingWriter would return all of those bytes to the BatchMultipartWriter to write

This PR changes the responsibilities such that it's more cleanly layered. The BatchBufferingWriter is now responsible only for converting its format and buffering, and has no awareness of multipart uploads. The BatchMultipartWriter decides when and how much to upload for a particular part. The new process is:

1. A batch gets inserted into the ArrowWriter (which converts Arrow to parquet)
2. If the row group is now larger than the configured row_group_size_bytes, we flush it to our buffer
3. The BatchMultipartManager checks the size of the buffer
    a. If we don't have an active multipart upload, we check if the buffer is larger than our desired multipart upload size
    b. If we do have one, we check if it's larger than the actual multipart upload size for this upload
4. If the appropriate condition is matched, we instruct the BatchBufferingWriter to split its buffer at the desired point, and upload that using the MultipartManager

A bit of additional complexity comes in once we're ready to finish the multipart upload, as we need to ensure that the final part is smaller than our part size. Before sending the last part we check if that's the case, and if not we split it into two parts.

In addition to the functional changes, there are also some performance improvements from moving from Vec<u8> to Bytes/BytesMut, which allows us to avoid some copies.

### Breaking changes

This PR also includes some breaking changes to how we configure filesystem options; these are aimed at making the configuration more useful and easier to understand:

* `parquet_row_batch_size` is removed (this was not actually be used anywhere)
* `parquet_row_group_size` is replaced with `parquet.row_group_size_bytes`, as I believe size-based configuration is more useful than row-count base configuration
* `parquet_compression` is renamed `parquet.compression` to match our standard option style

### Testing

These changes were tested against R2 and Minio, with parquet, json, and deltalake. To ensure that checkpointing correctness is unaffected, I used the following query:

```sql
create table impulse with (
    connector = 'impulse',
    event_rate = 500000
);

create table sink with (
    connector = 'filesystem',
    type = 'sink',
    format = 'parquet',
    target_file_size = 268435456,
    rollover_seconds = 120,
    target_part_size = 5242880,
    parquet_compression = 'zstd',
    path = 's3::http://127.0.2.3:9000/test/outputs/consistency3'

);

insert into sink
select counter, sha512(counter), sha256(counter), md5(counter) from impulse;
```

which produces an incrementing counter (along with junk data to run up the file size). While that was running, I stopped/started and randomly kill -9'd the worker and controller processes and allowed it to recover. Then, I verified that the data was consistent with this duckdb query:

```sql
D create table events as SELECT counter FROM read_parquet('s3://test/outputs/consistency/*.parquet');
D select count(*), count(distinct counter), max(counter)+1 from events;
┌─────────────────┬─────────────────────────┬─────────────────┐
│  count_star()   │ count(DISTINCT counter) │  max(counter)   │
│      int64      │          int64          │     uint64      │
├─────────────────┼─────────────────────────┼─────────────────┤
│    62844075     │        62844075         │    62844075     │
│ (62.84 million) │     (62.84 million)     │ (62.84 million) │
└─────────────────┴─────────────────────────┴─────────────────┘
```

which should produce the same number for each (the +1 on the max is due to 0-based indexing on the counter)