### PR TITLE
checkpoint_timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "parquet",
  "prometheus",
  "prost",
+ "serde",
  "tokio",
  "tracing",
 ]

--- a/crates/arroyo-api/migrations/V25__add_checkpoint_events.sql
+++ b/crates/arroyo-api/migrations/V25__add_checkpoint_events.sql
@@ -1,0 +1,1 @@
+alter table checkpoints add column event_spans JSONB DEFAULT '[]' NOT NULL;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -236,7 +236,7 @@ WHERE job_configs.organization_id = :organization_id AND job_configs.id = :job_i
 --: DbCheckpoint (finish_time?, operators?)
 
 --! get_job_checkpoints: DbCheckpoint
-SELECT epoch, state_backend, start_time, finish_time, operators FROM checkpoints
+SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints
 JOIN job_configs ON checkpoints.job_id = job_configs.id
 WHERE job_configs.id = :job_id
     AND checkpoints.organization_id = :organization_id
@@ -245,7 +245,7 @@ WHERE job_configs.id = :job_id
 ORDER BY epoch;
 
 --! get_job_checkpoint: DbCheckpoint
-SELECT epoch, state_backend, start_time, finish_time, operators FROM checkpoints
+SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints
 JOIN job_configs ON checkpoints.job_id = job_configs.id
 WHERE job_configs.id = :job_id
     AND checkpoints.organization_id = :organization_id
@@ -254,7 +254,7 @@ WHERE job_configs.id = :job_id
     AND checkpoints.pub_id = :checkpoint_pub_id;
 
 --! get_checkpoint_details: (finish_time?, operators?)
-SELECT epoch, state_backend, start_time, finish_time, operators FROM checkpoints
+SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints
 WHERE job_id = :job_id
     AND organization_id = :organization_id
     AND epoch = :epoch

--- a/crates/arroyo-api/sqlite_migrations/V3__add_checkpoint_events.sql
+++ b/crates/arroyo-api/sqlite_migrations/V3__add_checkpoint_events.sql
@@ -1,0 +1,1 @@
+alter table checkpoints add column event_spans TEXT DEFAULT '[]' NOT NULL;

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -324,7 +324,6 @@ impl IntoResponse for HttpError {
         NewlineDelimitedFraming,
         PaginationQueryParams,
         CheckpointEventSpan,
-        CheckpointSpanType,
         OperatorCheckpointGroupCollection,
         SubtaskCheckpointGroup,
         OperatorCheckpointGroup,

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -59,14 +59,16 @@ UPDATE checkpoints
 SET
     operators = :operators,
     finish_time = :finish_time,
-    state = :state
+    state = :state,
+    event_spans = :event_spans
 WHERE pub_id = :pub_id;
 
 --! commit_checkpoint
 UPDATE checkpoints
 SET
     finish_time = :finish_time,
-    state = 'ready'
+    state = 'ready',
+    event_spans = :event_spans
 WHERE pub_id = :pub_id;
 
 --! mark_compacting

--- a/crates/arroyo-rpc/proto/api.proto
+++ b/crates/arroyo-rpc/proto/api.proto
@@ -229,7 +229,7 @@ message ArroyoExecNode {
 enum TaskCheckpointEventType {
   ALIGNMENT_STARTED = 0;
   CHECKPOINT_STARTED = 1;
-  CHECKPOINT_OPERATOR_FINISHED = 2;
+  CHECKPOINT_OPERATOR_SETUP_FINISHED = 2;
   CHECKPOINT_SYNC_FINISHED = 3;
   CHECKPOINT_PRE_COMMIT = 4;
 }
@@ -252,6 +252,7 @@ message OperatorCheckpointDetail {
   uint64 start_time = 2;
   optional uint64 finish_time = 3;
   bool has_state = 4;
+  optional uint64 started_metadata_write = 6;
   map<uint32, TaskCheckpointDetail> tasks = 5;
 }
 

--- a/crates/arroyo-rpc/src/api_types/checkpoints.rs
+++ b/crates/arroyo-rpc/src/api_types/checkpoints.rs
@@ -1,4 +1,6 @@
+use arroyo_types::to_micros;
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -8,15 +10,7 @@ pub struct Checkpoint {
     pub backend: String,
     pub start_time: u64,
     pub finish_time: Option<u64>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum CheckpointSpanType {
-    Alignment,
-    Sync,
-    Async,
-    Committing,
+    pub events: Vec<CheckpointEventSpan>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -24,7 +18,7 @@ pub enum CheckpointSpanType {
 pub struct CheckpointEventSpan {
     pub start_time: u64,
     pub finish_time: u64,
-    pub span_type: CheckpointSpanType,
+    pub event: String,
     pub description: String,
 }
 
@@ -41,5 +35,63 @@ pub struct SubtaskCheckpointGroup {
 pub struct OperatorCheckpointGroup {
     pub operator_id: String,
     pub bytes: u64,
+    pub started_metadata_write: Option<u64>,
+    pub finish_time: Option<u64>,
     pub subtasks: Vec<SubtaskCheckpointGroup>,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum JobCheckpointEventType {
+    Checkpointing,
+    CheckpointingOperators,
+    WritingMetadata,
+    Compacting,
+    Committing,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobCheckpointSpan {
+    pub event: JobCheckpointEventType,
+    pub start_time: u64,
+    pub finish_time: Option<u64>,
+}
+
+impl JobCheckpointSpan {
+    pub fn now(event: JobCheckpointEventType) -> Self {
+        Self {
+            event,
+            start_time: to_micros(SystemTime::now()),
+            finish_time: None,
+        }
+    }
+
+    pub fn finish(&mut self) {
+        if self.finish_time.is_none() {
+            self.finish_time = Some(to_micros(SystemTime::now()));
+        }
+    }
+}
+
+impl From<JobCheckpointSpan> for CheckpointEventSpan {
+    fn from(value: JobCheckpointSpan) -> Self {
+        let description = match value.event {
+            JobCheckpointEventType::Checkpointing => "The entire checkpointing process",
+            JobCheckpointEventType::CheckpointingOperators => {
+                "The time spent checkpointing operator states"
+            }
+            JobCheckpointEventType::WritingMetadata => "Writing the final checkpoint metadata",
+            JobCheckpointEventType::Compacting => "Compacting old checkpoints",
+            JobCheckpointEventType::Committing => {
+                "Running two-phase commit for transactional connectors"
+            }
+        }
+        .to_string();
+
+        Self {
+            start_time: value.start_time,
+            finish_time: value.finish_time.unwrap_or_default(),
+            event: format!("{:?}", value.event),
+            description,
+        }
+    }
 }

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -176,7 +176,7 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
         }
     }
 
-    checkpoint_state.save_state().await.unwrap();
+    checkpoint_state.write_metadata().await.unwrap();
 
     info!("Smoke test checkpoint completed");
 }

--- a/crates/arroyo-state/Cargo.toml
+++ b/crates/arroyo-state/Cargo.toml
@@ -28,3 +28,4 @@ prost = {workspace = true}
 prometheus = { workspace = true }
 lazy_static = "1.4.0"
 object_store = { workspace = true }
+serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
This PR fixes some issues with how we were calculating checkpoint spans (in particular, a misunderstanding of the confusingly-named "CheckpointOperatorFinished" which refers to the operator-setup phase, not the entirety of operator checkpointing), and also adds additional spans to help us better understand where we're spending time in checkpointing.