### PR TITLE
Re-introduce limit to number of recovery attempts for task failures

### DIFF
--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -600,7 +600,7 @@ impl State for Scheduling {
                             started_tasks.insert((node_id, operator_subtask));
                         }
                         Some(JobMessage::RunningMessage(RunningMessage::TaskFailed(event))) => {
-                            return Err(ctx.handle_task_error(self, event).await);
+                            return ctx.handle_task_error(self, event).await;
                         }
                         Some(JobMessage::ConfigUpdate(c)) => {
                             stop_if_desired_non_running!(self, &c);

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -784,11 +784,12 @@ impl WorkerGrpc for WorkerServer {
 
         let req = request.into_inner();
         for s in sources {
-            s.send(ControlMessage::Stop {
-                mode: req.stop_mode(),
-            })
-            .await
-            .unwrap();
+            // if this fails, it means the source has already shut down
+            let _ = s
+                .send(ControlMessage::Stop {
+                    mode: req.stop_mode(),
+                })
+                .await;
         }
 
         Ok(Response::new(StopExecutionResp {}))


### PR DESCRIPTION
The changes to how we handle task failures introduced in #980 inadvertently removed the previously-enforced limit on how many times we would attempt to recover a pipeline for errors in the running phase. This PR reintroduces that limit (defined in `pipelines.allowed_restarts`), implements it more in a more principled way in the Recovering phase, and adds backoff to the retries (configured by pipeline.state_initial_backoff/pipeline.state_max_backoff).