### PR TITLE
Remove unused variable

### DIFF
--- a/crates/arroyo-state/src/tables/expiring_time_key_map.rs
+++ b/crates/arroyo-state/src/tables/expiring_time_key_map.rs
@@ -307,10 +307,6 @@ impl Table for ExpiringTimeKeyTable {
             .values()
             .filter_map(|metadata| metadata.watermark)
             .min();
-        let _max_watermark = subtask_metadata
-            .values()
-            .filter_map(|metadata| metadata.watermark)
-            .min();
         let cutoff = min_watermark
             .map(|min_watermark| min_watermark - config.retention_micros)
             .unwrap_or_default();


### PR DESCRIPTION
I'm removing this because it's not used today, and that it mis-calculate the maximum by called `min()`.