### PR TITLE
Add exponential backoff to state retries

### DIFF
--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -10,6 +10,8 @@ worker-heartbeat-timeout = "30s"
 healthy-duration = "2m"
 worker-startup-time = "10m"
 task-startup-time = "2m"
+state-initial-backoff = "500ms"
+state-max-backoff = "1m"
 chaining.enabled = true
 
 [pipeline.compaction]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -514,6 +514,12 @@ pub struct PipelineConfig {
     /// Amount of time to wait for tasks to startup before considering it failed
     pub task_startup_time: HumanReadableDuration,
 
+    /// Initial backoff delay for retryable state errors
+    pub state_initial_backoff: HumanReadableDuration,
+
+    /// Maximum backoff delay for retryable state errors
+    pub state_max_backoff: HumanReadableDuration,
+
     /// Default sink, for when none is specified
     #[serde(default)]
     pub default_sink: DefaultSink,


### PR DESCRIPTION
Currently we retry controller state machine failures with a fixed 500ms backoff. With the default 20 retries, that means that we could exhaust all within 10 seconds. If we are failing due to a flakey external system (like our scheduler) that may not be enough time for it to recover.

This change makes the initial retry delay configurable (with the default still 500ms) and add exponential backoff up to a configurable limit (1m). With the default config, we will now retry on average for ~22 minutes.