### PR TITLE
mTLS and key-based authentication

### DIFF
--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -34,6 +34,7 @@ use crate::rest_utils::{
 };
 use crate::types::public::LogLevel;
 use crate::{queries::api_queries, to_micros, types::public, AuthData};
+use arroyo_rpc::config::config;
 use arroyo_rpc::controller_client;
 use cornucopia_async::DatabaseSource;
 
@@ -452,7 +453,9 @@ pub async fn get_job_output(
     }
     let (tx, rx) = tokio::sync::mpsc::channel(32);
 
-    let mut controller = controller_client().await.map_err(log_and_map)?;
+    let mut controller = controller_client("api", &config().api.tls)
+        .await
+        .map_err(log_and_map)?;
 
     let mut stream = controller
         .subscribe_to_output(Request::new(grpc::rpc::GrpcOutputSubscription {

--- a/crates/arroyo-api/src/metrics.rs
+++ b/crates/arroyo-api/src/metrics.rs
@@ -41,13 +41,17 @@ pub async fn get_operator_metric_groups(
     )
     .await?;
 
-    let channel =
-        arroyo_rpc::connect_grpc(config().controller_endpoint(), &config().controller.tls)
-            .await
-            .map_err(|e| {
-                error!("Failed to connect to controller service: {}", e);
-                service_unavailable("controller-service")
-            })?;
+    let channel = arroyo_rpc::connect_grpc(
+        "api",
+        config().controller_endpoint(),
+        &config().api.tls,
+        &config().controller.tls,
+    )
+    .await
+    .map_err(|e| {
+        error!("Failed to connect to controller service: {}", e);
+        service_unavailable("controller-service")
+    })?;
 
     let mut controller = ControllerGrpcClient::new(channel)
         .accept_compressed(CompressionEncoding::Zstd)

--- a/crates/arroyo-connectors/src/preview/operator.rs
+++ b/crates/arroyo-connectors/src/preview/operator.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use arroyo_operator::context::{Collector, OperatorContext};
 use arroyo_operator::operator::ArrowOperator;
+use arroyo_rpc::config::config;
 use arroyo_rpc::controller_client;
 use arroyo_rpc::grpc::rpc::controller_grpc_client::ControllerGrpcClient;
 use arroyo_rpc::grpc::rpc::{SinkDataReq, TableConfig};
@@ -37,7 +38,7 @@ impl ArrowOperator for PreviewSink {
         self.row = *table.get(&ctx.task_info.task_index).unwrap_or(&0);
 
         self.client = Some(
-            controller_client()
+            controller_client("worker", &config().worker.tls)
                 .await
                 .expect("could not connect to controller"),
         );

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -346,7 +346,13 @@ impl NodeScheduler {
     }
 
     async fn client(node: &NodeStatus) -> anyhow::Result<NodeGrpcClient<Channel>> {
-        let channel = connect_grpc(format!("http://{}", node.addr), &config().node.tls).await?;
+        let channel = connect_grpc(
+            "controller",
+            format!("http://{}", node.addr),
+            &config().controller.tls,
+            &config().node.tls,
+        )
+        .await?;
         Ok(NodeGrpcClient::new(channel))
     }
 

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -119,12 +119,17 @@ async fn handle_worker_connect<'a>(
                 );
 
                 for i in 0..3 {
-                    match grpc_channel_builder(rpc_address.clone(), &config().worker.tls)
-                        .await
-                        .unwrap()
-                        .timeout(Duration::from_secs(90))
-                        .connect()
-                        .await
+                    match grpc_channel_builder(
+                        "controller",
+                        rpc_address.clone(),
+                        &config().controller.tls,
+                        &config().worker.tls,
+                    )
+                    .await
+                    .unwrap()
+                    .timeout(Duration::from_secs(90))
+                    .connect()
+                    .await
                     {
                         Ok(channel) => {
                             {

--- a/crates/arroyo-node/src/lib.rs
+++ b/crates/arroyo-node/src/lib.rs
@@ -310,7 +310,7 @@ pub async fn start_server(guard: ShutdownGuard) -> NodeId {
     guard.into_spawn_task(async move {
         let mut attempts = 0;
         loop {
-            match controller_client().await {
+            match controller_client("node", &config.node.tls).await {
                 Ok(mut controller) => {
                     tokio::time::sleep(Duration::from_millis(1000)).await;
                     controller

--- a/crates/arroyo-server-common/src/tls.rs
+++ b/crates/arroyo-server-common/src/tls.rs
@@ -1,25 +1,82 @@
-use anyhow::{anyhow, Result};
-use arroyo_rpc::config::TlsConfig;
+use anyhow::{anyhow, bail, Result};
+use arroyo_rpc::config::{config, ApiAuthMode, TlsConfig};
 use arroyo_rpc::native_cert_store;
 use axum_server::tls_rustls::RustlsConfig;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
 use rustls::{ClientConfig, RootCertStore, ServerConfig};
 use std::sync::Arc;
-use tonic::transport::{Identity, ServerTlsConfig};
+use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 
 /// Create TLS configuration for Axum HTTP/HTTPS servers
-pub async fn create_http_tls_config(tls_config: &TlsConfig) -> Result<RustlsConfig> {
+pub async fn create_http_tls_config(
+    auth_mode: &ApiAuthMode,
+    tls_config: &Option<TlsConfig>,
+) -> Result<Option<RustlsConfig>> {
+    let config = config();
+    let mut tls_config = config.get_tls_config(tls_config).cloned();
+    let mtls_enabled = match (&mut tls_config, &auth_mode) {
+        (_, ApiAuthMode::None) => false,
+        (Some(tls_config), ApiAuthMode::Mtls { ca_cert_file }) => {
+            tls_config.mtls_ca_file = tls_config
+                .mtls_ca_file
+                .as_ref()
+                .or(ca_cert_file.as_ref())
+                .cloned();
+            true
+        }
+        (None, ApiAuthMode::Mtls { .. }) => {
+            bail!("api.auth_mode set to MTLS, but no TLS config was provided");
+        }
+        (_, ApiAuthMode::StaticApiKey { .. }) => false,
+    };
+
+    let Some(tls_config) = tls_config else {
+        return Ok(None);
+    };
+
     let tls_config = tls_config.load().await?;
 
-    RustlsConfig::from_pem(tls_config.cert, tls_config.key)
-        .await
-        .map_err(|e| anyhow!("Failed to load TLS configuration: {}", e))
+    let cert = CertificateDer::from_pem_slice(&tls_config.cert)?;
+    let key = PrivateKeyDer::from_pem_reader(&tls_config.key[..])?;
+
+    let mtls_ca = if mtls_enabled {
+        tls_config.mtls_ca
+    } else {
+        None
+    };
+
+    let cfg = if let Some(mtls_ca) = mtls_ca {
+        let mut roots = RootCertStore::empty();
+        roots.add_parsable_certificates(CertificateDer::from_pem_slice(&mtls_ca[..]));
+
+        let verifier = WebPkiClientVerifier::builder(roots.into()).build()?;
+
+        ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(vec![cert], key)?
+    } else {
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)?
+    };
+
+    Ok(Some(RustlsConfig::from_config(Arc::new(cfg))))
 }
 
 /// Create TLS configuration for gRPC servers
 pub async fn create_grpc_server_tls_config(tls_config: &TlsConfig) -> Result<ServerTlsConfig> {
     let tls_config = tls_config.load().await?;
 
-    let tls = ServerTlsConfig::new().identity(Identity::from_pem(tls_config.cert, tls_config.key));
+    let mut tls =
+        ServerTlsConfig::new().identity(Identity::from_pem(tls_config.cert, tls_config.key));
+
+    if let Some(cert) = tls_config.mtls_ca {
+        tls = tls
+            .client_auth_optional(false)
+            .client_ca_root(Certificate::from_pem(&cert[..]));
+    }
 
     Ok(tls)
 }
@@ -37,28 +94,54 @@ pub async fn create_tcp_server_tls_config(tls_config: &TlsConfig) -> Result<Serv
         .map_err(|e| anyhow!("Failed to parse private key: {e}"))?
         .ok_or_else(|| anyhow!("No private key found"))?;
 
-    let config = ServerConfig::builder_with_provider(default_provider().into())
-        .with_safe_default_protocol_versions()?
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)?;
+    let config_builder = ServerConfig::builder_with_provider(default_provider().into())
+        .with_safe_default_protocol_versions()?;
+
+    let config = if let Some(mtls_cert) = tls_config.mtls_ca {
+        let mut roots = RootCertStore::empty();
+        roots.add(
+            CertificateDer::from_pem_slice(&mtls_cert)
+                .map_err(|e| anyhow!("invalid mtls ca certificate: {:?}", e))?,
+        )?;
+
+        config_builder
+            .with_client_cert_verifier(WebPkiClientVerifier::builder(roots.into()).build()?)
+            .with_single_cert(cert_chain, key)?
+    } else {
+        config_builder
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key)?
+    };
 
     Ok(config)
 }
 
 /// Create TLS configuration for raw TCP clients (workers)
-pub async fn create_tcp_client_tls_config() -> Result<Arc<ClientConfig>> {
+pub async fn create_tcp_client_tls_config(tls_config: &TlsConfig) -> Result<Arc<ClientConfig>> {
     use rustls::crypto::aws_lc_rs::default_provider;
 
     let mut root_store = RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     root_store.extend((*native_cert_store()).clone().roots);
 
-    let config = ClientConfig::builder_with_provider(default_provider().into())
+    let config_builder = ClientConfig::builder_with_provider(default_provider().into())
         .with_safe_default_protocol_versions()?
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_root_certificates(root_store);
 
-    // TODO: Add support for custom CA certificates and client certificates
+    let config = if tls_config.mtls_ca_file.is_some() {
+        let tls_config = tls_config.load().await?;
+
+        config_builder
+            .with_client_auth_cert(
+                vec![CertificateDer::from_pem_slice(&tls_config.cert)
+                    .map_err(|e| anyhow!("invalid worker TLS cert: {:?}", e))?],
+                PrivateKeyDer::from_pem_slice(&tls_config.key)
+                    .map_err(|e| anyhow!("invalid worker TLS key: {:?}", e))?,
+            )
+            .map_err(|e| anyhow!("failed to construct worker TLS configuration: {:?}", e))?
+    } else {
+        config_builder.with_no_client_auth()
+    };
 
     Ok(Arc::new(config))
 }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -203,7 +203,7 @@ impl WorkerServer {
         let local_addr = listener.local_addr()?;
 
         let mut client = retry!(
-            controller_client().await,
+            controller_client("worker", &config.worker.tls).await,
             2,
             Duration::from_millis(100),
             Duration::from_secs(2),
@@ -282,7 +282,7 @@ impl WorkerServer {
         let cancel_token = self.shutdown_guard.token();
 
         async move {
-            let mut controller = controller_client()
+            let mut controller = controller_client("worker", &config().worker.tls)
                 .await
                 .expect("Unable to connect to controller");
 


### PR DESCRIPTION
This PR adds mTLS authentication for all services, and the ability to set a static Bearer token to product HTTP APIs (the API service and admin service).

mTLS is enabled by setting the global or service-specific `tls.mtls_ca_file` configuration to point to a CA certificate file. 