### PR TITLE
Validate Format Compatibility with Connection Type

### DIFF
--- a/crates/arroyo-api/src/connection_tables.rs
+++ b/crates/arroyo-api/src/connection_tables.rs
@@ -100,19 +100,21 @@ async fn get_and_validate_connector(
 
     let schema: Option<ConnectionSchema> = req.schema.clone();
 
+    let connection_type = connector.table_type(&profile_config, &req.config).unwrap();
+
     let schema = if let Some(schema) = schema {
         let name = connector.name();
         Some(
             expand_schema(
                 &req.name,
                 name,
-                connector.table_type(&profile_config, &req.config).unwrap(),
+                connection_type,
                 schema,
                 &profile_config,
                 &req.config,
             )
             .await?
-            .validate()
+            .validate(Some(connection_type))
             .map_err(|e| bad_request(format!("Invalid schema: {e}")))?,
         )
     } else {

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -555,6 +555,9 @@ impl ArrowDeserializer {
     }
 
     fn deserialize_single(&mut self, msg: &[u8]) -> DataflowResult<()> {
+        // NOTE: When adding support for a new input format here, also update the format validation
+        // in arroyo-rpc/src/api_types/connections.rs ConnectionSchema::validate() to allow the format
+        // for ConnectionType::Source and ConnectionType::Lookup
         match &*self.format {
             Format::RawString(_)
             | Format::Json(JsonFormat {

--- a/crates/arroyo-formats/src/ser.rs
+++ b/crates/arroyo-formats/src/ser.rs
@@ -115,6 +115,9 @@ impl ArrowSerializer {
             .project(&self.projection)
             .expect("batch has wrong number of columns");
 
+        // NOTE: When adding support for a new output format here, also update the format validation
+        // in arroyo-rpc/src/api_types/connections.rs ConnectionSchema::validate() to allow the format
+        // for ConnectionType::Sink
         match &self.format {
             Format::Json(json) => self.serialize_json(json, &batch),
             Format::Avro(avro) => self.serialize_avro(avro, &batch),


### PR DESCRIPTION
## Context
Connection schemas should validate that formats are compatible with the connection type (source vs sink) to catch configuration errors early.

## Changes
Allowlist supported formats: sources (json, avro, protobuf, raw_string, raw_bytes), sinks (json, avro, parquet, raw_string, raw_bytes).

## Testing
Added unit test that demonstrates format validation.