### PR TITLE
Update parquet fork to include missing patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "55.2.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fparquet#102420c8b5428c6d7513d939753c89630663df86"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fparquet#d00f572b226edab8089f61a1b71c7690800b1541"
 dependencies = [
  "ahash",
  "arrow-array",


### PR DESCRIPTION
Adds in https://github.com/ArroyoSystems/arrow-rs/commit/d00f572b226edab8089f61a1b71c7690800b1541 which fixes a regression in #920 that caused 

```
called `Result::unwrap()` on an `Err` value: General("SerializedFileWriter already finished") panic.file="crates/arroyo-connectors/src/filesystem/sink/parquet.rs" panic.line=182 panic.column=24
```

errors when writing parquet files to object storage