### PR TITLE
Add support for time-based generated filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "tonic",
  "tracing",
  "typify 0.0.13",
+ "ulid",
  "url",
  "uuid",
 ]
@@ -9866,6 +9867,16 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.1",
+ "web-time",
+]
 
 [[package]]
 name = "uncased"

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -28,8 +28,8 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 typify = "0.0.13"
-prost = {workspace = true}
-tonic = {workspace = true}
+prost = { workspace = true }
+tonic = { workspace = true }
 governor = "0.8.0"
 anyhow = "1.0.71"
 tracing = "0.1.37"
@@ -40,6 +40,8 @@ bytes = "1.5.0"
 url = "2.5.0"
 itertools = "0.14.0"
 regex = "1"
+uuid = { version = "1.17.0", features = ["v4", "v7"] }
+ulid = "1.2.1"
 
 ##########################
 # connector dependencies #
@@ -47,7 +49,13 @@ regex = "1"
 
 # Kafka
 aws-msk-iam-sasl-signer = "1.0.0"
-rdkafka = { version = "0.37", features = ["cmake-build", "tracing", "sasl", "ssl-vendored", "zstd"] }
+rdkafka = { version = "0.37", features = [
+    "cmake-build",
+    "tracing",
+    "sasl",
+    "ssl-vendored",
+    "zstd",
+] }
 sasl2-sys = { version = "0.1.22", features = ["vendored"] }
 
 # SSE
@@ -63,26 +71,30 @@ reqwest = { workspace = true, features = ["stream"] }
 rabbitmq-stream-client = "0.7"
 
 # Redis
-redis = { version = "0.28", features = ["default", "tokio-rustls-comp", "cluster-async", "connection-manager"] }
+redis = { version = "0.28", features = [
+    "default",
+    "tokio-rustls-comp",
+    "cluster-async",
+    "connection-manager",
+] }
 
 # Fluvio
-fluvio = {version = "0.24", features = ["openssl"]}
+fluvio = { version = "0.24", features = ["openssl"] }
 
 # Kinesis
 aws-sdk-kinesis = { version = "1.44" }
 aws-config = { workspace = true }
-uuid = { version = "1.7.0", features = ["v4"] }
 
 # Filesystem
-parquet = { workspace = true, features = ["async"]}
+parquet = { workspace = true, features = ["async"] }
 object_store = { workspace = true }
 deltalake = { workspace = true, features = ["s3", "gcs"] }
-delta_kernel = {workspace =  true, features = ["arrow-55", "arrow-conversion"]}
+delta_kernel = { workspace = true, features = ["arrow-55", "arrow-conversion"] }
 async-compression = { version = "0.4.3", features = ["tokio", "zstd", "gzip"] }
 
 # MQTT
 rumqttc = { version = "0.24.0", features = ["url"] }
-rustls-native-certs =  "0.8"
+rustls-native-certs = "0.8"
 rustls-pemfile = "2"
 tokio-rustls = "0.25"
 rustls = "0.22"

--- a/crates/arroyo-connectors/src/filesystem/table.json
+++ b/crates/arroyo-connectors/src/filesystem/table.json
@@ -19,11 +19,7 @@
               "title": "Compression format",
               "type": "string",
               "description": "Compression format of the files in the source path",
-              "enum": [
-                "none",
-                "zstd",
-                "gzip"
-              ]
+              "enum": ["none", "zstd", "gzip"]
             },
             "regexPattern": {
               "title": "File Regex Pattern",
@@ -39,9 +35,7 @@
               }
             }
           },
-          "required": [
-            "path"
-          ]
+          "required": ["path"]
         },
         {
           "type": "object",
@@ -71,13 +65,7 @@
                     "compression": {
                       "title": "Compression",
                       "type": "string",
-                      "enum": [
-                        "none",
-                        "snappy",
-                        "gzip",
-                        "zstd",
-                        "lz4"
-                      ]
+                      "enum": ["none", "snappy", "gzip", "zstd", "lz4"]
                     },
                     "rowBatchSize": {
                       "title": "Row Batch Size",
@@ -105,9 +93,7 @@
                     "json_format": {
                       "title": "JSON Format",
                       "type": "string",
-                      "enum": [
-                        "json"
-                      ],
+                      "enum": ["json"],
                       "default": "json"
                     }
                   },
@@ -170,10 +156,7 @@
                 "commitStyle": {
                   "title": "Commit Style",
                   "type": "string",
-                  "enum": [
-                    "direct",
-                    "delta_lake"
-                  ]
+                  "enum": ["direct", "delta_lake"]
                 },
                 "fileNaming": {
                   "title": "File naming",
@@ -192,10 +175,7 @@
                     "strategy": {
                       "title": "Filename Strategy",
                       "type": "string",
-                      "enum": [
-                        "serial",
-                        "uuid"
-                      ]
+                      "enum": ["serial", "uuid", "uuidv7", "ulid"]
                     }
                   }
                 }
@@ -212,16 +192,12 @@
                   "description": "If enabled, we will shuffle by the partition keys, which can reduce the number of file sink produces; however this may cause backlog if data is skewed"
                 }
               }
-            } 
+            }
           },
-          "required": [
-            "writePath"
-          ]
+          "required": ["writePath"]
         }
       ]
     }
   },
-  "required": [
-    "tableType"
-  ]
+  "required": ["tableType"]
 }


### PR DESCRIPTION
This commit adds two new time-based filename generation strategies: UUIDv7 and ULID.

These can be enabled by choosing them when defining the connection using `'filename.strategy' = 'uuidv7'` or `'filename.strategy' = 'ulid'`

It should be noted that these times represent ONLY the time the filename was generated and SHOULD NOT be used to infer the contents of each file.