### PR TITLE
Don't schedule on workers with old run ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1053,6 +1054,7 @@ dependencies = [
  "tonic",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -106,6 +106,9 @@ impl KubernetesScheduler {
                 "name": RUN_ID_ENV, "value": format!("{}", req.run_id),
             },
             {
+                "name": "ARROYO__WORKER__MACHINE_ID", "value": pod_name,
+            },
+            {
                 "name": "ARROYO__WORKER__RPC_PORT", "value": "6900",
             },
             {
@@ -245,7 +248,7 @@ impl Scheduler for KubernetesScheduler {
     async fn stop_workers(
         &self,
         job_id: &str,
-        run_id: Option<i64>,
+        run_id: Option<u64>,
         force: bool,
     ) -> anyhow::Result<()> {
         let api: Api<Pod> = Api::default_namespaced(self.client.as_ref().unwrap().clone());
@@ -286,7 +289,7 @@ impl Scheduler for KubernetesScheduler {
     async fn workers_for_job(
         &self,
         job_id: &str,
-        run_id: Option<i64>,
+        run_id: Option<u64>,
     ) -> anyhow::Result<Vec<WorkerId>> {
         // get the pods associated with the replica set for the given job_id and run_id
         let api: Api<Pod> = Api::default_namespaced(self.client.as_ref().unwrap().clone());

--- a/crates/arroyo-node/Cargo.toml
+++ b/crates/arroyo-node/Cargo.toml
@@ -15,3 +15,4 @@ rand = { workspace = true }
 lazy_static = "1.4.0"
 prometheus = { workspace = true }
 anyhow = "1.0.72"
+uuid = { version =  "1.17.0", features = ["v4"] }

--- a/crates/arroyo-operator/src/operator.rs
+++ b/crates/arroyo-operator/src/operator.rs
@@ -940,7 +940,7 @@ async fn operator_run_behavior(
                                 ).await;
                             }
                             ArrowMessage::Signal(signal) => {
-                                match this.handle_control_message(idx,&signal, &mut counter, &mut closed, in_partitions,
+                                match this.handle_control_message(idx, &signal, &mut counter, &mut closed, in_partitions,
                                     &control_tx, chain_info, collector).await {
                                     ControlOutcome::Continue => {}
                                     ControlOutcome::Stop => {

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -6,14 +6,20 @@ import "api.proto";
 
 // Controller
 
+message WorkerInfo {
+  uint64 worker_id = 1;
+  string job_id = 2;
+  uint64 run_id = 3;
+  string machine_id = 4;
+}
+
+
 message WorkerResources {
   uint64 slots = 1;
 }
 
 message RegisterWorkerReq {
-  uint64 worker_id = 1;
-  uint64 node_id = 2;
-  string job_id = 3;
+  WorkerInfo worker_info = 1;
   string rpc_address = 4;
   string data_address = 5;
   WorkerResources resources = 6;
@@ -109,7 +115,7 @@ message TaskStartedResp {
 }
 
 message RegisterNodeReq {
-  uint64 node_id = 1;
+  string machine_id = 1;
   uint64 task_slots = 2;
   string addr = 3;
 }
@@ -118,7 +124,7 @@ message RegisterNodeResp {
 }
 
 message HeartbeatNodeReq {
-  uint64 node_id = 1;
+  string machine_id = 1;
   uint64 time = 2;
 }
 
@@ -139,10 +145,8 @@ message SinkDataResp {
 }
 
 message WorkerFinishedReq {
-  uint64 node_id = 1;
-  uint64 worker_id = 2;
+  WorkerInfo worker_info = 1;
   uint64 slots = 3;
-  string job_id = 4;
 }
 
 message WorkerFinishedResp {
@@ -410,7 +414,7 @@ message StartWorkerReq {
   string name = 1;
   string job_id = 2;
   uint64 slots = 6;
-  uint64 node_id = 7;
+  string machine_id = 7;
   uint64 run_id = 8;
   map<string, string> env_vars = 10;
 }
@@ -514,9 +518,9 @@ message Quantile {
 }
 
 message Summary {
-  optional uint64   sample_count = 1;
-  optional double   sample_sum   = 2;
-  repeated Quantile quantile     = 3;
+  optional uint64    sample_count = 1;
+  optional double    sample_sum   = 2;
+  repeated Quantile quantile      = 3;
 }
 
 message Untyped {
@@ -535,12 +539,12 @@ message Bucket {
 }
 
 message Metric {
-  repeated LabelPair label        = 1;
-  optional Gauge     gauge        = 2;
-  optional Counter   counter      = 3;
-  optional Summary   summary      = 4;
-  optional Untyped   untyped      = 5;
-  optional Histogram histogram    = 7;
+  repeated LabelPair label       = 1;
+  optional Gauge     gauge       = 2;
+  optional Counter   counter     = 3;
+  optional Summary   summary     = 4;
+  optional Untyped   untyped     = 5;
+  optional Histogram histogram   = 7;
   optional int64     timestamp_ms = 6;
 }
 

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -421,6 +421,10 @@ pub struct WorkerConfig {
     #[serde(default)]
     pub id: Option<u64>,
 
+    /// ID for the machine this worker is running on
+    #[serde(default)]
+    pub machine_id: Option<String>,
+
     /// Name to identify this worker (e.g., e.g., its hostname or a pod name)
     pub name: Option<String>,
 
@@ -436,7 +440,7 @@ pub struct WorkerConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct NodeConfig {
     /// ID for this node
-    pub id: Option<u64>,
+    pub id: Option<String>,
 
     /// Bind address for the node service
     pub bind_address: IpAddr,

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::RangeInclusive;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 // worker configuration
@@ -27,8 +28,14 @@ pub const HASH_SEEDS: [u64; 4] = [
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
 pub struct WorkerId(pub u64);
 
-#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
-pub struct NodeId(pub u64);
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub struct MachineId(pub Arc<String>);
+
+impl Display for MachineId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 pub fn to_millis(time: SystemTime) -> u64 {
     time.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64

--- a/crates/arroyo-worker/Cargo.toml
+++ b/crates/arroyo-worker/Cargo.toml
@@ -31,6 +31,7 @@ bytes = "1.4"
 serde_json = "1.0"
 serde = "1.0"
 ordered-float = "3"
+uuid = { version = "1.17.0", features = ["v4"] }
 
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-schema = {workspace = true, features = ["serde"]}

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -360,7 +360,7 @@ pub struct Engine {
     program: Program,
     worker_id: WorkerId,
     #[allow(unused)]
-    run_id: String,
+    run_id: u64,
     job_id: String,
     network_manager: NetworkManager,
     assignments: HashMap<(u32, usize), TaskAssignment>,
@@ -453,7 +453,7 @@ impl Engine {
         program: Program,
         worker_id: WorkerId,
         job_id: String,
-        run_id: String,
+        run_id: u64,
         network_manager: NetworkManager,
         assignments: Vec<TaskAssignment>,
     ) -> Self {
@@ -503,7 +503,7 @@ impl Engine {
             program,
             worker_id,
             job_id,
-            run_id: "0".to_string(),
+            run_id: 0,
             network_manager: NetworkManager::new(0).await?,
             assignments,
         })


### PR DESCRIPTION
This PR adds run_id (an incrementing integer which identifies a particular run of a job) to the worker -> controller register RPC, and updates the scheduling state to ignore workers with the wrong run id.

This fixes a race condition case in scheduling in the case that a worker container crashes and is restarted. In certain distributed schedulers, this can lead to a sequence:

1. The controller detects the failure of the worker and moves to recovering
2. In Recovering, the controller tears down the existing cluster
3. It moves to Scheduling, and creates a new set of workers
4. The restarted worker comes up, and registers itself
5. The controller tries to schedule tasks on the worker
6. The cluster scheduler finishes tearing down the worker node
7. Scheduling times out

By conditioning scheduling on the worker having the expected run_id, we avoid the mistaken schedule in step 5.

This PR also changes the name of "node_id" (which identifies which server the worker is running on) to "machine_id" to not clash with our _other_ meaning of node_id, which is the dataflow graph vertex that a task is associated with, and changes the type of a string to more usefully identify servers across various platforms (like physical server names or kubernetes pods).