### PR TITLE
Add state migration system for operators

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/iceberg.rs
+++ b/crates/arroyo-connectors/src/filesystem/iceberg.rs
@@ -235,7 +235,10 @@ impl Connector for IcebergConnector {
             bail!("'format' must be parquet for Iceberg sink")
         };
 
-        let description = format!("IcebergSink<{}.{}>", sink.namespace, sink.table_name);
+        let description = format!(
+            "IcebergSink{:?}<{}.{}>",
+            sink.version, sink.namespace, sink.table_name
+        );
 
         let config = OperatorConfig {
             connection: serde_json::to_value(config).unwrap(),

--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -1,7 +1,7 @@
 mod config;
 pub mod delta;
 pub(crate) mod iceberg;
-mod sink;
+pub mod sink;
 mod source;
 
 use self::sink::{
@@ -209,11 +209,14 @@ impl Connector for FileSystemConnector {
                 ("FileSystem".to_string(), ConnectionType::Source, None)
             }
             FileSystemTableType::Sink(FileSystemSink {
-                path, partitioning, ..
+                path,
+                partitioning,
+                version,
+                ..
             }) => {
                 BackendConfig::parse_url(path, true)?;
 
-                let description = format!("FileSystemSink<{format}, {path}>");
+                let description = format!("FileSystemSink{:?}<{format}, {path}>", version);
 
                 let exprs = partitioning
                     .partition_expr(&schema.arroyo_schema().schema)?

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -183,7 +183,7 @@ fn map_object_store_error(obj_err: &object_store::Error) -> DataflowError {
 }
 
 #[derive(Clone)]
-pub(crate) struct FsEventLogger {
+pub struct FsEventLogger {
     task_info: Option<Arc<TaskInfo>>,
     connection_id: Arc<String>,
 }
@@ -253,7 +253,7 @@ enum CheckpointData {
 }
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
-struct InProgressFileCheckpoint {
+pub struct InProgressFileCheckpoint {
     filename: String,
     // unused, retained for backwards compatibility
     partition: Option<String>,
@@ -621,11 +621,11 @@ async fn write_trailing_bytes(
 pub struct FileToFinish {
     filename: String,
     // unused -- retained for backwards compatibility
-    partition: Option<String>,
-    multi_part_upload_id: String,
-    completed_parts: Vec<String>,
-    size: usize,
-    metadata: Option<IcebergFileMetadata>,
+    pub partition: Option<String>,
+    pub multi_part_upload_id: String,
+    pub completed_parts: Vec<String>,
+    pub size: usize,
+    pub metadata: Option<IcebergFileMetadata>,
 }
 
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
@@ -1763,9 +1763,9 @@ impl Debug for MultipartCallback {
 
 #[derive(Debug, Decode, Encode, Clone, PartialEq, Eq)]
 pub struct FileSystemDataRecovery {
-    next_file_index: usize,
-    active_files: Vec<InProgressFileCheckpoint>,
-    delta_version: i64,
+    pub next_file_index: usize,
+    pub active_files: Vec<InProgressFileCheckpoint>,
+    pub delta_version: i64,
 }
 
 #[async_trait]

--- a/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/two_phase_committer.rs
@@ -152,6 +152,7 @@ impl<TPC: TwoPhaseCommitter> ArrowOperator for TwoPhaseCommitterOperator<TPC> {
                     uses_two_phase_commit: true,
                 }
                 .encode_to_vec(),
+                state_version: 0,
             },
         );
         tables

--- a/crates/arroyo-connectors/src/filesystem/sink/v2/migration.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/migration.rs
@@ -1,0 +1,359 @@
+use arroyo_rpc::connector_err;
+use arroyo_rpc::errors::DataflowResult;
+use tracing::info;
+
+use super::checkpoint::{
+    FileToCommit, FileToCommitType, FilesCheckpointV2, InProgressFile, InProgressFileState,
+};
+use crate::filesystem::sink::{
+    FileCheckpointData, FileSystemDataRecovery, FileToFinish, InFlightPartCheckpoint,
+    InProgressFileCheckpoint,
+};
+
+pub fn migrate_recovery_v1_to_v2(v1: FileSystemDataRecovery) -> DataflowResult<FilesCheckpointV2> {
+    info!(
+        "Migrating filesystem sink recovery state from V1 to V2 ({} files)",
+        v1.active_files.len()
+    );
+
+    let mut open_files = Vec::with_capacity(v1.active_files.len());
+
+    for file in v1.active_files {
+        open_files.push(migrate_file_checkpoint(file)?);
+    }
+
+    Ok(FilesCheckpointV2 {
+        open_files,
+        file_index: v1.next_file_index,
+        delta_version: v1.delta_version,
+    })
+}
+
+fn migrate_file_checkpoint(v1: InProgressFileCheckpoint) -> DataflowResult<InProgressFile> {
+    let (state, data, metadata) = match v1.data {
+        FileCheckpointData::Empty => (InProgressFileState::New, vec![], None),
+
+        FileCheckpointData::MultiPartNotCreated {
+            parts_to_add,
+            trailing_bytes,
+            metadata,
+        } => {
+            let mut data: Vec<u8> = parts_to_add.into_iter().flatten().collect();
+            if let Some(tb) = trailing_bytes {
+                data.extend(tb);
+            }
+            (InProgressFileState::New, data, metadata)
+        }
+
+        FileCheckpointData::MultiPartInFlight {
+            multi_part_upload_id,
+            in_flight_parts,
+            trailing_bytes,
+            metadata,
+        } => {
+            let (parts, has_in_progress) = extract_completed_parts(&in_flight_parts);
+            if has_in_progress {
+                return Err(connector_err!(
+                    Internal,
+                    NoRetry,
+                    "Cannot migrate V1 state with in-progress parts (file: {}). \
+                     This state should not occur during normal checkpoint.",
+                    v1.filename
+                ));
+            }
+            (
+                InProgressFileState::MultipartStarted {
+                    multipart_id: multi_part_upload_id,
+                    parts,
+                },
+                trailing_bytes.unwrap_or_default(),
+                metadata,
+            )
+        }
+
+        FileCheckpointData::MultiPartWriterClosed {
+            multi_part_upload_id,
+            in_flight_parts,
+            metadata,
+        } => {
+            let (parts, has_in_progress) = extract_completed_parts(&in_flight_parts);
+            if has_in_progress {
+                return Err(connector_err!(
+                    Internal,
+                    NoRetry,
+                    "Cannot migrate V1 closed state with in-progress parts (file: {}). \
+                     This state should not occur during normal checkpoint.",
+                    v1.filename
+                ));
+            }
+            (
+                InProgressFileState::MultipartStarted {
+                    multipart_id: multi_part_upload_id,
+                    parts,
+                },
+                vec![],
+                metadata,
+            )
+        }
+
+        FileCheckpointData::MultiPartWriterUploadCompleted { .. } => {
+            return Err(connector_err!(
+                Internal,
+                NoRetry,
+                "Unexpected MultiPartWriterUploadCompleted in V1 recovery state (file: {})",
+                v1.filename
+            ));
+        }
+    };
+
+    Ok(InProgressFile {
+        path: v1.filename,
+        total_size: v1.pushed_size,
+        data,
+        metadata,
+        state,
+    })
+}
+
+fn extract_completed_parts(parts: &[InFlightPartCheckpoint]) -> (Vec<String>, bool) {
+    let mut completed = Vec::new();
+    let mut has_in_progress = false;
+
+    for part in parts {
+        match part {
+            InFlightPartCheckpoint::FinishedPart { content_id, .. } => {
+                completed.push(content_id.clone());
+            }
+            InFlightPartCheckpoint::InProgressPart { .. } => {
+                has_in_progress = true;
+            }
+        }
+    }
+
+    (completed, has_in_progress)
+}
+
+pub fn migrate_precommit_v1_to_v2(v1: FileToFinish) -> FileToCommit {
+    FileToCommit {
+        path: v1.filename,
+        typ: FileToCommitType::Multipart {
+            multipart_id: v1.multi_part_upload_id,
+            parts: v1.completed_parts,
+            total_size: v1.size,
+        },
+        iceberg_metadata: v1.metadata,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filesystem::sink::iceberg::metadata::{ColumnAccum, IcebergFileMetadata};
+    use std::collections::HashMap;
+
+    fn make_iceberg_metadata() -> IcebergFileMetadata {
+        let mut columns = HashMap::new();
+        columns.insert(
+            1,
+            ColumnAccum {
+                compressed_size: 512,
+                num_values: 100,
+                null_values: 5,
+                bounds: Default::default(),
+            },
+        );
+        IcebergFileMetadata {
+            row_count: 100,
+            split_offsets: vec![0, 1024],
+            columns,
+        }
+    }
+
+    // Tests for migrate_precommit_v1_to_v2
+
+    #[test]
+    fn test_migrate_precommit_basic() {
+        let v1 = FileToFinish {
+            filename: "path/to/file.parquet".to_string(),
+            partition: Some("partition_key".to_string()),
+            multi_part_upload_id: "upload-123".to_string(),
+            completed_parts: vec!["part1".to_string(), "part2".to_string()],
+            size: 2048,
+            metadata: None,
+        };
+
+        let v2 = migrate_precommit_v1_to_v2(v1);
+
+        assert_eq!(v2.path, "path/to/file.parquet");
+        assert!(matches!(
+            v2.typ,
+            FileToCommitType::Multipart {
+                multipart_id,
+                parts,
+                total_size,
+            } if multipart_id == "upload-123"
+                && parts == vec!["part1", "part2"]
+                && total_size == 2048
+        ));
+        assert!(v2.iceberg_metadata.is_none());
+    }
+
+    #[test]
+    fn test_migrate_precommit_with_iceberg_metadata() {
+        let metadata = make_iceberg_metadata();
+        let v1 = FileToFinish {
+            filename: "iceberg/data/file.parquet".to_string(),
+            partition: None,
+            multi_part_upload_id: "upload-456".to_string(),
+            completed_parts: vec!["etag1".to_string()],
+            size: 4096,
+            metadata: Some(metadata.clone()),
+        };
+
+        let v2 = migrate_precommit_v1_to_v2(v1);
+
+        assert_eq!(v2.path, "iceberg/data/file.parquet");
+        assert_eq!(v2.iceberg_metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_migrate_precommit_empty_parts() {
+        let v1 = FileToFinish {
+            filename: "empty.parquet".to_string(),
+            partition: None,
+            multi_part_upload_id: "upload-789".to_string(),
+            completed_parts: vec![],
+            size: 0,
+            metadata: None,
+        };
+
+        let v2 = migrate_precommit_v1_to_v2(v1);
+
+        assert!(matches!(
+            v2.typ,
+            FileToCommitType::Multipart { parts, total_size, .. }
+            if parts.is_empty() && total_size == 0
+        ));
+    }
+
+    #[test]
+    fn test_migrate_recovery_empty() {
+        let v1 = FileSystemDataRecovery {
+            next_file_index: 5,
+            active_files: vec![],
+            delta_version: 10,
+        };
+
+        let v2 = migrate_recovery_v1_to_v2(v1).unwrap();
+
+        assert_eq!(v2.file_index, 5);
+        assert_eq!(v2.delta_version, 10);
+        assert!(v2.open_files.is_empty());
+    }
+
+    #[test]
+    fn test_migrate_recovery_multipart_not_created() {
+        let v1 = FileSystemDataRecovery {
+            next_file_index: 2,
+            active_files: vec![InProgressFileCheckpoint {
+                filename: "file2.parquet".to_string(),
+                partition: Some("part=1".to_string()),
+                data: FileCheckpointData::MultiPartNotCreated {
+                    parts_to_add: vec![vec![1, 2, 3], vec![4, 5, 6]],
+                    trailing_bytes: Some(vec![7, 8]),
+                    metadata: None,
+                },
+                pushed_size: 100,
+            }],
+            delta_version: 1,
+        };
+
+        let v2 = migrate_recovery_v1_to_v2(v1).unwrap();
+
+        assert_eq!(v2.open_files.len(), 1);
+        let file = &v2.open_files[0];
+        assert_eq!(file.path, "file2.parquet");
+        assert_eq!(file.total_size, 100);
+        // parts_to_add flattened + trailing_bytes
+        assert_eq!(file.data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(file.state, InProgressFileState::New);
+    }
+
+    #[test]
+    fn test_migrate_recovery_multipart_in_flight_all_finished() {
+        let v1 = FileSystemDataRecovery {
+            next_file_index: 3,
+            active_files: vec![InProgressFileCheckpoint {
+                filename: "inflight.parquet".to_string(),
+                partition: None,
+                data: FileCheckpointData::MultiPartInFlight {
+                    multi_part_upload_id: "upload-abc".to_string(),
+                    in_flight_parts: vec![
+                        InFlightPartCheckpoint::FinishedPart {
+                            part: 1,
+                            content_id: "etag1".to_string(),
+                        },
+                        InFlightPartCheckpoint::FinishedPart {
+                            part: 2,
+                            content_id: "etag2".to_string(),
+                        },
+                    ],
+                    trailing_bytes: Some(vec![99, 100]),
+                    metadata: None,
+                },
+                pushed_size: 500,
+            }],
+            delta_version: 5,
+        };
+
+        let v2 = migrate_recovery_v1_to_v2(v1).unwrap();
+
+        let file = &v2.open_files[0];
+        assert_eq!(file.path, "inflight.parquet");
+        assert_eq!(file.total_size, 500);
+        assert_eq!(file.data, vec![99, 100]); // trailing bytes become data
+        assert_eq!(
+            file.state,
+            InProgressFileState::MultipartStarted {
+                multipart_id: "upload-abc".to_string(),
+                parts: vec!["etag1".to_string(), "etag2".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn test_migrate_recovery_multipart_writer_closed_all_finished() {
+        let v1 = FileSystemDataRecovery {
+            next_file_index: 1,
+            active_files: vec![InProgressFileCheckpoint {
+                filename: "closed.parquet".to_string(),
+                partition: None,
+                data: FileCheckpointData::MultiPartWriterClosed {
+                    multi_part_upload_id: "upload-closed".to_string(),
+                    in_flight_parts: vec![InFlightPartCheckpoint::FinishedPart {
+                        part: 1,
+                        content_id: "closed-etag1".to_string(),
+                    }],
+                    metadata: Some(make_iceberg_metadata()),
+                },
+                pushed_size: 1000,
+            }],
+            delta_version: 2,
+        };
+
+        let v2 = migrate_recovery_v1_to_v2(v1).unwrap();
+
+        let file = &v2.open_files[0];
+        assert_eq!(file.path, "closed.parquet");
+        assert_eq!(file.total_size, 1000);
+        assert!(file.data.is_empty()); // closed writer has no trailing bytes
+        assert!(file.metadata.is_some());
+        assert_eq!(
+            file.state,
+            InProgressFileState::MultipartStarted {
+                multipart_id: "upload-closed".to_string(),
+                parts: vec!["closed-etag1".to_string()],
+            }
+        );
+    }
+}

--- a/crates/arroyo-connectors/src/kafka/sink/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/mod.rs
@@ -261,6 +261,7 @@ impl ArrowOperator for KafkaSinkFunc {
                         uses_two_phase_commit: true,
                     }
                     .encode_to_vec(),
+                    state_version: 0,
                 },
             )
         } else {

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -337,6 +337,7 @@ message OperatorMetadata {
 message TableConfig {
   TableEnum table_type = 1;
   bytes config = 2;
+  uint32 state_version = 3;
 }
 
 message TableCheckpointMetadata {

--- a/crates/arroyo-rpc/src/errors.rs
+++ b/crates/arroyo-rpc/src/errors.rs
@@ -290,6 +290,16 @@ pub enum StateError {
         table: String,
         expected: &'static str,
     },
+    #[error(
+        "unsupported state version for table {table}: found version {found}, expected {expected}"
+    )]
+    UnsupportedStateVersion {
+        table: String,
+        found: u32,
+        expected: u32,
+    },
+    #[error("failed to migrate state for table {table}: {error}")]
+    MigrationFailed { table: String, error: String },
     #[error("unexpected state error: [{table}] {error}")]
     Other { table: String, error: String },
     #[error("storage error: {0}")]

--- a/crates/arroyo-state/src/lib.rs
+++ b/crates/arroyo-state/src/lib.rs
@@ -57,6 +57,14 @@ pub fn global_table_config(
     name: impl Into<String>,
     description: impl Into<String>,
 ) -> HashMap<String, TableConfig> {
+    global_table_config_with_version(name, description, 0)
+}
+
+pub fn global_table_config_with_version(
+    name: impl Into<String>,
+    description: impl Into<String>,
+    state_version: u32,
+) -> HashMap<String, TableConfig> {
     let name = name.into();
     single_item_hash_map(
         name.clone(),
@@ -68,6 +76,7 @@ pub fn global_table_config(
                 uses_two_phase_commit: false,
             }
             .encode_to_vec(),
+            state_version,
         },
     )
 }
@@ -89,6 +98,7 @@ pub fn timestamp_table_config(
             schema: Some(schema.into()),
         }
         .encode_to_vec(),
+        state_version: 0,
     }
 }
 

--- a/crates/arroyo-state/src/tables/expiring_time_key_map.rs
+++ b/crates/arroyo-state/src/tables/expiring_time_key_map.rs
@@ -252,6 +252,8 @@ impl Table for ExpiringTimeKeyTable {
         task_info: Arc<TaskInfo>,
         storage_provider: arroyo_storage::StorageProviderRef,
         checkpoint_message: Option<Self::TableCheckpointMessage>,
+        // TODO: implement versioning for time key tables
+        _state_version: u32,
     ) -> Result<Self, StateError> {
         let schema: ArroyoSchema = config
             .schema


### PR DESCRIPTION
This PR adds a state migration system for operator state, allowing changes to state formats. This is particularly relevant for GlobalState tables, which use bincoded structs that cannot otherwise be modified.

The strategy here:

* Operators define a new struct for the new version of their state
* These structs implement the new MigratableState trait, which has a VERSION field, a PreviousVersion type, and a migrate method which migrates the previous version of the state into the current version
* Now, when writing checkpoint files we include the state version into the parquet metadata
* On recovery, if we read a state file that has an earlier version (defaulting to version 0 for old files that do not have the metadata) it will be automatically migrated to the current version using the trait methods

Currently only single-version migrations are supported (like v0->v1).

In addition to the infrastructure, this PR also includes a migration for the v2 filesystem sink state, allowing v1 sinks to be migrated to v2.