### PR TITLE
Add support for Decimal 128 type

### DIFF
--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -327,6 +327,7 @@ impl IntoResponse for HttpError {
         RawStringFormat,
         RawBytesFormat,
         TimestampFormat,
+        DecimalEncoding,
         Framing,
         FramingMethod,
         NewlineDelimitedFraming,

--- a/crates/arroyo-connectors/src/preview/operator.rs
+++ b/crates/arroyo-connectors/src/preview/operator.rs
@@ -70,6 +70,7 @@ impl ArrowOperator for PreviewSink {
             .with_explicit_nulls(true)
             .with_encoder_factory(Arc::new(ArroyoEncoderFactory {
                 timestamp_format: TimestampFormat::RFC3339,
+                decimal_encoding: Default::default(),
             }))
             .build(&mut buf);
 

--- a/crates/arroyo-formats/src/avro/de.rs
+++ b/crates/arroyo-formats/src/avro/de.rs
@@ -134,7 +134,7 @@ mod tests {
     use crate::ser::record_batch_to_vec;
     use arrow_schema::{DataType, Field, Schema, TimeUnit};
     use arroyo_rpc::df::ArroyoSchema;
-    use arroyo_rpc::formats::{AvroFormat, BadData, Format, TimestampFormat};
+    use arroyo_rpc::formats::{AvroFormat, BadData, DecimalEncoding, Format, TimestampFormat};
     use arroyo_rpc::schema_resolver::{FailingSchemaResolver, FixedSchemaResolver, SchemaResolver};
     use serde_json::json;
     use std::sync::Arc;
@@ -276,18 +276,23 @@ mod tests {
 
         let batch = deserializer.flush_buffer().unwrap().unwrap();
 
-        record_batch_to_vec(&batch, true, TimestampFormat::RFC3339)
-            .unwrap()
-            .iter()
-            .map(|b| {
-                serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(b.as_slice())
-                    .unwrap()
-            })
-            .map(|mut f| {
-                f.remove("_timestamp");
-                f
-            })
-            .collect()
+        record_batch_to_vec(
+            &batch,
+            true,
+            TimestampFormat::RFC3339,
+            DecimalEncoding::Bytes,
+        )
+        .unwrap()
+        .iter()
+        .map(|b| {
+            serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(b.as_slice())
+                .unwrap()
+        })
+        .map(|mut f| {
+            f.remove("_timestamp");
+            f
+        })
+        .collect()
     }
 
     #[tokio::test]

--- a/crates/arroyo-formats/src/avro/schema.rs
+++ b/crates/arroyo-formats/src/avro/schema.rs
@@ -100,7 +100,14 @@ fn arrow_to_avro(name: &str, dt: &DataType) -> serde_json::value::Value {
         }
         DataType::Union(_, _) => unimplemented!("unions are not supported"),
         DataType::Dictionary(_, _) => unimplemented!("dictionaries are not supported"),
-        DataType::Decimal128(_, _) => unimplemented!("decimal128 is not supported"),
+        DataType::Decimal128(precision, scale) => {
+            return json!({
+                "types": "bytes",
+                "logicalType": "decimal",
+                "scale": scale,
+                "precision": precision,
+            })
+        }
         DataType::Decimal256(_, _) => unimplemented!("decimal256 is not supported"),
         DataType::Map(_, _) => unimplemented!("maps are not supported"),
         DataType::RunEndEncoded(_, _) => unimplemented!("run end encoded is not supported"),

--- a/crates/arroyo-formats/src/avro/schema.rs
+++ b/crates/arroyo-formats/src/avro/schema.rs
@@ -102,7 +102,7 @@ fn arrow_to_avro(name: &str, dt: &DataType) -> serde_json::value::Value {
         DataType::Dictionary(_, _) => unimplemented!("dictionaries are not supported"),
         DataType::Decimal128(precision, scale) => {
             return json!({
-                "types": "bytes",
+                "type": "bytes",
                 "logicalType": "decimal",
                 "scale": scale,
                 "precision": precision,

--- a/crates/arroyo-formats/src/avro/ser.rs
+++ b/crates/arroyo-formats/src/avro/ser.rs
@@ -131,7 +131,7 @@ fn serialize_column<T: SerializeTarget>(
             write_arrow_value!(
                 ArrayRef::as_primitive::<Decimal128Type>,
                 Value::Decimal,
-                |v: i128| { v.to_be_bytes().try_into().unwrap() }
+                |v: i128| { v.to_be_bytes().into() }
             );
         }
 
@@ -448,7 +448,7 @@ mod tests {
                     ("favorite_color".to_string(), Union(0, Box::new(Null))),
                     (
                         "favorite_decimal".to_string(),
-                        Decimal(apache_avro::Decimal::try_from(100i128.to_be_bytes()).unwrap())
+                        Decimal(apache_avro::Decimal::from(100i128.to_be_bytes()))
                     ),
                     (
                         "address".to_string(),
@@ -489,7 +489,7 @@ mod tests {
                     ),
                     (
                         "favorite_decimal".to_string(),
-                        Decimal(apache_avro::Decimal::try_from(110i128.to_be_bytes()).unwrap())
+                        Decimal(apache_avro::Decimal::from(110i128.to_be_bytes()))
                     ),
                     (
                         "address".to_string(),
@@ -520,7 +520,7 @@ mod tests {
                     ("favorite_color".to_string(), Union(0, Box::new(Null))),
                     (
                         "favorite_decimal".to_string(),
-                        Decimal(apache_avro::Decimal::try_from((-3099i128).to_be_bytes()).unwrap())
+                        Decimal(apache_avro::Decimal::from((-3099i128).to_be_bytes()))
                     ),
                     (
                         "address".to_string(),

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -830,6 +830,7 @@ mod tests {
                 debezium: false,
                 unstructured: false,
                 timestamp_format: Default::default(),
+                decimal_encoding: Default::default(),
             }),
             schema,
             &[],
@@ -965,6 +966,7 @@ mod tests {
                 debezium: false,
                 unstructured: false,
                 timestamp_format: Default::default(),
+                decimal_encoding: Default::default(),
             }),
             arroyo_schema,
             &[

--- a/crates/arroyo-formats/src/json/encoders.rs
+++ b/crates/arroyo-formats/src/json/encoders.rs
@@ -141,7 +141,7 @@ impl Encoder for DecimalEncoder {
             DecimalEncoder::BytesEncoder(array) => {
                 let v = array.value(idx);
                 out.push(b'"');
-                out.extend_from_slice(&BASE64_STANDARD.encode(&v.to_be_bytes()).as_bytes());
+                out.extend_from_slice(BASE64_STANDARD.encode(v.to_be_bytes()).as_bytes());
                 out.push(b'"');
             }
         }

--- a/crates/arroyo-formats/src/json/mod.rs
+++ b/crates/arroyo-formats/src/json/mod.rs
@@ -27,7 +27,8 @@ pub fn field_to_json_schema(field: &Field) -> Value {
         }
         arrow::datatypes::DataType::Float16
         | arrow::datatypes::DataType::Float32
-        | arrow::datatypes::DataType::Float64 => {
+        | arrow::datatypes::DataType::Float64
+        | arrow::datatypes::DataType::Decimal128(_, _) => {
             json! {{ "type": "number" }}
         }
         arrow::datatypes::DataType::Timestamp(_, _) => {
@@ -57,7 +58,6 @@ pub fn field_to_json_schema(field: &Field) -> Value {
         arrow::datatypes::DataType::Struct(s) => arrow_to_json_schema(s),
         arrow::datatypes::DataType::Union(_, _) => todo!(),
         arrow::datatypes::DataType::Dictionary(_, _) => todo!(),
-        arrow::datatypes::DataType::Decimal128(_, _) => todo!(),
         arrow::datatypes::DataType::Decimal256(_, _) => todo!(),
         arrow::datatypes::DataType::Map(_, _) => todo!(),
         arrow::datatypes::DataType::RunEndEncoded(_, _) => todo!(),
@@ -139,7 +139,15 @@ pub fn field_to_kafka_json(field: &Field) -> Value {
         }
         Union(_, _) => todo!(),
         Dictionary(_, _) => todo!(),
-        Decimal128(_, _) => todo!(),
+        Decimal128(_, scale) => {
+            return json! {{
+                "type": "bytes",
+                "field": field.name().clone(),
+                "optional": field.is_nullable(),
+                "name": "org.apache.kafka.connect.data.Decimal",
+                "scale": scale
+            }}
+        }
         Decimal256(_, _) => todo!(),
         Map(_, _) => todo!(),
         RunEndEncoded(_, _) => todo!(),

--- a/crates/arroyo-formats/src/ser.rs
+++ b/crates/arroyo-formats/src/ser.rs
@@ -485,8 +485,7 @@ mod tests {
 
         let event_times: Vec<_> = vs
             .iter()
-            .enumerate()
-            .map(|(_, _)| to_nanos(SystemTime::now()) as i64)
+            .map(|_| to_nanos(SystemTime::now()) as i64)
             .collect();
 
         let schema = Arc::new(Schema::new(vec![

--- a/crates/arroyo-formats/src/ser.rs
+++ b/crates/arroyo-formats/src/ser.rs
@@ -143,7 +143,8 @@ impl ArrowSerializer {
             v
         });
 
-        let rows = record_batch_to_vec(batch, true, json.timestamp_format, json.decimal_encoding).unwrap();
+        let rows =
+            record_batch_to_vec(batch, true, json.timestamp_format, json.decimal_encoding).unwrap();
 
         let include_schema = json.include_schema.then(|| self.kafka_schema.clone());
 
@@ -270,9 +271,11 @@ impl ArrowSerializer {
 #[cfg(test)]
 mod tests {
     use crate::ser::ArrowSerializer;
-    use arrow_array::builder::TimestampNanosecondBuilder;
+    use arrow_array::builder::{Decimal128Builder, TimestampNanosecondBuilder};
     use arrow_schema::{Schema, TimeUnit};
-    use arroyo_rpc::formats::{DecimalEncoding, Format, RawBytesFormat, RawStringFormat, TimestampFormat};
+    use arroyo_rpc::formats::{
+        DecimalEncoding, Format, JsonFormat, RawBytesFormat, RawStringFormat, TimestampFormat,
+    };
     use arroyo_types::to_nanos;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
@@ -458,5 +461,115 @@ mod tests {
         assert_eq!(iter.next().unwrap(), br#"{"value":1612274910045}"#);
         assert_eq!(iter.next().unwrap(), br#"{"value":null}"#);
         assert_eq!(iter.next().unwrap(), br#"{"value":1712274910045}"#);
+    }
+
+    #[test]
+    fn test_json_decimal() {
+        let mut serializer = ArrowSerializer::new(Format::Json(arroyo_rpc::formats::JsonFormat {
+            confluent_schema_registry: false,
+            schema_id: None,
+            include_schema: false,
+            debezium: false,
+            unstructured: false,
+            timestamp_format: TimestampFormat::UnixMillis,
+            decimal_encoding: DecimalEncoding::Number,
+        }));
+
+        let mut decimal_array = Decimal128Builder::new()
+            .with_precision_and_scale(5, 3)
+            .unwrap();
+        decimal_array.append_value(10);
+        decimal_array.append_value(51);
+        decimal_array.append_value(-399);
+        let vs = Arc::new(decimal_array.finish());
+
+        let event_times: Vec<_> = vs
+            .iter()
+            .enumerate()
+            .map(|(_, _)| to_nanos(SystemTime::now()) as i64)
+            .collect();
+
+        let schema = Arc::new(Schema::new(vec![
+            arrow_schema::Field::new("value", arrow_schema::DataType::Decimal128(5, 3), true),
+            arrow_schema::Field::new(
+                "_timestamp",
+                arrow_schema::DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+
+        let batch = arrow_array::RecordBatch::try_new(
+            schema,
+            vec![
+                vs,
+                Arc::new(arrow_array::TimestampNanosecondArray::from(event_times)),
+            ],
+        )
+        .unwrap();
+
+        // number
+        let mut iter = serializer.serialize(&batch);
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":0.010}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":0.051}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":-0.399}"#.to_string()
+        );
+
+        // string
+        match &mut serializer.format {
+            Format::Json(JsonFormat {
+                decimal_encoding, ..
+            }) => {
+                *decimal_encoding = DecimalEncoding::String;
+            }
+            _ => {
+                unreachable!();
+            }
+        }
+        let mut iter = serializer.serialize(&batch);
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"0.010"}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"0.051"}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"-0.399"}"#.to_string()
+        );
+
+        // bytes
+        match &mut serializer.format {
+            Format::Json(JsonFormat {
+                decimal_encoding, ..
+            }) => {
+                *decimal_encoding = DecimalEncoding::Bytes;
+            }
+            _ => {
+                unreachable!();
+            }
+        }
+        let mut iter = serializer.serialize(&batch);
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"AAAAAAAAAAAAAAAAAAAACg=="}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"AAAAAAAAAAAAAAAAAAAAMw=="}"#.to_string()
+        );
+        assert_eq!(
+            String::from_utf8(iter.next().unwrap()).unwrap(),
+            r#"{"value":"///////////////////+cQ=="}"#.to_string()
+        );
     }
 }

--- a/crates/arroyo-operator/src/udfs.rs
+++ b/crates/arroyo-operator/src/udfs.rs
@@ -184,7 +184,7 @@ fn scalar_none(datatype: &DataType) -> ScalarValue {
         DataType::Struct(_) => todo!(),
         DataType::Union(_, _) => todo!(),
         DataType::Dictionary(_, _) => todo!(),
-        DataType::Decimal128(_, _) => todo!(),
+        DataType::Decimal128(precision, scale) => ScalarValue::Decimal128(None, *precision, *scale),
         DataType::Decimal256(_, _) => todo!(),
         DataType::Map(_, _) => todo!(),
         DataType::RunEndEncoded(_, _) => todo!(),

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -53,7 +53,7 @@ impl TryFrom<&str> for DecimalEncoding {
             "number" => Ok(Self::Number),
             "string" => Ok(Self::String),
             "bytes" => Ok(Self::Bytes),
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -31,6 +31,34 @@ impl TryFrom<&str> for TimestampFormat {
 }
 
 #[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, Hash, PartialOrd, ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DecimalEncoding {
+    /// Encode the decimal as a JSON number, possibly losing precision depending on the consumer
+    #[default]
+    Number,
+    /// Encode as a full-precision string
+    String,
+    // Encode as a two's-complement, big-endian unscaled integer binary array, as base64
+    // The scale must be communicated as part of the schema
+    Bytes,
+}
+
+impl TryFrom<&str> for DecimalEncoding {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "number" => Ok(Self::Number),
+            "string" => Ok(Self::String),
+            "bytes" => Ok(Self::Bytes),
+            _ => Err(())
+        }
+    }
+}
+
+#[derive(
     Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, Hash, PartialOrd, ToSchema,
 )]
 #[serde(rename_all = "camelCase")]
@@ -52,6 +80,9 @@ pub struct JsonFormat {
 
     #[serde(default)]
     pub timestamp_format: TimestampFormat,
+
+    #[serde(default)]
+    pub decimal_encoding: DecimalEncoding,
 }
 
 impl JsonFormat {
@@ -81,6 +112,19 @@ impl JsonFormat {
                 }
             });
 
+        let decimal_encoding: DecimalEncoding = opts
+            .pull_opt_str("json.decimal_encoding")?
+            .map(|t| t.as_str().try_into())
+            .transpose()
+            .map_err(|_| plan_datafusion_err!("invalid value for `json.decimal_encoding`"))?
+            .unwrap_or_else(|| {
+                if debezium {
+                    DecimalEncoding::Bytes
+                } else {
+                    DecimalEncoding::default()
+                }
+            });
+
         Ok(Self {
             confluent_schema_registry,
             schema_id: None,
@@ -88,6 +132,7 @@ impl JsonFormat {
             debezium,
             unstructured,
             timestamp_format,
+            decimal_encoding,
         })
     }
 }


### PR DESCRIPTION
This has become more necessary because of improved promotion rules in DF 48, in particular relating to math between BIGINT UNSIGNED and BIGINT which can promote to Decimal128.