### PR TITLE
Capture and report JSON deserialization errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "55.2.0"
-source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fjson#0ae49da04b5c0ceb20cbd8e506fb3ceab3ebc219"
+source = "git+https://github.com/ArroyoSystems/arrow-rs?branch=55.2.0%2Fjson#d31f8d8f97c6e1394b52927cd8c23c14fec6ba16"
 dependencies = [
  "arrow-array",
  "arrow-buffer",


### PR DESCRIPTION
Emits deserialization_error events when JSON records fail to deserialize in BadData::Drop mode. Errors are logged immediately at deserialization time with human-readable error messages.

Changes:
  - Updated arrow-json dependency to include validation error support
  - Added event logging in BufferDecoder::flush() to capture field-level deserialization failures

Events are emitted through the pluggable log_event! macro.

Corresponding arrow-rs change: https://github.com/ArroyoSystems/arrow-rs/pull/6