### PR TITLE
#891 JSON buffering fix when bad data drop is enabled

### DIFF
--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -550,10 +550,10 @@ impl ArrowDeserializer {
     pub fn flush_buffer(&mut self) -> Option<Result<RecordBatch, SourceError>> {
         let (arrays, error_mask) = match self.buffer_decoder.flush(&self.bad_data)? {
             Ok((a, b)) => {
-                // All latest incomplete messages buffered need to be cleared when flush succeeds 
+                // All latest incomplete messages buffered need to be cleared when flush succeeds
                 self.buffered_incomplete.clear();
                 (a, b)
-            },
+            }
             Err(e) => return Some(Err(e)),
         };
 
@@ -632,7 +632,12 @@ impl ArrowDeserializer {
                     }
                 // We have previously buffered incomplete data - combine with current message
                 } else {
-                    let combined_msg: Vec<u8> = self.buffered_incomplete.iter().chain(msg).copied().collect();
+                    let combined_msg: Vec<u8> = self
+                        .buffered_incomplete
+                        .iter()
+                        .chain(msg)
+                        .copied()
+                        .collect();
 
                     match is_complete_json(&combined_msg) {
                         Ok(true) => {
@@ -810,7 +815,7 @@ fn is_complete_json(input: &[u8]) -> Result<bool, serde_json::Error> {
         Ok(_) => {
             de.end()?;
             Ok(true)
-        },
+        }
         Err(e) if e.is_eof() => Ok(false),
         Err(e) => Err(e),
     }


### PR DESCRIPTION
This PR adds improvements to the JSON buffering logic in `ArrowDeserializer`, ensuring better handling of incomplete or invalid JSON inputs, and preserving decoding state across message boundaries.

## 🧩 Key Changes

### ✨ Enhancements:

- Added handling of partial/incomplete JSON messages via `buffered_incomplete` queue.
- Added documentation for `reset_buffer_decoder` and `is_complete_json` functions.

### 🛠 Fixes:

- Fixed the irrecoverable 'invalid JSON' error when bad data drop is enabled by creating an empty BufferDecoder with `reset_buffer_decoder` method when corrupted or poisoned buffer is detected (#891).
- JSON messages are now pre-validated in `is_complete_json` function with serde_json's `deserialize` to prevent them from reaching the tape decoder and remaining as incomplete messages which poisons the buffer (#891).

## 📦 Dependencies
_Unchanged_

## 📝 Notes

> ⚠️ Due to the nature of the arrow_json's `TapeDecoder`, when an invalid JSON message comes in after a previous incomplete message(s), the whole buffer has to be reset. This shouldn't be a problem if flushed frequently.

closes #891 