### PR TITLE
Allow running the webui on a non-root path

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" href="/icon.png" type="image/png" />
     <title>Arroyo Console</title>
     <script>
+      window.__ARROYO_BASENAME = "{{BASENAME}}" === "{{" + "BASENAME}}" ? "/" : "{{BASENAME}}";
       const clusterId = "{{CLUSTER_ID}}";
       const disableTelemetry = ("{{DISABLE_TELEMETRY}}" == "true" || "{{DISABLE_TELEMETRY}}" == "{{" + "DISABLE_TELEMETRY" + "}}");
 

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -35,7 +35,9 @@ export type GlobalUdf = schemas['GlobalUdf'];
 export type PipelineLocalUdf = schemas['Udf'];
 export type UdfValidationResult = schemas['UdfValidationResult'];
 
-const BASE_URL = '/api';
+const base = window.__ARROYO_BASENAME.replace(/\/$/, '') || '';
+const BASE_URL = `${base}/api`;
+
 export const { get, post, patch, del } = createClient<paths>({ baseUrl: BASE_URL });
 
 const processResponse = (data: any | undefined, error: any | undefined) => {

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -7,6 +7,12 @@ import '@fontsource/inter/variable.css';
 import { modalTheme, popoverTheme, tabsTheme } from './theming';
 import { createRoot } from './lib/CloudComponents';
 
+declare global {
+  interface Window {
+    __ARROYO_BASENAME: string;
+  }
+}
+
 const config: ThemeConfig = {
   initialColorMode: 'dark',
   useSystemColorMode: false,

--- a/webui/src/router.tsx
+++ b/webui/src/router.tsx
@@ -50,13 +50,18 @@ export function Router(): JSX.Element {
 
   addCloudRoutes(routes);
 
-  let router = createBrowserRouter([
+  let router = createBrowserRouter(
+    [
+      {
+        path: '/',
+        element: App(),
+        children: routes,
+      },
+    ],
     {
-      path: '/',
-      element: App(),
-      children: routes,
-    },
-  ]);
+      basename: window.__ARROYO_BASENAME,
+    }
+  );
 
   let orgSetup = needsOrgSetup();
   if (orgSetup) {


### PR DESCRIPTION
This PR allows running the web ui on a non-base path (i.e., on paths other than `/`). This enables it to be run behind a proxy that can root it at an arbitrary subpath. In order to communicate the basename, the proxy must set the `x-arroyo-basename` header.

Here's an example Caddy configuration that shows how to set this up:

```Caddyfile
localhost:8080

@arroyo {
    path_regexp arroyo ^(/admin/pipelines/[^/]+/arroyo)(?:/.*)?$
}

handle @arroyo {
    uri strip_prefix {http.regexp.arroyo.1}

    reverse_proxy 127.0.0.1:5115 {
        header_up X-Arroyo-Basename {http.regexp.arroyo.1}
    }
}

handle {
    reverse_proxy 127.0.0.1:5115
}
```