### PR TITLE
Add config to disable persisting deserialization errors to DB

### DIFF
--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -13,6 +13,7 @@ task-startup-time = "2m"
 state-initial-backoff = "500ms"
 state-max-backoff = "1m"
 chaining.enabled = true
+store-deserialization-errors = true
 
 [pipeline.compaction]
 enabled = false

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -524,6 +524,9 @@ pub struct PipelineConfig {
     #[serde(default)]
     pub default_sink: DefaultSink,
 
+    /// Whether to persist deserialization errors to job_log_messages
+    pub store_deserialization_errors: bool,
+
     pub chaining: ChainingConfig,
 
     pub compaction: CompactionConfig,


### PR DESCRIPTION
## Summary
- Adds `pipeline.store-deserialization-errors` config option (default: `true`)
- When `false`, skips sending `ControlResp::Error` for deserialization errors, preventing writes to `job_log_messages`
- Prometheus metrics and analytics are unaffected

## Motivation
With `bad_data=drop`, long-running pipelines accumulate unbounded deserialization error rows in `job_log_messages`. This config allows suppressing those writes where the DB records aren't needed, or are too voluminous.

Env var: `ARROYO__PIPELINE__STORE_DESERIALIZATION_ERRORS=false`