### PR TITLE
Implement a state machine for worker initialization

### DIFF
--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -177,6 +177,34 @@ message WorkerErrorReq {
 message WorkerErrorRes {
 }
 
+enum WorkerPhase {
+  IDLE = 0;
+  INITIALIZING = 1;
+  RUNNING = 2;
+  FAILED = 3;
+}
+
+message GetWorkerPhaseReq {
+  // empty
+}
+
+message GetWorkerPhaseResp {
+  WorkerPhase phase = 1;
+  optional uint64 phase_started_at = 2;  // set for INITIALIZING and FAILED phases
+  optional string error_message = 3;     // only set if phase == FAILED
+}
+
+message WorkerInitializationCompleteReq {
+  uint64 worker_id = 1;
+  string job_id = 2;
+  uint64 time = 3;
+  bool success = 4;
+  optional string error_message = 5;  // only if success == false
+}
+
+message WorkerInitializationCompleteResp {
+}
+
 message JobMetricsReq {
   string job_id = 1;
 }
@@ -199,6 +227,7 @@ service ControllerGrpc {
   rpc SendSinkData(SinkDataReq) returns (SinkDataResp);
   // sent from the node to the controller when a worker process exits
   rpc WorkerFinished(WorkerFinishedReq) returns (WorkerFinishedResp);
+  rpc WorkerInitializationComplete(WorkerInitializationCompleteReq) returns (WorkerInitializationCompleteResp);
 
   rpc SubscribeToOutput(GrpcOutputSubscription) returns (stream OutputData);
   rpc WorkerError(WorkerErrorReq) returns (WorkerErrorRes);
@@ -406,6 +435,7 @@ service WorkerGrpc {
   rpc StopExecution(StopExecutionReq) returns (StopExecutionResp);
   rpc JobFinished(JobFinishedReq) returns (JobFinishedResp);
   rpc GetMetrics(MetricsReq) returns (MetricsResp);
+  rpc GetWorkerPhase(GetWorkerPhaseReq) returns (GetWorkerPhaseResp);
 }
 
 // Node

--- a/crates/arroyo-server-common/src/shutdown.rs
+++ b/crates/arroyo-server-common/src/shutdown.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
+pub use tokio_util::sync::CancellationToken;
 use tonic::async_trait;
 use tracing::{debug, error, info, warn};
 


### PR DESCRIPTION
Currently, worker initialization is kicked off by the controller sending an RPC to the worker. At that point, within the RPC handler, the worker does its initialization process, which can potentially take a while if there are a lot of tasks.

This exacerbated the bug in #914, in which a controller could end up trying to initialize the worker twice, which would fail with a panic the second time due to it being in a partially-initialized state. But it also conceptually is weak: the worker fundamentally exists in multiple states, and RPCs are only valid in certain states.

This PR explicitly models that reality with a state machine. This simplifies the logic around RPC validation. It also makes the initialization process in the worker asynchronous, and marked by the new Initializing state. When completed, the worker transitions to the Running state and notifies the controller.