### PR TITLE
Add output format and table format labels to filesystem sink trace events

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/mod.rs
@@ -40,6 +40,14 @@ pub enum TableFormat {
 }
 
 impl TableFormat {
+    pub fn name(&self) -> &'static str {
+        match self {
+            TableFormat::None => "none",
+            TableFormat::Delta => "delta",
+            TableFormat::Iceberg(_) => "iceberg",
+        }
+    }
+
     pub async fn get_storage_provider(
         &mut self,
         task_info: Arc<TaskInfo>,

--- a/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
@@ -304,6 +304,8 @@ impl<BBW: BatchBufferingWriter + Send + 'static> FileSystemSinkV2<BBW> {
         }
 
         let connection_id_str = connection_id.clone().unwrap_or_default();
+        let output_format = format.name();
+        let table_format_name = table_format.name();
 
         Self {
             config: SinkConfig {
@@ -328,6 +330,8 @@ impl<BBW: BatchBufferingWriter + Send + 'static> FileSystemSinkV2<BBW> {
             event_logger: FsEventLogger {
                 task_info: None,
                 connection_id: connection_id_str.into(),
+                output_format,
+                table_format: table_format_name,
             },
             watermark: None,
         }

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -376,22 +376,22 @@ pub enum Format {
 
 impl Display for Format {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Format::Json(_) => "json",
-                Format::Avro(_) => "avro",
-                Format::Protobuf(_) => "protobuf",
-                Format::Parquet(_) => "parquet",
-                Format::RawString(_) => "raw_string",
-                Format::RawBytes(_) => "raw_bytes",
-            }
-        )
+        f.write_str(self.name())
     }
 }
 
 impl Format {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Format::Json(_) => "json",
+            Format::Avro(_) => "avro",
+            Format::Protobuf(_) => "protobuf",
+            Format::Parquet(_) => "parquet",
+            Format::RawString(_) => "raw_string",
+            Format::RawBytes(_) => "raw_bytes",
+        }
+    }
+
     pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Option<Self>> {
         let Some(name) = opts.pull_opt_str("format")? else {
             return Ok(None);


### PR DESCRIPTION
### Context
Filesystem sink trace events currently don't include the output format or table format. Inclusion of these events would enrich analytic capabilities to describe sink behavior.

### Changes
- Add `Format::name()` and `TableFormat::name()` returning `&'static str` to prevent string allocations
- Add `output_format` and `table_format` fields to `FsEventLogger`, emitted as labels in `filesystem_write` trace events