### PR TITLE
Reduce iceberg commit overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_json",
+ "sha2",
  "strum 0.27.2",
  "strum_macros 0.27.1",
  "thrift",

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -45,6 +45,7 @@ ulid = "1.2.1"
 schemars = "1.0.4"
 strum = "0.27"
 strum_macros = "0.27"
+sha2 = "0.10"
 
 ##########################
 # connector dependencies #

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -21,7 +21,9 @@ use arroyo_rpc::api_types::connections::{
 use arroyo_rpc::formats::Format;
 use arroyo_rpc::{ConnectorOptions, OperatorConfig};
 use arroyo_storage::{BackendConfig, StorageProvider};
+use arroyo_types::TaskInfo;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 const ICON: &str = include_str!("./filesystem.svg");
 
@@ -34,6 +36,7 @@ pub enum TableFormat {
 impl TableFormat {
     pub async fn get_storage_provider(
         &mut self,
+        task_info: Arc<TaskInfo>,
         config: &FileSystemSink,
         schema: &Schema,
     ) -> anyhow::Result<StorageProvider> {
@@ -42,7 +45,7 @@ impl TableFormat {
                 StorageProvider::for_url_with_options(&config.path, config.storage_options.clone())
                     .await?
             }
-            TableFormat::Iceberg(table) => table.get_storage_provider(schema).await?,
+            TableFormat::Iceberg(table) => table.get_storage_provider(task_info, schema).await?,
         })
     }
 }

--- a/crates/arroyo-connectors/src/filesystem/sink/local.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/local.rs
@@ -260,6 +260,7 @@ impl<V: LocalWriter + Send + 'static> TwoPhaseCommitter for LocalFileSystemWrite
 
     async fn commit(
         &mut self,
+        _epoch: u32,
         _task_info: &TaskInfo,
         pre_commit: Vec<Self::PreCommit>,
     ) -> Result<()> {

--- a/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
@@ -51,6 +51,7 @@ pub trait TwoPhaseCommitter: Send + 'static {
     // TODO: figure out how to have the relevant vectors be of pointers across async boundaries.
     async fn commit(
         &mut self,
+        epoch: u32,
         task_info: &TaskInfo,
         pre_commit: Vec<Self::PreCommit>,
     ) -> Result<()>;
@@ -105,7 +106,7 @@ impl<TPC: TwoPhaseCommitter> TwoPhaseCommitterOperator<TPC> {
         };
 
         self.committer
-            .commit(&ctx.task_info, pre_commits)
+            .commit(epoch, &ctx.task_info, pre_commits)
             .await
             .expect("committer committed");
 


### PR DESCRIPTION
Reduces the overhead of iceberg commits, which can currently get quite bad once there are enough manifest lists (2-3 minutes). With this MR commits should remain relatively fast even with a large number of manifest lists (although we will still have some linearly increasing memory usage and CPU until we're doing manifest compaction).

The basic story of this optimization—like most order-of-magnitude improvements, is that previously we were doing something dumb, and no we no longer are doing that dumb thing.

Previously we were relying on some logic taken from iceberg-rust which tries to prevent duplicate files from being committed to the manifest. It did this by getting the latest checkpoint, looping through each manifest entry, *loading that manifest from object storage*, and building a list of all unique files. We would do that on every commit.

This works, but is significantly more work than we need to do. In particular, we can rely on guarantees from Arroyo's checkpointing system. This allows us to know that for each commit operation, we are committing a unique set of files. The one risk is that we might have failed after a commit, but before we recorded in our Arroyo state that it was committed; in that case we could end up writing the same data to the catalog twice.

We address that by including a tx id in each commit, derived from the job, operator, table, and epoch. Before committing, we load the last successful commit and check whether it has the tx id associated with this epoch. If it does, we have already committed and are able to skip.

This logic has been tested by inserting panics into various stages of the commit process and ensuring that even with those failures we maintain exactly-once semantics.