### PR TITLE
Fix tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then, load the Web UI at http://localhost:5115.
 
 For a more in-depth guide, see the [getting started guide](https://doc.arroyo.dev/getting-started).
 
-Once you have Arroyo running, follow the [tutorial](https://doc.arroyo.dev/tutorial) to create your first real-time
+Once you have Arroyo running, follow the [tutorial]([https://doc.arroyo.dev/tutorial/first-pipeline/)) to create your first real-time
 pipeline.
 
 


### PR DESCRIPTION
The existing tutorial link is no longer available. I'm not sure what the original tutorial was, but I was interested in the "First pipeline" tutorial so that's what I updated the link to point to.