### PR TITLE
Trace event logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "arrow-array",
  "arrow-ord",
  "arrow-schema",
+ "arroyo-datastream",
  "arroyo-rpc",
  "arroyo-storage",
  "arroyo-types",
@@ -910,6 +911,7 @@ dependencies = [
  "prometheus",
  "prost",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -33,8 +33,7 @@ use arroyo_rpc::formats::Format;
 use arroyo_rpc::grpc::rpc::compiler_grpc_client::CompilerGrpcClient;
 use arroyo_rpc::public_ids::{generate_id, IdTypes};
 use arroyo_rpc::schema_resolver::{ConfluentSchemaRegistry, ConfluentSchemaType};
-use arroyo_rpc::{error_chain, OperatorConfig};
-use arroyo_server_common::log_event;
+use arroyo_rpc::{error_chain, log_event, OperatorConfig};
 use arroyo_udf_host::ParsedUdfFile;
 use prost::Message;
 use serde_json::json;
@@ -438,9 +437,9 @@ pub(crate) async fn create_pipeline_int(
     )
     .await?;
 
-    log_event(
+    log_event!(
         "job_created",
-        json!({
+        {
             "service": "api",
             "is_preview": is_preview,
             "job_id": job_id,
@@ -450,7 +449,7 @@ pub(crate) async fn create_pipeline_int(
             "python_udfs": udfs.iter().any(|e| e.language == UdfLanguage::Python),
             // TODO: program features
             "features": compiled.program.features(),
-        }),
+        }
     );
 
     Ok(pub_id)

--- a/crates/arroyo-api/src/rest_utils.rs
+++ b/crates/arroyo-api/src/rest_utils.rs
@@ -1,5 +1,5 @@
 use crate::{cloud, AuthData};
-use arroyo_server_common::log_event;
+use arroyo_rpc::log_event;
 use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -7,7 +7,6 @@ use axum::Json;
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
-use serde_json::json;
 use tracing::{error, warn};
 
 use cornucopia_async::{DatabaseSource, DbError};
@@ -89,7 +88,7 @@ where
     E: core::fmt::Debug,
 {
     error!("Error while handling: {:?}", err);
-    log_event("api_error", json!({ "error": format!("{:?}", err) }));
+    log_event!("api_error", { "error": format!("{:?}", err) });
     ErrorResp {
         status_code: StatusCode::INTERNAL_SERVER_ERROR,
         message: "Something went wrong".to_string(),

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -1208,9 +1208,9 @@ impl MultipartManager {
             let elapsed = start.elapsed();
 
             if upload_part.is_ok() {
-                log_fs_event(&*task_info, bytes, 0, elapsed, 0);
+                log_fs_event(&task_info, bytes, 0, elapsed, 0);
             } else {
-                log_fs_event(&*task_info, 0, 0, elapsed, 1);
+                log_fs_event(&task_info, 0, 0, elapsed, 1);
             }
 
             Ok(MultipartCallbackWithName {

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -402,7 +402,7 @@ impl RunningJobModel {
             checkpoint_id,
             self.epoch,
             self.min_epoch,
-            self.program.tasks_per_operator(),
+            self.program.clone(),
         );
 
         self.checkpoint_state = Some(CheckpointingOrCommittingState::Checkpointing(state));

--- a/crates/arroyo-datastream/src/logical.rs
+++ b/crates/arroyo-datastream/src/logical.rs
@@ -364,6 +364,27 @@ impl LogicalProgram {
         tasks_per_operator
     }
 
+    pub fn operator_names_by_id(&self) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        for node in self.graph.node_weights() {
+            for op in &node.operator_chain.operators {
+                m.insert(
+                    op.operator_id.clone(),
+                    match op.operator_name {
+                        OperatorName::ConnectorSource | OperatorName::ConnectorSink => {
+                            let c: api::ConnectorOp =
+                                prost::Message::decode(&op.operator_config[..]).unwrap();
+                            c.connector
+                        }
+                        name => name.to_string(),
+                    },
+                );
+            }
+        }
+
+        m
+    }
+
     pub fn tasks_per_node(&self) -> HashMap<u32, usize> {
         let mut tasks_per_node = HashMap::new();
         for node in self.graph.node_weights() {

--- a/crates/arroyo-metrics/src/lib.rs
+++ b/crates/arroyo-metrics/src/lib.rs
@@ -11,6 +11,10 @@ use prometheus::{
     HistogramOpts, IntCounter, IntCounterVec, IntGauge, Opts,
 };
 
+pub const NODE_ID_LABEL: &str = "node_id";
+pub const SUBTASK_IDX_LABEL: &str = "subtask_idx";
+pub const OPERATOR_NAME_LABEL: &str = "operator_name";
+
 pub fn gauge_for_task(
     chain_info: &ChainInfo,
     name: &'static str,
@@ -42,7 +46,7 @@ pub fn histogram_for_task(
 
 lazy_static! {
     pub static ref TASK_METRIC_LABELS: Vec<&'static str> =
-        vec!["node_id", "subtask_idx", "operator_name"];
+        vec![NODE_ID_LABEL, SUBTASK_IDX_LABEL, OPERATOR_NAME_LABEL];
     pub static ref MESSAGE_RECV_COUNTER: IntCounterVec = register_int_counter_vec!(
         MESSAGES_RECV,
         "Count of messages received by this subtask",

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -665,6 +665,15 @@ pub struct HumanReadableDuration {
     original: String,
 }
 
+impl From<Duration> for HumanReadableDuration {
+    fn from(value: Duration) -> Self {
+        Self {
+            duration: value,
+            original: format!("{}ns", value.as_nanos()),
+        }
+    }
+}
+
 impl Deref for HumanReadableDuration {
     type Target = Duration;
 

--- a/crates/arroyo-server-common/Cargo.toml
+++ b/crates/arroyo-server-common/Cargo.toml
@@ -18,7 +18,7 @@ tracing-log = "0.2"
 
 # middleware
 tower = { workspace = true }
-tower-http = {workspace = true, features = ["trace", "fs"]}
+tower-http = {workspace = true, features = ["trace", "fs", "validate-request", "auth"]}
 tonic = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 prometheus = {workspace = true, features = ["process"] }

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -54,8 +54,6 @@ pub const VERSION: &str = "0.15.0-dev";
 static CLUSTER_ID: OnceCell<String> = OnceCell::new();
 
 pub fn init_logging(name: &str) -> Option<WorkerGuard> {
-    init_event_logger(Arc::new(AnalyticsEventLogger::new()));
-
     init_logging_with_filter(
         name,
         EnvFilter::builder()
@@ -82,6 +80,8 @@ macro_rules! register_log {
 }
 
 pub fn init_logging_with_filter(_name: &str, filter: EnvFilter) -> Option<WorkerGuard> {
+    init_event_logger(Arc::new(AnalyticsEventLogger::new()));
+    
     if let Err(e) = LogTracer::init() {
         eprintln!("Failed to initialize log tracer {e:?}");
     }

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -81,7 +81,7 @@ macro_rules! register_log {
 
 pub fn init_logging_with_filter(_name: &str, filter: EnvFilter) -> Option<WorkerGuard> {
     init_event_logger(Arc::new(AnalyticsEventLogger::new()));
-    
+
     if let Err(e) = LogTracer::init() {
         eprintln!("Failed to initialize log tracer {e:?}");
     }

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -5,7 +5,7 @@ pub mod shutdown;
 pub mod tls;
 
 use anyhow::anyhow;
-use arroyo_types::POSTHOG_KEY;
+use arroyo_types::TELEMETRY_KEY;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -17,7 +17,8 @@ use once_cell::sync::OnceCell;
 use profile::handle_get_profile;
 use prometheus::{register_int_counter, Encoder, IntCounter, ProtobufEncoder, TextEncoder};
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{json, Number, Value};
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
 use std::future::Future;
@@ -41,6 +42,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
 use arroyo_rpc::config::{config, ApiAuthMode, LogFormat};
+use arroyo_rpc::{init_event_logger, EventLevel, EventLogger};
 use tracing_appender::non_blocking::{NonBlockingBuilder, WorkerGuard};
 use tracing_log::LogTracer;
 use uuid::Uuid;
@@ -52,6 +54,8 @@ pub const VERSION: &str = "0.15.0-dev";
 static CLUSTER_ID: OnceCell<String> = OnceCell::new();
 
 pub fn init_logging(name: &str) -> Option<WorkerGuard> {
+    init_event_logger(Arc::new(AnalyticsEventLogger::new()));
+
     init_logging_with_filter(
         name,
         EnvFilter::builder()
@@ -173,39 +177,72 @@ pub fn get_cluster_id() -> String {
     CLUSTER_ID.get().map(|s| s.to_string()).unwrap()
 }
 
-pub fn log_event(name: &str, mut props: Value) {
-    static CLIENT: OnceCell<Client> = OnceCell::new();
-    let cluster_id = get_cluster_id();
-    if !config().disable_telemetry {
-        let name = name.to_string();
-        tokio::task::spawn(async move {
-            let client = CLIENT.get_or_init(Client::new);
+pub struct AnalyticsEventLogger {
+    client: Client,
+}
 
-            if let Some(props) = props.as_object_mut() {
-                props.insert("distinct_id".to_string(), Value::String(cluster_id));
-                props.insert("git_sha".to_string(), Value::String(GIT_SHA.to_string()));
-                props.insert("version".to_string(), Value::String(VERSION.to_string()));
-                props.insert(
-                    "build_timestamp".to_string(),
-                    Value::String(BUILD_TIMESTAMP.to_string()),
-                );
-            }
+impl Default for AnalyticsEventLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
-            let obj = json!({
-                "api_key": POSTHOG_KEY,
-                "event": name,
-                "properties": props,
+impl AnalyticsEventLogger {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+}
+
+impl EventLogger for AnalyticsEventLogger {
+    fn log_event(
+        &self,
+        name: &str,
+        mut labels: Value,
+        values: BTreeMap<String, f64>,
+        level: EventLevel,
+    ) {
+        if level != EventLevel::Analytics {
+            return;
+        }
+
+        let cluster_id = get_cluster_id();
+        if !config().disable_telemetry {
+            let name = name.to_string();
+            let client = self.client.clone();
+            tokio::task::spawn(async move {
+                if let Some(props) = labels.as_object_mut() {
+                    props.insert("distinct_id".to_string(), Value::String(cluster_id));
+                    props.insert("git_sha".to_string(), Value::String(GIT_SHA.to_string()));
+                    props.insert("version".to_string(), Value::String(VERSION.to_string()));
+                    props.insert(
+                        "build_timestamp".to_string(),
+                        Value::String(BUILD_TIMESTAMP.to_string()),
+                    );
+                    props.extend(
+                        values
+                            .into_iter()
+                            .filter_map(|(k, v)| Some((k, Value::Number(Number::from_f64(v)?)))),
+                    );
+                }
+
+                let obj = json!({
+                    "api_key": TELEMETRY_KEY,
+                    "event": name,
+                    "properties": labels,
+                });
+
+                if let Err(e) = client
+                    .post("https://events.arroyo.dev/capture")
+                    .json(&obj)
+                    .send()
+                    .await
+                {
+                    debug!("Failed to record event: {}", e);
+                }
             });
-
-            if let Err(e) = client
-                .post("https://events.arroyo.dev/capture")
-                .json(&obj)
-                .send()
-                .await
-            {
-                debug!("Failed to record event: {}", e);
-            }
-        });
+        }
     }
 }
 

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalGraph, LogicalNode, LogicalProgram, OperatorName, ProgramConfig};
+use arroyo_datastream::logical::{
+    LogicalEdge, LogicalEdgeType, LogicalGraph, LogicalNode, LogicalProgram, OperatorName,
+    ProgramConfig,
+};
 use arroyo_planner::{parse_and_get_arrow_program, ArroyoSchemaProvider, SqlConfig};
 use arroyo_state::parquet::ParquetBackend;
 use petgraph::algo::has_path_connecting;
@@ -407,7 +410,13 @@ async fn run_pipeline_and_assert_outputs(
     run_and_checkpoint(
         Arc::new(job_id.to_string()),
         Program::local_from_logical(job_id.to_string(), &graph, udfs, None, control_tx).await,
-        Arc::new(LogicalProgram::new(graph.clone(), ProgramConfig { udf_dylibs: Default::default(), python_udfs: Default::default() })),
+        Arc::new(LogicalProgram::new(
+            graph.clone(),
+            ProgramConfig {
+                udf_dylibs: Default::default(),
+                python_udfs: Default::default(),
+            },
+        )),
         tasks_per_operator(&graph),
         &mut control_rx,
         checkpoint_interval,

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
-use arroyo_datastream::logical::{
-    LogicalEdge, LogicalEdgeType, LogicalGraph, LogicalNode, LogicalProgram, OperatorName,
-};
+use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalGraph, LogicalNode, LogicalProgram, OperatorName, ProgramConfig};
 use arroyo_planner::{parse_and_get_arrow_program, ArroyoSchemaProvider, SqlConfig};
 use arroyo_state::parquet::ParquetBackend;
 use petgraph::algo::has_path_connecting;
@@ -111,7 +109,7 @@ struct SmokeTestContext<'a> {
     job_id: Arc<String>,
     engine: &'a RunningEngine,
     control_rx: &'a mut Receiver<ControlResp>,
-    tasks_per_operator: HashMap<String, usize>,
+    program: Arc<LogicalProgram>,
 }
 
 async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
@@ -121,7 +119,7 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
         checkpoint_id.to_string(),
         epoch,
         0,
-        ctx.tasks_per_operator.clone(),
+        ctx.program.clone(),
     );
 
     // trigger a checkpoint, pass the messages to the CheckpointState
@@ -298,6 +296,7 @@ fn set_internal_parallelism(graph: &mut Graph<LogicalNode, LogicalEdge>, paralle
 async fn run_and_checkpoint(
     job_id: Arc<String>,
     program: Program,
+    logical_program: Arc<LogicalProgram>,
     tasks_per_operator: HashMap<String, usize>,
     control_rx: &mut Receiver<ControlResp>,
     checkpoint_interval: i32,
@@ -316,7 +315,7 @@ async fn run_and_checkpoint(
         job_id: job_id.clone(),
         engine: &running_engine,
         control_rx,
-        tasks_per_operator: tasks_per_operator.clone(),
+        program: logical_program,
     };
 
     // trigger a couple checkpoints
@@ -408,6 +407,7 @@ async fn run_pipeline_and_assert_outputs(
     run_and_checkpoint(
         Arc::new(job_id.to_string()),
         Program::local_from_logical(job_id.to_string(), &graph, udfs, None, control_tx).await,
+        Arc::new(LogicalProgram::new(graph.clone(), ProgramConfig { udf_dylibs: Default::default(), python_udfs: Default::default() })),
         tasks_per_operator(&graph),
         &mut control_rx,
         checkpoint_interval,

--- a/crates/arroyo-state/Cargo.toml
+++ b/crates/arroyo-state/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-storage = { path = "../arroyo-storage" }
+arroyo-datastream = { path = "../arroyo-datastream" }
 
 datafusion = { workspace = true }
 
@@ -29,3 +30,4 @@ prometheus = { workspace = true }
 lazy_static = "1.4.0"
 object_store = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1"

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -542,8 +542,6 @@ impl StorageProvider {
             canonical_url.push_str(key.as_ref());
         }
 
-        println!("ENDPOINT = {endpoint:?}");
-
         builder = builder
             .with_endpoint(endpoint)
             .with_virtual_hosted_style_request(false);

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -15,7 +15,7 @@ pub const JOB_ID_ENV: &str = "JOB_ID";
 pub const RUN_ID_ENV: &str = "RUN_ID";
 
 // telemetry configuration
-pub const POSTHOG_KEY: &str = "phc_ghJo7Aa9QOo4inoWFYZP7o2aKszllEUyH77QeFgznUe";
+pub const TELEMETRY_KEY: &str = "phc_ghJo7Aa9QOo4inoWFYZP7o2aKszllEUyH77QeFgznUe";
 
 // These seeds were randomly generated; changing them will break existing state
 pub const HASH_SEEDS: [u64; 4] = [

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -411,15 +411,15 @@ pub fn raw_schema() -> Schema {
     )])
 }
 
-pub static MESSAGES_RECV: &str = "arroyo_worker_messages_recv";
-pub static MESSAGES_SENT: &str = "arroyo_worker_messages_sent";
-pub static BYTES_RECV: &str = "arroyo_worker_bytes_recv";
-pub static BYTES_SENT: &str = "arroyo_worker_bytes_sent";
-pub static BATCHES_RECV: &str = "arroyo_worker_batches_recv";
-pub static BATCHES_SENT: &str = "arroyo_worker_batches_sent";
-pub static TX_QUEUE_SIZE: &str = "arroyo_worker_tx_queue_size";
-pub static TX_QUEUE_REM: &str = "arroyo_worker_tx_queue_rem";
-pub static DESERIALIZATION_ERRORS: &str = "arroyo_worker_deserialization_errors";
+pub const MESSAGES_RECV: &str = "arroyo_worker_messages_recv";
+pub const MESSAGES_SENT: &str = "arroyo_worker_messages_sent";
+pub const BYTES_RECV: &str = "arroyo_worker_bytes_recv";
+pub const BYTES_SENT: &str = "arroyo_worker_bytes_sent";
+pub const BATCHES_RECV: &str = "arroyo_worker_batches_recv";
+pub const BATCHES_SENT: &str = "arroyo_worker_batches_sent";
+pub const TX_QUEUE_SIZE: &str = "arroyo_worker_tx_queue_size";
+pub const TX_QUEUE_REM: &str = "arroyo_worker_tx_queue_rem";
+pub const DESERIALIZATION_ERRORS: &str = "arroyo_worker_deserialization_errors";
 
 #[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct CheckpointBarrier {

--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -2,16 +2,15 @@ mod run;
 
 use anyhow::{anyhow, bail};
 use arroyo_planner::{ArroyoSchemaProvider, SqlConfig};
-use arroyo_rpc::config;
 use arroyo_rpc::config::{config, DatabaseType};
+use arroyo_rpc::{config, log_event};
 use arroyo_server_common::shutdown::{Shutdown, SignalBehavior};
-use arroyo_server_common::{log_event, start_admin_server};
+use arroyo_server_common::start_admin_server;
 use arroyo_worker::{utils, WorkerServer};
 use clap::{Args, Parser, Subcommand};
 use clio::Input;
 use cornucopia_async::DatabaseSource;
 use deadpool_postgres::{ManagerConfig, Pool, RecyclingMethod};
-use serde_json::json;
 use std::env::temp_dir;
 use std::path::PathBuf;
 use std::process::exit;
@@ -420,12 +419,12 @@ async fn start_control_plane(service: CPService) {
 
     let db = db_source().await;
 
-    log_event(
+    log_event!(
         "service_startup",
-        json!({
+        {
             "service": service.name(),
             "scheduler": config.controller.scheduler,
-        }),
+        }
     );
 
     let shutdown = Shutdown::new(service.name(), SignalBehavior::Handle);

--- a/crates/arroyo/src/run.rs
+++ b/crates/arroyo/src/run.rs
@@ -3,15 +3,14 @@ use anyhow::{anyhow, bail};
 use arroyo_openapi::types::{Pipeline, PipelinePatch, PipelinePost, StopType, ValidateQueryPost};
 use arroyo_openapi::Client;
 use arroyo_rpc::config::{config, DatabaseType, DefaultSink, Scheduler};
+use arroyo_rpc::log_event;
 use arroyo_rpc::{config, init_db_notifier, notify_db, retry};
-use arroyo_server_common::log_event;
 use arroyo_server_common::shutdown::{Shutdown, ShutdownHandler, SignalBehavior};
 use arroyo_storage::StorageProvider;
 use arroyo_types::to_millis;
 use async_trait::async_trait;
 use rand::random;
 use rusqlite::{Connection, DatabaseName, OpenFlags};
-use serde_json::json;
 use std::env;
 use std::env::{set_var, temp_dir};
 use std::path::PathBuf;
@@ -435,7 +434,7 @@ pub async fn run(args: RunArgs) {
 
     // check if this is the correct database for this pipeline
 
-    log_event("pipeline_cluster_start", json!({}));
+    log_event!("pipeline_cluster_start", {});
 
     let controller_port = arroyo_controller::ControllerServer::new(db.clone())
         .await


### PR DESCRIPTION
This PR adds infrastructure for logging trace events. These can be integrated with event-oriented metrics system like Clickhouse to add observability to Arroyo clusters and pipelines.

This PR includes the infrastructure for logging trace events within the source code and adds calls to it in the filesystem sink and checkpoint system.

There is not yet a collector for these events, so they are currently ignored, but that can be added in the future.