### PR TITLE
Ensure that all parts of multipart uploads are the same size even after recovery

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -131,7 +131,6 @@ impl LocalWriter for JsonLocalWriter {
                 representative_timestamp: representitive_timestamp(
                     batch.column(self.schema.timestamp_index),
                 )?,
-                part_size: None,
             });
         } else {
             self.stats.as_mut().unwrap().last_write_at = Instant::now();

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -300,7 +300,6 @@ impl LocalWriter for ParquetLocalWriter {
                 representative_timestamp: representitive_timestamp(
                     batch.column(self.schema.timestamp_index),
                 )?,
-                part_size: None,
             });
         } else {
             self.stats.as_mut().unwrap().last_write_at = Instant::now();


### PR DESCRIPTION
R2 requires that all parts of a multipart upload be the same size. Previously we were accomplishing this by writing the first part, noting its size, and then truncating all future parts to be that same size.

This works for normal operation, but was failing on recovery because we were not storing the target multipart upload size in the checkpoint. Additionally, our recovery process was going through a different code path that hadn't been updated to ensure equal sizes.

This PR fixes both issues. It addresses the first by always using the configured target part size rather than the size the first part (i.e., the first flushed set of rowgroups) happens to be. This means we don't need to share any information across restarts, because it's a fixed part of the configuration for the job.

The second is addressed by adding part-size awareness to the recovery code. Long term we should try to unify both codepaths so we're not duplicating logic, but that will be a larger refactoring.
