### PR TITLE
Fix regression in #827 that caused all sink inputs to be shuffled

### DIFF
--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -720,6 +720,8 @@ fn maybe_add_key_extension_to_sink(plan: LogicalPlan) -> Result<LogicalPlan> {
         })
         .collect::<Result<_>>()?;
 
+    let mut sink = sink.clone();
+    sink.shuffle_inputs = true;
     let node = sink.with_exprs_and_inputs(vec![], inputs)?;
 
     Ok(LogicalPlan::Extension(Extension { node }))
@@ -866,6 +868,7 @@ pub async fn parse_and_get_arrow_program(
                         table.clone(),
                         plan_rewrite.schema().clone(),
                         Arc::new(plan_rewrite),
+                        false,
                     ),
                     Table::MemoryTable { logical_plan, .. } => {
                         if logical_plan.is_some() {
@@ -892,6 +895,7 @@ pub async fn parse_and_get_arrow_program(
                 },
                 plan_rewrite.schema().clone(),
                 Arc::new(plan_rewrite),
+                false,
             ),
         };
         extensions.push(LogicalPlan::Extension(Extension {


### PR DESCRIPTION
#827 introduced infrastructure to allow sink to be planned as [key by] -x-> [sink], in order to support shuffling by partition for the file system sink. This was meant to only introduce a shuffle with that option, however it actually caused a shuffle edge to be added for all sinks. This PR fixes that regression by only adding the shuffle with the key by.