### PR TITLE
Fix infinite retries in MQTT sink

### DIFF
--- a/crates/arroyo-connectors/src/mqtt/sink/mod.rs
+++ b/crates/arroyo-connectors/src/mqtt/sink/mod.rs
@@ -86,7 +86,7 @@ impl ArrowOperator for MqttSinkFunc {
             };
 
             tokio::time::sleep(Duration::from_millis((50 * (1 << attempts)).min(5_000))).await;
-            attempts -= 1;
+            attempts += 1;
         }
 
         panic!("Failed to establish connection to mqtt after 20 retries");


### PR DESCRIPTION
Currently, there is no limit on the connection attempts of an MQTT sink due to a sign error. This PR fixes the issue.