### PR TITLE
Add support for DECIMAL in DDL

### DIFF
--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -318,6 +318,7 @@ impl IntoResponse for HttpError {
         StructField,
         ListField,
         ListFieldItem,
+        DecimalField,
         TimestampField,
         TimestampUnit,
         SchemaDefinition,

--- a/crates/arroyo-planner/src/test/queries/decimal.sql
+++ b/crates/arroyo-planner/src/test/queries/decimal.sql
@@ -1,0 +1,10 @@
+create table my_table (
+    a INT,
+    b DECIMAL(10, 5)
+) with (
+    connector = 'polling_http',
+    endpoint = 'https://example.com',
+    format = 'json'
+);
+
+select * from my_table;

--- a/crates/arroyo-planner/src/test/queries/iceberg_partitioning.sql
+++ b/crates/arroyo-planner/src/test/queries/iceberg_partitioning.sql
@@ -6,6 +6,10 @@ create table impulse with (
 create table sink (
     id INT,
     ts TIMESTAMP(6) NOT NULL,
+    ts2 TIMESTAMP(6) NOT NULL,
+    ts3 TIMESTAMP(6) NOT NULL,
+    ts4 TIMESTAMP(6) NOT NULL,
+    b TEXT,
     count INT
 ) with (
     connector = 'iceberg',
@@ -14,12 +18,22 @@ create table sink (
     type = 'sink',
     table_name = 'my-ice-table',
     format = 'parquet',
-    'rolling_policy.interval' = interval '30 seconds'
+    'rolling_policy.interval' = interval '30 seconds',
+    'shuffle_by_partition.enabled' = true
 ) PARTITIONED BY (
     bucket(count, 4),
-    hour(ts)
+    truncate(count, 1),
+    truncate(b, 10),
+    identity(ts),
+    identity(b),
+    hour(ts),
+    day(ts2),
+    month(ts3),
+    year(ts4),
+    void(count)
 );
 
 insert into sink
-select subtask_index, row_time(), counter
+select subtask_index, row_time(), row_time() as ts2, row_time() as t3, row_time() as ts4,
+       cast(counter as TEXT) as counter_text, counter
 from impulse;


### PR DESCRIPTION
#921 added support for the Decimal128 type. This PR additionally supports it in DDL, allowing users to create sources/sinks that read and write it:

```sql
create table my_table (
    a INT,
    b DECIMAL(10, 5)
) with (
    connector = 'polling_http',
    endpoint = 'https://example.com',
    format = 'json'
);
```