### PR TITLE
Use bitnami legacy image

### DIFF
--- a/k8s/arroyo/values.yaml
+++ b/k8s/arroyo/values.yaml
@@ -72,6 +72,11 @@ postgresql:
     create: true
     name: arroyo-postgresql
 
+  # for now, use the legacy bitnami images while we figure out how to migrate off
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 15.3.0-debian-11-r24
 
 prometheus:
   # set to true to enable prometheus annotations on Arroyo cluster resources; if false,


### PR DESCRIPTION
Bitnami has removed all of their debian-based images. This breaks our helm chart when deploying postgres. For now, we'll just use the archived legacy repository, although we will want to find a supported distribution.

Closes  #949