### PR TITLE
Propagate error during hash computation

### DIFF
--- a/crates/arroyo-state/src/schemas/mod.rs
+++ b/crates/arroyo-state/src/schemas/mod.rs
@@ -176,7 +176,7 @@ impl SchemaWithHashAndOperation {
                     table: "".to_string(),
                     error: format!("failed to compute hashes: {e:?}"),
                 }
-            });
+            })?;
         let hash_array = PrimitiveArray::<UInt64Type>::from(hash_buffer);
 
         let hash_min = min(&hash_array).unwrap();


### PR DESCRIPTION
The result was never evaluated.

The `map_err` was recently added (#970), but it removes the `?`.