### PR TITLE
Fix race condition in control loop that could cause pipeline starts to be ignored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,6 @@ dependencies = [
  "rabbitmq-stream-client",
  "rand 0.9.0",
  "rdkafka",
- "rdkafka-sys",
  "redis",
  "regex",
  "regress 0.10.3",

--- a/crates/arroyo-api/src/cloud.rs
+++ b/crates/arroyo-api/src/cloud.rs
@@ -1,4 +1,4 @@
-use crate::{rest_utils::ErrorResp, AuthData, OrgMetadata};
+use crate::{rest_utils::ErrorResp, AuthData, OrgMetadata, DEFAULT_ORG};
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
@@ -10,7 +10,7 @@ pub(crate) async fn authenticate(
 ) -> Result<AuthData, ErrorResp> {
     Ok(AuthData {
         user_id: "user".to_string(),
-        organization_id: "org".to_string(),
+        organization_id: DEFAULT_ORG.to_string(),
         role: "admin".to_string(),
         org_metadata: OrgMetadata {
             can_create_programs: true,

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -79,6 +79,8 @@ fn default_kafka_qps() -> u32 {
     10_000
 }
 
+pub const DEFAULT_ORG: &str = "org";
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct OrgMetadata {
     #[serde(default)]

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -47,7 +47,6 @@ regex = "1"
 # Kafka
 aws-msk-iam-sasl-signer = "1.0.0"
 rdkafka = { version = "0.37", features = ["cmake-build", "tracing", "sasl", "ssl-vendored", "zstd"] }
-rdkafka-sys = "4.8.0"
 sasl2-sys = { version = "0.1.22", features = ["vendored"] }
 
 # SSE

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -32,7 +32,10 @@ use std::num::{NonZero, NonZeroU64};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use std::{fs, time::SystemTime};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    oneshot,
+};
 use tonic::{
     metadata::{Ascii, MetadataValue},
     service::Interceptor,
@@ -67,9 +70,9 @@ pub mod grpc {
         tonic::include_file_descriptor_set!("api_descriptor");
 }
 
-static DB_BACKUP_NOTIFIER: OnceLock<Sender<bool>> = OnceLock::new();
+static DB_BACKUP_NOTIFIER: OnceLock<Sender<oneshot::Sender<()>>> = OnceLock::new();
 
-pub fn init_db_notifier() -> Receiver<bool> {
+pub fn init_db_notifier() -> Receiver<oneshot::Sender<()>> {
     let (tx, rx) = channel(1);
     DB_BACKUP_NOTIFIER
         .set(tx)
@@ -77,8 +80,9 @@ pub fn init_db_notifier() -> Receiver<bool> {
     rx
 }
 
-pub fn notify_db() -> Option<()> {
-    DB_BACKUP_NOTIFIER.get()?.try_send(true).ok()
+pub fn notify_db() -> Option<oneshot::Receiver<()>> {
+    let (tx, rx) = oneshot::channel();
+    DB_BACKUP_NOTIFIER.get()?.try_send(tx).ok().map(|_| rx)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR fix a race condition in the controller that could cause configuration updates to be missed.

The potential race worked like this: the run_to_completion loop would read the config at the end of an iteration. If a JobConfig update arrived (via StateMachine::update) after this read but before the execute_state call in the next iteration, the JobContext for that next iteration would be created with the stale config. The StateMachine::update method would send a JobMessage::ConfigUpdate, but the state machine might have already proceeded with an older config.

This is addressed by adding a new Applied or NotApplied status to each configuration read from the database, which allows us to track whether we've started a controller loop with a particular configuration or not, preventing us from missing a configuration update.

