### PR TITLE
Support json serde for binary fields as base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "55.2.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fjson#91e87d9c2a6f7b17c02fba7df39fcc4b69c273f5"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fjson#0ae49da04b5c0ceb20cbd8e506fb3ceab3ebc219"
 dependencies = [
  "arrow-array",
  "arrow-buffer",


### PR DESCRIPTION
This PR adds support for serializing and deserializing binary data in JSON, as base64.

In our schema definitions we support binary fields, however it turns out this was not actually supported in our JSON deserializer). This is addressed by adding support in our arrow-json fork, with https://github.com/ArroyoSystems/arrow-rs/commit/0ae49da04b5c0ceb20cbd8e506fb3ceab3ebc219, and updating to that commit here.

On the serialization side, this was actually supported, however arrow-json is serializing as hex rather than our documented (and intended) base64 encoding. This is technically a breaking change, but it's very unlikely that anyone was using binary encodings since the deserialization was not working.

Also includes another small json fix (https://github.com/ArroyoSystems/arrow-rs/commit/f478a0ec3423b68cdb00df72c7a78c9e488faf26) in which escapes in quotes were not properly preserved when parsing raw json.