### PR TITLE
Fix deserialization error counter increment

### DIFF
--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -379,6 +379,12 @@ impl SourceCollector {
                                 .unwrap();
                         })
                         .await;
+
+                    TaskCounters::DeserializationErrors.for_connection(
+                        &self.collector.chain_info,
+                        self.connection_id.as_deref().unwrap_or_default(),
+                        |c| c.inc_by(count as u64),
+                    );
                 }
                 (_, e) => {
                     return Err(e);


### PR DESCRIPTION
Context
The DeserializationErrors counter increment was unintentionally removed during the structured error handling refactor. This causes deserialization error metrics to always report 0, even though errors are being logged.

Changes
This PR restores the counter increment in `collect_source_errors()` using the `chain_info` from the nested `ArrowCollector`.