### PR TITLE
Update Rust to 1.87 and fix clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: clippy, rustfmt
-          toolchain: 1.86
+          toolchain: 1.87
       - uses: actions/cache@v4
         with:
           path: |

--- a/crates/arroyo-connectors/src/filesystem/sink/local.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/local.rs
@@ -238,8 +238,10 @@ impl<V: LocalWriter + Send + 'static> TwoPhaseCommitter for LocalFileSystemWrite
         self.commit_state = Some(match self.file_settings.commit_style.unwrap() {
             CommitStyle::DeltaLake => CommitState::DeltaLake {
                 last_version: -1,
-                table: load_or_create_table(&storage_provider, &schema.schema_without_timestamp())
-                    .await?,
+                table: Box::new(
+                    load_or_create_table(&storage_provider, &schema.schema_without_timestamp())
+                        .await?,
+                ),
             },
             CommitStyle::Direct => CommitState::VanillaParquet,
         });

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -447,7 +447,7 @@ struct AsyncMultipartFileSystemWriter<R: MultiPartWriter> {
 pub enum CommitState {
     DeltaLake {
         last_version: i64,
-        table: DeltaTable,
+        table: Box<DeltaTable>,
     },
     VanillaParquet,
 }
@@ -728,8 +728,9 @@ where
         let commit_state = match file_settings.commit_style.unwrap() {
             CommitStyle::DeltaLake => CommitState::DeltaLake {
                 last_version: -1,
-                table: load_or_create_table(&object_store, &schema.schema_without_timestamp())
-                    .await?,
+                table: Box::new(
+                    load_or_create_table(&object_store, &schema.schema_without_timestamp()).await?,
+                ),
             },
             CommitStyle::Direct => CommitState::VanillaParquet,
         };

--- a/crates/arroyo-connectors/src/nexmark/operator.rs
+++ b/crates/arroyo-connectors/src/nexmark/operator.rs
@@ -609,11 +609,7 @@ impl GeneratorConfig {
 
     pub fn next_base0_auction_id(&self, event_id: u64, random: &mut SmallRng) -> u64 {
         let max_auction = self.last_base0_auction_id(event_id);
-        let min_auction = if max_auction < self.configuration.num_inflight_auctions {
-            0
-        } else {
-            max_auction - self.configuration.num_inflight_auctions
-        };
+        let min_auction = max_auction.saturating_sub(self.configuration.num_inflight_auctions);
         random.random_range(min_auction..max_auction + 1 + AUCTION_ID_LEAD)
     }
 

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -60,7 +60,7 @@ impl SourceRewriter<'_> {
                                     name: field.name().to_string(),
                                 }))
                             }
-                            FieldSpec::Virtual { expression, .. } => Some(expression.clone()),
+                            FieldSpec::Virtual { expression, .. } => Some(*expression.clone()),
                         };
                     }
                     None
@@ -121,7 +121,7 @@ impl SourceRewriter<'_> {
                                     name: field.name().to_string(),
                                 }))
                             }
-                            FieldSpec::Virtual { expression, .. } => Some(expression.clone()),
+                            FieldSpec::Virtual { expression, .. } => Some(*expression.clone()),
                         };
                     }
                     None

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -103,7 +103,7 @@ multifield_partial_ord!(
 pub enum FieldSpec {
     Struct(Field),
     Metadata { field: Field, key: String },
-    Virtual { field: Field, expression: Expr },
+    Virtual { field: Field, expression: Box<Expr> },
 }
 
 impl FieldSpec {
@@ -397,7 +397,7 @@ impl ConnectorTable {
 
                 table.fields.push(FieldSpec::Virtual {
                     field: Field::new("__watermark", logical_expr.get_type(&schema)?, false),
-                    expression: logical_expr,
+                    expression: Box::new(logical_expr),
                 });
                 table.watermark_field = Some("__watermark".to_string());
             } else {
@@ -738,7 +738,7 @@ impl Table {
                     } else {
                         Ok(FieldSpec::Virtual {
                             field: struct_field,
-                            expression: df_expr,
+                            expression: Box::new(df_expr),
                         })
                     }
                 } else {

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -81,7 +81,7 @@ impl Debug for QueueNode {
 
 #[derive(Debug)]
 pub enum SubtaskOrQueueNode {
-    SubtaskNode(SubtaskNode),
+    SubtaskNode(Box<SubtaskNode>),
     QueueNode(QueueNode),
 }
 
@@ -143,7 +143,7 @@ impl SubtaskOrQueueNode {
 
     fn unwrap_subtask(self) -> SubtaskNode {
         match self {
-            SubtaskOrQueueNode::SubtaskNode(n) => n,
+            SubtaskOrQueueNode::SubtaskNode(n) => *n,
             SubtaskOrQueueNode::QueueNode(_) => panic!("not subtask node"),
         }
     }
@@ -264,7 +264,7 @@ impl Program {
                 &node.parallelism
             });
             for i in 0..parallelism {
-                physical.add_node(SubtaskOrQueueNode::SubtaskNode(SubtaskNode {
+                physical.add_node(SubtaskOrQueueNode::SubtaskNode(Box::new(SubtaskNode {
                     node_id: node.node_id,
                     subtask_idx: i,
                     parallelism,
@@ -284,7 +284,7 @@ impl Program {
                         registry.clone(),
                     )
                     .await,
-                }));
+                })));
             }
         }
 


### PR DESCRIPTION
Most new lints are about enums with variants of different sizes, one about doing bounds checks before arithmetic which is covered by the saturating methods.