### PR TITLE
docs: fix broken links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 We welcome contributions from the community!
 
 Please refer to the [dev setup](https://doc.arroyo.dev/developing/dev-setup) guide for how to get started. You can
-find help on our [discord](https://doc.arroyo.dev/developing/dev-setup) or via email at
+find help on our [discord](https://discord.gg/cjCr5rVmyR) or via email at
 [support@arroyo.systems](mailto:support@arroyo.systems).

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then, load the Web UI at http://localhost:5115.
 
 For a more in-depth guide, see the [getting started guide](https://doc.arroyo.dev/getting-started).
 
-Once you have Arroyo running, follow the [tutorial]([https://doc.arroyo.dev/tutorial/first-pipeline/)) to create your first real-time
+Once you have Arroyo running, follow the [tutorial](https://doc.arroyo.dev/tutorial/first-pipeline/) to create your first real-time
 pipeline.
 
 


### PR DESCRIPTION
## Summary

Two broken links fixed in the documentation:

### README.md
The tutorial link had malformed Markdown syntax — an extra `[` and a mismatched closing paren:
```
# Before (broken)
[tutorial]([https://doc.arroyo.dev/tutorial/first-pipeline/))

# After (fixed)
[tutorial](https://doc.arroyo.dev/tutorial/first-pipeline/)
```

### CONTRIBUTING.md
The Discord link was pointing to the dev-setup docs page instead of the actual Discord invite URL:
```
# Before (wrong destination)
[discord](https://doc.arroyo.dev/developing/dev-setup)

# After (correct Discord invite)
[discord](https://discord.gg/cjCr5rVmyR)
```

Both fixes are trivial but ensure readers can actually reach Discord from CONTRIBUTING.md and click through to the tutorial from the README.