### PR TITLE
Retry unhandled panics in data flow

### DIFF
--- a/crates/arroyo-rpc/src/errors.rs
+++ b/crates/arroyo-rpc/src/errors.rs
@@ -226,7 +226,7 @@ impl From<DataflowError> for TaskError {
                 (domain, retry, None)
             }
             DataflowError::InternalOperatorError { .. } => {
-                (ErrorDomain::Internal, RetryHint::NoRetry, None)
+                (ErrorDomain::Internal, RetryHint::WithBackoff, None)
             }
             DataflowError::StateError(_) => (ErrorDomain::Internal, RetryHint::WithBackoff, None),
             DataflowError::ArgumentError(_) => (ErrorDomain::User, RetryHint::NoRetry, None),


### PR DESCRIPTION
Currently unhandled panics in operators are being reported to the controller as errors with NoRetry, which means that job will immediately fail. This is a unintended regression from #980.