### PR TITLE
Update Rust toolchain to 1.93 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: clippy, rustfmt
-          toolchain: 1.92
+          toolchain: 1.93
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
New version of the toolchain, comes with some new clippy.