### PR TITLE
feat: add ignore_state option to pipeline restart

### DIFF
--- a/crates/arroyo-api/migrations/V27__ignore_state_before_epoch.sql
+++ b/crates/arroyo-api/migrations/V27__ignore_state_before_epoch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE job_configs
+ADD COLUMN ignore_state_before_epoch integer;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -176,13 +176,14 @@ SET
    parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides)
 WHERE id = :job_id AND organization_id = :organization_id;
 
---! restart_job(mode)
+--! restart_job(mode, ignore_state_before_epoch?)
 UPDATE job_configs
 SET
    updated_at = :updated_at,
    updated_by = :updated_by,
    restart_nonce = restart_nonce + 1,
-   restart_mode = :mode
+   restart_mode = :mode,
+   ignore_state_before_epoch = :ignore_state_before_epoch
 WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
@@ -234,6 +235,12 @@ FROM job_configs
 WHERE job_configs.organization_id = :organization_id AND job_configs.id = :job_id;
 
 --: DbCheckpoint (finish_time?, operators?)
+--: MaxCheckpointEpoch (max_epoch?)
+
+--! max_checkpoint_epoch : MaxCheckpointEpoch
+SELECT MAX(epoch) as max_epoch
+FROM checkpoints
+WHERE job_id = :job_id AND organization_id = :organization_id;
 
 --! get_job_checkpoints: DbCheckpoint
 SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints

--- a/crates/arroyo-api/sqlite_migrations/V5__ignore_state_before_epoch.sql
+++ b/crates/arroyo-api/sqlite_migrations/V5__ignore_state_before_epoch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE job_configs
+ADD COLUMN ignore_state_before_epoch integer;

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -1,4 +1,4 @@
---! all_jobs : Job(ttl_micros?, state?, start_time?, finish_time?, tasks?, failure_message?, failure_domain?, run_id?, pipeline_path?, wasm_path?)
+--! all_jobs : Job(ttl_micros?, state?, start_time?, finish_time?, tasks?, failure_message?, failure_domain?, run_id?, pipeline_path?, wasm_path?, ignore_state_before_epoch?)
 SELECT
     c.id as id,
     c.organization_id as org_id,
@@ -20,7 +20,8 @@ SELECT
     wasm_path,
     c.restart_nonce as config_restart_nonce,
     s.restart_nonce as status_restart_nonce,
-    restart_mode
+    restart_mode,
+    ignore_state_before_epoch
 FROM job_configs c
 INNER JOIN job_statuses s ON c.id = s.id;
 

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -90,6 +90,7 @@ pub struct JobConfig {
     parallelism_overrides: HashMap<u32, usize>,
     restart_nonce: i32,
     restart_mode: RestartMode,
+    ignore_state_before_epoch: Option<i32>,
 }
 
 #[derive(Clone, Debug)]
@@ -629,6 +630,7 @@ impl ControllerServer {
                             .collect(),
                         restart_nonce: p.config_restart_nonce,
                         restart_mode: p.restart_mode,
+                        ignore_state_before_epoch: p.ignore_state_before_epoch,
                     };
 
                     let mut jobs = jobs.lock().await;

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -49,6 +49,7 @@ pub struct PipelinePatch {
 #[serde(rename_all = "snake_case")]
 pub struct PipelineRestart {
     pub force: Option<bool>,
+    pub ignore_state: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -845,6 +845,7 @@ export interface components {
         };
         PipelineRestart: {
             force?: boolean | null;
+            ignore_state?: boolean | null;
         };
         PreviewPost: {
             enable_sinks?: boolean;

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -507,14 +507,14 @@ export const usePipeline = (pipelineId?: string, refresh: boolean = false) => {
     await mutate();
   };
 
-  const restartPipeline = async () => {
+  const restartPipeline = async (ignoreState?: boolean) => {
     if (!pipelineId) {
       return;
     }
 
     await post('/v1/pipelines/{id}/restart', {
       params: { path: { id: pipelineId } },
-      body: {},
+      body: { ignore_state: ignoreState ?? false },
     });
     await mutate();
   };


### PR DESCRIPTION
Enables recovery from corrupted operator state by restarting pipelines without loading checkpoints.

When pipelines fail due to corrupted state, restarting normally restores the corrupted state and fails again. This adds ignore_state flag to restart API that skips checkpoint loading (restore_epoch=None), allowing recovery with fresh state.

Implementation uses ignore_state_before_epoch threshold: API queries MAX(checkpoint epoch) and sets threshold = max + 1. Controller only restores checkpoints with epoch >= threshold. This ensures reliable recovery across retries and respects config/status separation (controller reads config, never mutates it).