### PR TITLE
Local json compression + optimization for empty encoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "sha2",
  "strum 0.27.2",
  "strum_macros 0.27.1",
+ "tempfile",
  "thrift",
  "tokio",
  "tokio-rustls 0.25.0",

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -117,5 +117,8 @@ async-nats = "0.38.0"
 nkeys = "0.3.0"
 murmur3 = "0.5.2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 glob = "0.3"

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -21,13 +21,15 @@ use std::{fs::File, io::Write, time::Instant};
 ///
 /// Generic over `W: Write` so it can wrap both in-memory buffers (`Writer<BytesMut>`)
 /// and file handles (`File`).
-///
-/// The `Gzipped` variant uses an `Option` so that the encoder can be temporarily
-/// taken out (via `.take()`) for operations that consume it (like `finish()`).
-/// In addition, `None` is used to indicate that the writer has been closed.
 enum JsonBuffer<W: Write> {
     Uncompressed(W),
-    Gzipped(Option<GzEncoder<W>>),
+    /// The `Gzipped` variant uses an `Option` so that the encoder can be temporarily
+    /// taken out (via `.take()`) for operations that consume it (like `finish()`).
+    /// In addition, `None` is used to indicate that the writer has been closed.
+    Gzipped {
+        encoder: Option<GzEncoder<W>>,
+        dirty: bool,
+    },
 }
 
 impl<W: Write> JsonBuffer<W> {
@@ -35,17 +37,14 @@ impl<W: Write> JsonBuffer<W> {
     fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
         match self {
             JsonBuffer::Uncompressed(w) => w.write_all(data),
-            JsonBuffer::Gzipped(Some(encoder)) => encoder.write_all(data),
-            JsonBuffer::Gzipped(None) => panic!("write_all called after close()"),
-        }
-    }
-
-    /// Flushes the encoder or the inner writer.
-    fn flush(&mut self) -> std::io::Result<()> {
-        match self {
-            JsonBuffer::Uncompressed(w) => w.flush(),
-            JsonBuffer::Gzipped(Some(encoder)) => encoder.flush(),
-            JsonBuffer::Gzipped(None) => panic!("flush called after close()"),
+            JsonBuffer::Gzipped {
+                encoder: Some(enc),
+                dirty,
+            } => {
+                *dirty = true;
+                enc.write_all(data)
+            }
+            JsonBuffer::Gzipped { encoder: None, .. } => panic!("write_all called after close()"),
         }
     }
 
@@ -53,8 +52,10 @@ impl<W: Write> JsonBuffer<W> {
     fn writer_ref(&self) -> &W {
         match self {
             JsonBuffer::Uncompressed(w) => w,
-            JsonBuffer::Gzipped(Some(encoder)) => encoder.get_ref(),
-            JsonBuffer::Gzipped(None) => panic!("inner_ref called after close()"),
+            JsonBuffer::Gzipped {
+                encoder: Some(enc), ..
+            } => enc.get_ref(),
+            JsonBuffer::Gzipped { encoder: None, .. } => panic!("inner_ref called after close()"),
         }
     }
 
@@ -62,32 +63,37 @@ impl<W: Write> JsonBuffer<W> {
     fn writer_ref_mut(&mut self) -> &mut W {
         match self {
             JsonBuffer::Uncompressed(w) => w,
-            JsonBuffer::Gzipped(Some(encoder)) => encoder.get_mut(),
-            JsonBuffer::Gzipped(None) => panic!("inner_ref_mut called after close()"),
+            JsonBuffer::Gzipped {
+                encoder: Some(enc), ..
+            } => enc.get_mut(),
+            JsonBuffer::Gzipped { encoder: None, .. } => {
+                panic!("inner_ref_mut called after close()")
+            }
         }
     }
 
-    /// Takes the encoder out of the `Gzipped` variant, leaving `None` in its place.
-    /// Panics if called on `Uncompressed` or if the encoder was already taken.
-    fn take_encoder(&mut self) -> GzEncoder<W> {
-        match self {
-            JsonBuffer::Gzipped(encoder @ Some(_)) => encoder.take().unwrap(),
-            _ => panic!("take_encoder called on non-Gzipped or already-taken buffer"),
-        }
-    }
-
-    /// Restores an encoder into the `Gzipped` variant after a previous `take_encoder`.
     fn restore_encoder(&mut self, new_encoder: GzEncoder<W>) {
         match self {
-            JsonBuffer::Gzipped(slot @ None) => *slot = Some(new_encoder),
+            JsonBuffer::Gzipped {
+                encoder: slot @ None,
+                dirty,
+            } => {
+                *slot = Some(new_encoder);
+                // This is a fresh gzip member; no record bytes were written yet.
+                *dirty = false;
+            }
             _ => panic!("restore_encoder called on non-Gzipped or non-empty buffer"),
         }
     }
 
-    /// Finishes the current gzip member and returns the inner writer.
-    /// This writes the gzip trailer, making the compressed data a complete gzip member.
     fn finish_encoder(&mut self) -> std::io::Result<W> {
-        self.take_encoder().finish()
+        match self {
+            JsonBuffer::Gzipped {
+                encoder: encoder @ Some(_),
+                ..
+            } => encoder.take().unwrap().finish(),
+            _ => panic!("finish_encoder called on non-Gzipped or already-taken buffer"),
+        }
     }
 }
 
@@ -113,10 +119,13 @@ impl BatchBufferingWriter for JsonWriter {
 
         let buffer = match compression {
             JsonCompression::Uncompressed => JsonBuffer::Uncompressed(BytesMut::new().writer()),
-            JsonCompression::Gzip => JsonBuffer::Gzipped(Some(GzEncoder::new(
-                BytesMut::new().writer(),
-                GzipCompression::default(),
-            ))),
+            JsonCompression::Gzip => JsonBuffer::Gzipped {
+                encoder: Some(GzEncoder::new(
+                    BytesMut::new().writer(),
+                    GzipCompression::default(),
+                )),
+                dirty: false,
+            },
         };
 
         Self {
@@ -185,39 +194,47 @@ impl BatchBufferingWriter for JsonWriter {
     fn get_trailing_bytes_for_checkpoint(&mut self) -> (Vec<u8>, Option<IcebergFileMetadata>) {
         let bytes = match &self.buffer {
             JsonBuffer::Uncompressed(inner) => inner.get_ref().to_vec(),
-            JsonBuffer::Gzipped(_) => {
-                // Finish infallible, since the underlying Writer<BytesMut>::write() always returns `Ok`.
-                // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
-                let inner = self
-                    .buffer
-                    .finish_encoder()
-                    .expect("Failed to finish gzip encoder at checkpoint");
+            JsonBuffer::Gzipped { dirty, .. } => {
+                if *dirty {
+                    // Finish is infallible since the underlying Writer<BytesMut>::write() always returns `Ok`.
+                    // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
+                    let inner = self
+                        .buffer
+                        .finish_encoder()
+                        .expect("Failed to finish gzip encoder at checkpoint");
 
-                let bytes = inner.get_ref().to_vec();
+                    let bytes = inner.get_ref().to_vec();
 
-                // Reuse the buffer (retaining the data) for the new gzip member.
-                self.buffer
-                    .restore_encoder(GzEncoder::new(inner, GzipCompression::default()));
+                    self.buffer
+                        .restore_encoder(GzEncoder::new(inner, GzipCompression::default()));
 
-                bytes
+                    bytes
+                } else {
+                    // No data written since last checkpoint — return existing buffer
+                    self.buffer.writer_ref().get_ref().to_vec()
+                }
             }
         };
-
         (bytes, None)
     }
 
     fn close(&mut self) -> (Bytes, Option<IcebergFileMetadata>) {
         let data = match &mut self.buffer {
             JsonBuffer::Uncompressed(inner) => inner.get_mut().split().freeze(),
-            JsonBuffer::Gzipped(_) => {
-                // Finish infallible, since the underlying Writer<BytesMut>::write() always returns `Ok`.
-                // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
-                let inner = self
-                    .buffer
-                    .finish_encoder()
-                    .expect("Failed to finish gzip encoder at close");
+            JsonBuffer::Gzipped { dirty, .. } => {
+                if *dirty {
+                    // Finish infallible, since the underlying Writer<BytesMut>::write() always returns `Ok`.
+                    // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
+                    let inner = self
+                        .buffer
+                        .finish_encoder()
+                        .expect("Failed to finish gzip encoder at close");
 
-                inner.into_inner().split().freeze()
+                    inner.into_inner().split().freeze()
+                } else {
+                    // No data written since last checkpoint — return existing buffer
+                    self.buffer.writer_ref_mut().get_mut().split().freeze()
+                }
             }
         };
 
@@ -252,9 +269,10 @@ impl LocalWriter for JsonLocalWriter {
 
         let buffer = match compression {
             JsonCompression::Uncompressed => JsonBuffer::Uncompressed(file),
-            JsonCompression::Gzip => {
-                JsonBuffer::Gzipped(Some(GzEncoder::new(file, GzipCompression::default())))
-            }
+            JsonCompression::Gzip => JsonBuffer::Gzipped {
+                encoder: Some(GzEncoder::new(file, GzipCompression::default())),
+                dirty: false,
+            },
         };
 
         JsonLocalWriter {
@@ -303,20 +321,36 @@ impl LocalWriter for JsonLocalWriter {
     }
 
     fn sync(&mut self) -> anyhow::Result<usize> {
-        self.buffer.flush()?;
+        match &mut self.buffer {
+            JsonBuffer::Gzipped {
+                dirty,
+                encoder: Some(enc),
+            } => {
+                // Only flush the encoder if it contains data.
+                if *dirty {
+                    enc.flush()?;
+                }
+            }
+            JsonBuffer::Gzipped { encoder: None, .. } => panic!("sync called after close()"),
+            JsonBuffer::Uncompressed(w) => w.flush()?,
+        }
         let size = self.buffer.writer_ref().metadata()?.len() as usize;
-        self.stats.as_mut().unwrap().bytes_written = size;
+        if let Some(stats) = &mut self.stats {
+            stats.bytes_written = size;
+        }
         Ok(size)
     }
 
     fn close(&mut self) -> anyhow::Result<super::local::FilePreCommit> {
         match &self.buffer {
-            JsonBuffer::Gzipped(_) => {
-                // Finish the current gzip member (writes trailer), making the file valid.
+            JsonBuffer::Gzipped { .. } => {
+                // Always finalize local gzip on close so file bytes cannot change later
+                // from encoder drop-time writes after we return.
                 let mut file = self.buffer.finish_encoder()?;
                 file.flush()?;
-                let size = file.metadata()?.len() as usize;
-                self.stats.as_mut().unwrap().bytes_written = size;
+                if let Some(stats) = &mut self.stats {
+                    stats.bytes_written = file.metadata()?.len() as usize;
+                }
             }
             JsonBuffer::Uncompressed(_) => {
                 self.sync()?;
@@ -331,20 +365,21 @@ impl LocalWriter for JsonLocalWriter {
 
     fn checkpoint(&mut self) -> anyhow::Result<Option<super::local::CurrentFileRecovery>> {
         let bytes_written = match &self.buffer {
-            JsonBuffer::Gzipped(_) => {
+            JsonBuffer::Gzipped { dirty, .. } if *dirty => {
                 // Finish the current gzip member (writes trailer), making the file valid
                 // up to this point. We must measure the file size *before* creating a new
                 // encoder, since GzEncoder writes the gzip header on the first flush/write.
                 let mut file = self.buffer.finish_encoder()?;
                 file.flush()?;
                 let size = file.metadata()?.len() as usize;
-                self.stats.as_mut().unwrap().bytes_written = size;
-
+                if let Some(stats) = &mut self.stats {
+                    stats.bytes_written = size;
+                }
                 self.buffer
                     .restore_encoder(GzEncoder::new(file, GzipCompression::default()));
                 size
             }
-            JsonBuffer::Uncompressed(_) => self.sync()?,
+            _ => self.sync()?,
         };
 
         if bytes_written > 0 {
@@ -765,5 +800,203 @@ mod tests {
 
         assert!(decompressed.contains("committed_data"));
         assert!(!decompressed.contains("uncommitted_data"));
+    }
+
+    #[test]
+    fn test_local_writer_gzip_empty_checkpoint_truncation_recovery() {
+        // Verify that a checkpoint with no new rows still represents a valid
+        // truncation boundary for gzip recovery.
+        let dir = tempfile::tempdir().unwrap();
+        let (schema, arroyo_schema) = local_writer_schema();
+
+        let mut writer = create_test_local_writer(dir.path(), JsonCompression::Gzip, arroyo_schema);
+
+        // Write and checkpoint committed data.
+        let batch1 = local_writer_batch(&schema, vec!["committed_data"]);
+        writer.write_batch(&batch1).unwrap();
+        let _recovery1 = writer.checkpoint().unwrap().unwrap();
+
+        // Checkpoint again without new rows.
+        let recovery2 = writer.checkpoint().unwrap().unwrap();
+
+        // Write data after the second checkpoint (should be lost on recovery).
+        let batch2 = local_writer_batch(&schema, vec!["uncommitted_data"]);
+        writer.write_batch(&batch2).unwrap();
+        drop(writer);
+
+        // Simulate recovery by truncating to second checkpoint boundary.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&recovery2.tmp_file)
+            .unwrap();
+        file.set_len(recovery2.bytes_written as u64).unwrap();
+        drop(file);
+
+        let compressed = std::fs::read(&recovery2.tmp_file).unwrap();
+        let mut decoder = MultiGzDecoder::new(&compressed[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+
+        assert!(decompressed.contains("committed_data"));
+        assert!(!decompressed.contains("uncommitted_data"));
+    }
+
+    #[test]
+    fn test_checkpoint_no_data_no_growth() {
+        // Verify that repeated checkpoints with no data written between them
+        // do not cause the gzip buffer to grow (no empty gzip members emitted).
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "field",
+            DataType::Utf8,
+            false,
+        )]));
+
+        let mut writer = create_test_writer(schema.clone(), JsonCompression::Gzip);
+
+        // Checkpoint with no data written
+        let (bytes1, _) = writer.get_trailing_bytes_for_checkpoint();
+
+        // Checkpoint again with no data written
+        let (bytes2, _) = writer.get_trailing_bytes_for_checkpoint();
+
+        // A third time to be sure
+        let (bytes3, _) = writer.get_trailing_bytes_for_checkpoint();
+
+        // Buffer should not have grown
+        assert_eq!(
+            bytes1.len(),
+            bytes2.len(),
+            "Repeated checkpoints with no data should not grow the buffer"
+        );
+        assert_eq!(bytes2.len(), bytes3.len());
+        assert_eq!(
+            bytes1.len(),
+            0,
+            "Checkpoint with no data should produce empty bytes"
+        );
+    }
+
+    #[test]
+    fn test_local_writer_checkpoint_no_data_no_growth() {
+        // Verify that repeated checkpoints on a local gzip writer with no data
+        // written between them do not cause the file to grow.
+        let dir = tempfile::tempdir().unwrap();
+        let (schema, arroyo_schema) = local_writer_schema();
+
+        let mut writer = create_test_local_writer(dir.path(), JsonCompression::Gzip, arroyo_schema);
+
+        // Write initial batch so stats are initialized
+        let batch = local_writer_batch(&schema, vec!["initial"]);
+        writer.write_batch(&batch).unwrap();
+
+        // First checkpoint — finalizes the gzip member
+        let recovery1 = writer.checkpoint().unwrap().unwrap();
+        let size_after_first = recovery1.bytes_written;
+
+        // Second checkpoint — no new data, should not grow
+        let recovery2 = writer.checkpoint().unwrap().unwrap();
+        let size_after_second = recovery2.bytes_written;
+
+        // Third checkpoint — still no new data
+        let recovery3 = writer.checkpoint().unwrap().unwrap();
+        let size_after_third = recovery3.bytes_written;
+
+        assert_eq!(
+            size_after_first, size_after_second,
+            "File should not grow on empty checkpoint"
+        );
+        assert_eq!(size_after_second, size_after_third);
+
+        // Verify the file is still valid gzip
+        let compressed = std::fs::read(&recovery3.tmp_file).unwrap();
+        let mut decoder = MultiGzDecoder::new(&compressed[..]);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed).unwrap();
+        assert!(decompressed.contains("initial"));
+    }
+
+    #[test]
+    fn test_write_after_empty_checkpoint() {
+        // Verify that writing data after an empty checkpoint (no data between
+        // checkpoints) still produces valid compressed output.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "field",
+            DataType::Utf8,
+            false,
+        )]));
+
+        let mut writer = create_test_writer(schema.clone(), JsonCompression::Gzip);
+
+        // Empty checkpoint (no data written yet)
+        let (empty_bytes, _) = writer.get_trailing_bytes_for_checkpoint();
+        assert_eq!(empty_bytes.len(), 0, "Should be empty before any writes");
+
+        // Now write data and checkpoint
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["after_empty"]))],
+        )
+        .unwrap();
+        writer.add_batch_data(&batch);
+
+        let (checkpoint_bytes, _) = writer.get_trailing_bytes_for_checkpoint();
+        assert!(!checkpoint_bytes.is_empty(), "Should have data after write");
+
+        // Verify the compressed data is valid and contains our value
+        let mut decoder = MultiGzDecoder::new(&checkpoint_bytes[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        let text = std::str::from_utf8(&decompressed).unwrap();
+        assert!(
+            text.contains("after_empty"),
+            "Decompressed data should contain the written value"
+        );
+    }
+
+    #[test]
+    fn test_close_after_clean_checkpoint() {
+        // Verify that closing after a checkpoint with no new writes still
+        // returns a valid suffix and preserves correct decompression semantics.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "field",
+            DataType::Utf8,
+            false,
+        )]));
+
+        let mut writer = create_test_writer(schema.clone(), JsonCompression::Gzip);
+
+        // Write data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["only_data"]))],
+        )
+        .unwrap();
+        writer.add_batch_data(&batch);
+
+        // Checkpoint (finalizes gzip member). This returns a *copy* of the buffer.
+        let (checkpoint_bytes, _) = writer.get_trailing_bytes_for_checkpoint();
+
+        // Simulate the upload layer draining the buffer (as would happen in real use).
+        let buffered = writer.buffered_bytes();
+        let _ = writer.split_to(buffered);
+
+        // Close with no new writes.
+        let (close_bytes, _) = writer.close();
+
+        // Verify combined bytes remain valid gzip and contain the value exactly once.
+        let mut combined = checkpoint_bytes;
+        combined.extend_from_slice(&close_bytes);
+
+        let mut decoder = MultiGzDecoder::new(&combined[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        let text = std::str::from_utf8(&decompressed).unwrap();
+        assert!(
+            text.contains("only_data"),
+            "Should contain the written data"
+        );
+        assert_eq!(text.lines().count(), 1);
     }
 }

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -72,13 +72,13 @@ impl<W: Write> JsonBuffer<W> {
         }
     }
 
-    fn restore_encoder(&mut self, new_encoder: GzEncoder<W>) {
+    fn restore_encoder(&mut self, writer: W) {
         match self {
             JsonBuffer::Gzipped {
                 encoder: slot @ None,
                 dirty,
             } => {
-                *slot = Some(new_encoder);
+                *slot = Some(GzEncoder::new(writer, GzipCompression::default()));
                 // This is a fresh gzip member; no record bytes were written yet.
                 *dirty = false;
             }
@@ -86,13 +86,43 @@ impl<W: Write> JsonBuffer<W> {
         }
     }
 
-    fn finish_encoder(&mut self) -> std::io::Result<W> {
+    /// Flushes the underlying writer.
+    /// For gzip, this only flushes when the current member is dirty.
+    fn flush(&mut self) -> std::io::Result<()> {
         match self {
+            JsonBuffer::Uncompressed(w) => w.flush(),
             JsonBuffer::Gzipped {
-                encoder: encoder @ Some(_),
-                ..
-            } => encoder.take().unwrap().finish(),
-            _ => panic!("finish_encoder called on non-Gzipped or already-taken buffer"),
+                encoder: Some(enc),
+                dirty,
+            } => {
+                if *dirty {
+                    enc.flush()?;
+                }
+                Ok(())
+            }
+            JsonBuffer::Gzipped { encoder: None, .. } => panic!("flush called after close()"),
+        }
+    }
+
+    /// Finishes and returns the current gzip member only when it has new data.
+    fn finish_gzip_encoder_if_dirty(&mut self) -> std::io::Result<Option<W>> {
+        match self {
+            JsonBuffer::Uncompressed(_) => {
+                panic!("finish_gzip_encoder_if_dirty called on uncompressed buffer")
+            }
+            JsonBuffer::Gzipped { encoder, dirty } => {
+                let Some(enc) = encoder.take() else {
+                    panic!("finish_gzip_encoder_if_dirty called after close()")
+                };
+
+                if *dirty {
+                    *dirty = false;
+                    Ok(Some(enc.finish()?))
+                } else {
+                    *encoder = Some(enc);
+                    Ok(None)
+                }
+            }
         }
     }
 }
@@ -189,31 +219,26 @@ impl BatchBufferingWriter for JsonWriter {
             .freeze()
     }
 
-    /// The bytes stored in the checkpoint are bytes that we are ready to uploaded as-is.
-    /// For compressed mode, we finish the current gzip member to ensure all data is complete.
+    /// The bytes stored in the checkpoint are bytes that we are ready to upload as-is.
+    /// For compressed mode, we finish the current gzip member only if new data was written.
     fn get_trailing_bytes_for_checkpoint(&mut self) -> (Vec<u8>, Option<IcebergFileMetadata>) {
-        let bytes = match &self.buffer {
+        let bytes = match &mut self.buffer {
             JsonBuffer::Uncompressed(inner) => inner.get_ref().to_vec(),
-            JsonBuffer::Gzipped { dirty, .. } => {
-                if *dirty {
-                    // Finish is infallible since the underlying Writer<BytesMut>::write() always returns `Ok`.
-                    // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
-                    let inner = self
-                        .buffer
-                        .finish_encoder()
-                        .expect("Failed to finish gzip encoder at checkpoint");
-
+            // Finish is infallible since the underlying Writer<BytesMut>::write() always returns `Ok`.
+            // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
+            JsonBuffer::Gzipped { .. } => match self
+                .buffer
+                .finish_gzip_encoder_if_dirty()
+                .expect("Failed to finish gzip encoder at checkpoint")
+            {
+                Some(inner) => {
                     let bytes = inner.get_ref().to_vec();
-
-                    self.buffer
-                        .restore_encoder(GzEncoder::new(inner, GzipCompression::default()));
-
+                    self.buffer.restore_encoder(inner);
                     bytes
-                } else {
-                    // No data written since last checkpoint — return existing buffer
-                    self.buffer.writer_ref().get_ref().to_vec()
                 }
-            }
+                // No data written since last checkpoint — return existing buffer
+                None => self.buffer.writer_ref().get_ref().to_vec(),
+            },
         };
         (bytes, None)
     }
@@ -221,21 +246,14 @@ impl BatchBufferingWriter for JsonWriter {
     fn close(&mut self) -> (Bytes, Option<IcebergFileMetadata>) {
         let data = match &mut self.buffer {
             JsonBuffer::Uncompressed(inner) => inner.get_mut().split().freeze(),
-            JsonBuffer::Gzipped { dirty, .. } => {
-                if *dirty {
-                    // Finish infallible, since the underlying Writer<BytesMut>::write() always returns `Ok`.
-                    // Ref: https://docs.rs/crate/bytes/1.11.1/source/src/buf/writer.rs#78-83
-                    let inner = self
-                        .buffer
-                        .finish_encoder()
-                        .expect("Failed to finish gzip encoder at close");
-
-                    inner.into_inner().split().freeze()
-                } else {
-                    // No data written since last checkpoint — return existing buffer
-                    self.buffer.writer_ref_mut().get_mut().split().freeze()
-                }
-            }
+            JsonBuffer::Gzipped { .. } => match self
+                .buffer
+                .finish_gzip_encoder_if_dirty()
+                .expect("Failed to finish gzip encoder at close")
+            {
+                Some(inner) => inner.into_inner().split().freeze(),
+                None => self.buffer.writer_ref_mut().get_mut().split().freeze(),
+            },
         };
 
         (data, None)
@@ -321,35 +339,20 @@ impl LocalWriter for JsonLocalWriter {
     }
 
     fn sync(&mut self) -> anyhow::Result<usize> {
-        match &mut self.buffer {
-            JsonBuffer::Gzipped {
-                dirty,
-                encoder: Some(enc),
-            } => {
-                // Only flush the encoder if it contains data.
-                if *dirty {
-                    enc.flush()?;
-                }
-            }
-            JsonBuffer::Gzipped { encoder: None, .. } => panic!("sync called after close()"),
-            JsonBuffer::Uncompressed(w) => w.flush()?,
-        }
+        self.buffer.flush()?;
         let size = self.buffer.writer_ref().metadata()?.len() as usize;
-        if let Some(stats) = &mut self.stats {
-            stats.bytes_written = size;
-        }
+        self.stats.as_mut().unwrap().bytes_written = size;
         Ok(size)
     }
 
     fn close(&mut self) -> anyhow::Result<super::local::FilePreCommit> {
         match &self.buffer {
             JsonBuffer::Gzipped { .. } => {
-                // Always finalize local gzip on close so file bytes cannot change later
-                // from encoder drop-time writes after we return.
-                let mut file = self.buffer.finish_encoder()?;
-                file.flush()?;
-                if let Some(stats) = &mut self.stats {
-                    stats.bytes_written = file.metadata()?.len() as usize;
+                if let Some(mut file) = self.buffer.finish_gzip_encoder_if_dirty()? {
+                    file.flush()?;
+                    self.stats.as_mut().unwrap().bytes_written = file.metadata()?.len() as usize;
+                } else {
+                    self.sync()?;
                 }
             }
             JsonBuffer::Uncompressed(_) => {
@@ -365,21 +368,19 @@ impl LocalWriter for JsonLocalWriter {
 
     fn checkpoint(&mut self) -> anyhow::Result<Option<super::local::CurrentFileRecovery>> {
         let bytes_written = match &self.buffer {
-            JsonBuffer::Gzipped { dirty, .. } if *dirty => {
-                // Finish the current gzip member (writes trailer), making the file valid
-                // up to this point. We must measure the file size *before* creating a new
-                // encoder, since GzEncoder writes the gzip header on the first flush/write.
-                let mut file = self.buffer.finish_encoder()?;
-                file.flush()?;
-                let size = file.metadata()?.len() as usize;
-                if let Some(stats) = &mut self.stats {
-                    stats.bytes_written = size;
+            JsonBuffer::Gzipped { .. } => match self.buffer.finish_gzip_encoder_if_dirty()? {
+                Some(mut file) => {
+                    // Measure before creating the next member; a fresh GzEncoder can emit a header
+                    // on first flush/write.
+                    file.flush()?;
+                    let size = file.metadata()?.len() as usize;
+                    self.stats.as_mut().unwrap().bytes_written = size;
+                    self.buffer.restore_encoder(file);
+                    size
                 }
-                self.buffer
-                    .restore_encoder(GzEncoder::new(file, GzipCompression::default()));
-                size
-            }
-            _ => self.sync()?,
+                None => self.sync()?,
+            },
+            JsonBuffer::Uncompressed(_) => self.sync()?,
         };
 
         if bytes_written > 0 {
@@ -454,23 +455,6 @@ mod tests {
         ));
 
         JsonWriter::new(&config, format, arroyo_schema, None, event_logger)
-    }
-
-    #[test]
-    fn test_suffix_for_format() {
-        // Test uncompressed
-        let format = Format::Json(JsonFormat {
-            compression: JsonCompression::Uncompressed,
-            ..Default::default()
-        });
-        assert_eq!(JsonWriter::suffix_for_format(&format), "json");
-
-        // Test gzip
-        let format = Format::Json(JsonFormat {
-            compression: JsonCompression::Gzip,
-            ..Default::default()
-        });
-        assert_eq!(JsonWriter::suffix_for_format(&format), "json.gz");
     }
 
     #[test]
@@ -667,21 +651,6 @@ mod tests {
     }
 
     #[test]
-    fn test_local_writer_suffix_for_format() {
-        let format = Format::Json(JsonFormat {
-            compression: JsonCompression::Uncompressed,
-            ..Default::default()
-        });
-        assert_eq!(JsonLocalWriter::file_suffix_for_format(&format), "json");
-
-        let format = Format::Json(JsonFormat {
-            compression: JsonCompression::Gzip,
-            ..Default::default()
-        });
-        assert_eq!(JsonLocalWriter::file_suffix_for_format(&format), "json.gz");
-    }
-
-    #[test]
     fn test_local_writer_uncompressed_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let (schema, arroyo_schema) = local_writer_schema();
@@ -794,45 +763,6 @@ mod tests {
             "File should be truncated to checkpoint size"
         );
 
-        let mut decoder = MultiGzDecoder::new(&compressed[..]);
-        let mut decompressed = String::new();
-        decoder.read_to_string(&mut decompressed).unwrap();
-
-        assert!(decompressed.contains("committed_data"));
-        assert!(!decompressed.contains("uncommitted_data"));
-    }
-
-    #[test]
-    fn test_local_writer_gzip_empty_checkpoint_truncation_recovery() {
-        // Verify that a checkpoint with no new rows still represents a valid
-        // truncation boundary for gzip recovery.
-        let dir = tempfile::tempdir().unwrap();
-        let (schema, arroyo_schema) = local_writer_schema();
-
-        let mut writer = create_test_local_writer(dir.path(), JsonCompression::Gzip, arroyo_schema);
-
-        // Write and checkpoint committed data.
-        let batch1 = local_writer_batch(&schema, vec!["committed_data"]);
-        writer.write_batch(&batch1).unwrap();
-        let _recovery1 = writer.checkpoint().unwrap().unwrap();
-
-        // Checkpoint again without new rows.
-        let recovery2 = writer.checkpoint().unwrap().unwrap();
-
-        // Write data after the second checkpoint (should be lost on recovery).
-        let batch2 = local_writer_batch(&schema, vec!["uncommitted_data"]);
-        writer.write_batch(&batch2).unwrap();
-        drop(writer);
-
-        // Simulate recovery by truncating to second checkpoint boundary.
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&recovery2.tmp_file)
-            .unwrap();
-        file.set_len(recovery2.bytes_written as u64).unwrap();
-        drop(file);
-
-        let compressed = std::fs::read(&recovery2.tmp_file).unwrap();
         let mut decoder = MultiGzDecoder::new(&compressed[..]);
         let mut decompressed = String::new();
         decoder.read_to_string(&mut decompressed).unwrap();


### PR DESCRIPTION
This PR does two things:

1. [Add support for Gzip compression for the JsonLocalWriter](https://github.com/ArroyoSystems/arroyo/commit/62e6dfd93373388a0f92ea9bb49d7fa9563bb2a8)

Very similar to https://github.com/ArroyoSystems/arroyo/pull/1007, but for the Local file backend.


2. [Avoid finishing the encoder if no data was written](https://github.com/ArroyoSystems/arroyo/commit/b40ab7f0e6b004ab4a3506020002811ee13a3d93)

I noticed that the Gzip encoder would produce bytes (header + footer) on every checkpoint even when no user traffic. This patch tracks if we wrote user data to the underlying buffer, marking the buffer as `dirty`, and only finishing the encoder if this flag is set.

The `dirty` flag starts as `false` and is set to `true` when `write_all()` is called. The flag resets to `false` when a new encoder is created.

***
Tested locally a variety of scenarios:
* sink v1, v2 with minio
* sink v2 with local FS
* with and without compression
* with and without data (to test that we don't finish the encoder)
* crashes and recovery