### PR TITLE
Add support for configuring MQTTs max_packet_size

### DIFF
--- a/crates/arroyo-connectors/src/mqtt/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/mod.rs
@@ -75,9 +75,10 @@ impl MqttConnector {
         };
 
         let max_packet_size = options
-            .pull_opt_str("maxPacketSize")?
-            .map(|s| s.parse::<u32>())
-            .transpose()?;
+            .pull_opt_u64("max_packet_size")?
+            .map(|size| size.try_into())
+            .transpose()
+            .map_err(|_| anyhow!("max_packet_size must be <= {}", u32::MAX))?;
 
         Ok(MqttConfig {
             url,

--- a/crates/arroyo-connectors/src/mqtt/profile.json
+++ b/crates/arroyo-connectors/src/mqtt/profile.json
@@ -48,7 +48,7 @@
       "description": "The password for your mqtt cluster (if using auth)",
       "format": "var-str"
     },
-    "max_packet_size": {
+    "maxPacketSize": {
       "title": "Max Packet Size",
       "type": "integer",
       "description": "Maximum size for MQTT packets in bytes. Defaults to 10240.",

--- a/crates/arroyo-connectors/src/mqtt/profile.json
+++ b/crates/arroyo-connectors/src/mqtt/profile.json
@@ -48,7 +48,7 @@
       "description": "The password for your mqtt cluster (if using auth)",
       "format": "var-str"
     },
-    "maxPacketSize": {
+    "max_packet_size": {
       "title": "Max Packet Size",
       "type": "integer",
       "description": "Maximum size for MQTT packets in bytes. Defaults to 10240.",

--- a/crates/arroyo-connectors/src/mqtt/profile.json
+++ b/crates/arroyo-connectors/src/mqtt/profile.json
@@ -47,6 +47,13 @@
       "type": "string",
       "description": "The password for your mqtt cluster (if using auth)",
       "format": "var-str"
+    },
+    "maxPacketSize": {
+      "title": "Max Packet Size",
+      "type": "integer",
+      "description": "Maximum size for MQTT packets in bytes. Defaults to 10240.",
+      "minimum": 0,
+      "maximum": 4294967295
     }
   },
   "sensitive": ["password"],

--- a/crates/arroyo-connectors/src/mqtt/sink/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/test.rs
@@ -55,6 +55,7 @@ impl MqttTopicTester {
                 cert: self.cert.as_ref().map(|ca| VarStr::new(ca.clone())),
                 key: self.key.as_ref().map(|ca| VarStr::new(ca.clone())),
             }),
+            max_packet_size: None,
         }
     }
 

--- a/crates/arroyo-connectors/src/mqtt/source/test.rs
+++ b/crates/arroyo-connectors/src/mqtt/source/test.rs
@@ -96,6 +96,7 @@ impl MqttTopicTester {
                 cert: self.cert.as_ref().map(|ca| VarStr::new(ca.clone())),
                 key: self.key.as_ref().map(|ca| VarStr::new(ca.clone())),
             }),
+            max_packet_size: None,
         }
     }
 


### PR DESCRIPTION
When using the MQTT sink for records containing a lot of data, Arroyo errors with
```
ERROR arroyo_connectors::mqtt::sink: Failed to poll mqtt eventloop: MqttState(OutgoingPacketTooLarge { pkt_size: 25546, max: 10240 })
```

Currently, it is impossible to increase the max value. This PR adds the `maxPacketSize` configuration option to the MQTT sink that allows the user to set the `max_packet_size` on the underlying rumqttc client, resolving the issue.