### PR TITLE
Address non-idempotent recovery for initiated multiparts

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
@@ -780,6 +780,10 @@ impl<BBW: BatchBufferingWriter + Send + 'static> ArrowOperator for FileSystemSin
                 futures.extend(file.handle_event(event.data)?);
             }
 
+            if !files.is_empty() {
+                maybe_cause_failure("commit_after_finalize");
+            }
+
             maybe_cause_failure("commit_middle");
 
             // Add finalized multipart files to finished_files

--- a/crates/arroyo-connectors/src/filesystem/sink/v2/open_file.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/open_file.rs
@@ -4,8 +4,9 @@ use crate::filesystem::sink::map_storage_error;
 use crate::filesystem::sink::two_phase_committer::CommitStrategy;
 use crate::filesystem::sink::v2::SinkConfig;
 use crate::filesystem::sink::v2::uploads::{
-    FsResponseData, UploadFuture, create_multipart_finalize_future, create_multipart_init_future,
-    create_part_upload_future, create_single_file_upload_future,
+    FsResponseData, UploadFuture, create_last_parts_upload_future,
+    create_multipart_finalize_future, create_multipart_init_future, create_part_upload_future,
+    create_single_file_upload_future,
 };
 use crate::filesystem::sink::{
     BatchBufferingWriter, FsEventLogger, MultiPartWriterStats, split_into_parts,
@@ -563,6 +564,15 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
                 self.part_upload_completed(part_index, content_id)?;
                 Ok(vec![])
             }
+            FsResponseData::PartsFinished {
+                first_part_index,
+                content_ids,
+            } => {
+                for (i, id) in content_ids.into_iter().enumerate() {
+                    self.part_upload_completed(first_part_index + i, id)?;
+                }
+                Ok(vec![])
+            }
             FsResponseData::SingleFileFinished => {
                 let OpenFileState::Finishing {
                     iceberg_metadata,
@@ -607,6 +617,20 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
                     }
                 };
 
+                Ok(vec![])
+            }
+            FsResponseData::MultipartAlreadyComplete => {
+                self.state = match mem::take(&mut self.state) {
+                    OpenFileState::ClosingMulti {
+                        iceberg_metadata,
+                        total_size,
+                        ..
+                    } => OpenFileState::Closed {
+                        iceberg_metadata,
+                        total_size,
+                    },
+                    other => other,
+                };
                 Ok(vec![])
             }
         }
@@ -714,6 +738,7 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
 
     fn write_last_parts(
         &mut self,
+        bytes_already_written: u64,
         bytes: Bytes,
         multipart_id: Arc<MultipartId>,
         parts: &mut Vec<Part>,
@@ -724,7 +749,7 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
             return vec![];
         }
 
-        let futures = if self.storage_provider.requires_same_part_sizes()
+        let part_bytes = if self.storage_provider.requires_same_part_sizes()
             && bytes.len() > self.target_part_size_bytes
         {
             // our last part is bigger than our part size, which isn't allowed by some object stores
@@ -740,41 +765,30 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
             );
 
             part_bytes
-                .into_iter()
-                .enumerate()
-                .map(|(i, part)| {
-                    create_part_upload_future(
-                        self.storage_provider.clone(),
-                        self.path.clone(),
-                        multipart_id.clone(),
-                        parts.len() + i,
-                        part,
-                        self.logger.clone(),
-                    )
-                })
-                .collect()
         } else {
-            vec![create_part_upload_future(
-                self.storage_provider.clone(),
-                self.path.clone(),
-                multipart_id.clone(),
-                parts.len(),
-                bytes,
-                self.logger.clone(),
-            )]
+            vec![bytes]
         };
 
-        self.stats.parts_written += futures.len();
+        self.stats.parts_written += part_bytes.len();
         self.stats.bytes_written += len;
 
-        for _ in futures.iter() {
+        let first_part_index = parts.len();
+        for _ in part_bytes.iter() {
             parts.push(Part {
                 part_index: parts.len(),
                 content_id: None,
             });
         }
 
-        futures
+        vec![create_last_parts_upload_future(
+            self.storage_provider.clone(),
+            self.path.clone(),
+            multipart_id.clone(),
+            first_part_index,
+            part_bytes,
+            bytes_already_written,
+            self.logger.clone(),
+        )]
     }
 
     pub fn close(&mut self) -> DataflowResult<Vec<UploadFuture>> {
@@ -807,7 +821,12 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
             } => {
                 // write our last parts
                 let (bytes, iceberg_metadata) = writer.close();
-                futures = self.write_last_parts(bytes, multipart_id.clone(), &mut parts);
+                futures = self.write_last_parts(
+                    self.stats.bytes_written as u64,
+                    bytes,
+                    multipart_id.clone(),
+                    &mut parts,
+                );
 
                 OpenFileState::ClosingMulti {
                     multipart_id: multipart_id.clone(),
@@ -823,8 +842,12 @@ impl<BBW: BatchBufferingWriter + 'static> OpenFile<BBW> {
                 iceberg_metadata,
                 total_size,
             } => {
-                futures =
-                    self.write_last_parts(trailing_bytes.clone(), multipart_id.clone(), &mut parts);
+                futures = self.write_last_parts(
+                    total_size as u64,
+                    trailing_bytes.clone(),
+                    multipart_id.clone(),
+                    &mut parts,
+                );
 
                 OpenFileState::ClosingMulti {
                     multipart_id,

--- a/crates/arroyo-connectors/src/filesystem/sink/v2/uploads.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/uploads.rs
@@ -4,12 +4,14 @@ use arroyo_rpc::connector_err;
 use arroyo_rpc::errors::{DataflowError, DataflowResult, StorageError};
 use arroyo_storage::StorageProvider;
 use bytes::Bytes;
+use futures::future::try_join_all;
 use object_store::MultipartId;
 use object_store::path::Path;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
+use tracing::debug;
 
 #[derive(Debug)]
 pub enum FsResponseData {
@@ -20,8 +22,13 @@ pub enum FsResponseData {
         part_index: usize,
         content_id: String,
     },
+    PartsFinished {
+        first_part_index: usize,
+        content_ids: Vec<String>,
+    },
     SingleFileFinished,
     MultipartFinalized,
+    MultipartAlreadyComplete,
 }
 
 #[derive(Debug)]
@@ -84,6 +91,58 @@ pub fn create_part_upload_future(
     })
 }
 
+// writes (possibly) multiple final parts of a file, gracefully handling the case that in
+// recovery the file may have already been completed
+pub fn create_last_parts_upload_future(
+    storage: Arc<StorageProvider>,
+    path: Arc<Path>,
+    multipart_id: Arc<MultipartId>,
+    first_part_index: usize,
+    data: Vec<Bytes>,
+    existing_size: u64,
+    logger: FsEventLogger,
+) -> UploadFuture {
+    debug!("uploading last parts for {:?}", path);
+    let new_bytes = data.iter().map(|f| f.len()).sum();
+
+    Box::pin(async move {
+        let started = Instant::now();
+
+        let uploads = data.into_iter().enumerate().map(|(i, data)| {
+            storage.add_multipart(&path, &multipart_id, first_part_index + i, data)
+        });
+
+        match try_join_all(uploads).await {
+            Ok(parts) => {
+                logger.log_fs_event(new_bytes, 0, started.elapsed(), 0, None, 0, 0, 0);
+
+                Ok(FsResponse {
+                    path,
+                    data: FsResponseData::PartsFinished {
+                        first_part_index,
+                        content_ids: parts.into_iter().map(|p| p.content_id).collect(),
+                    },
+                })
+            }
+            Err(e) => {
+                validate_already_there(
+                    &storage,
+                    &path,
+                    existing_size + new_bytes as u64,
+                    started,
+                    &logger,
+                    e,
+                )
+                .await?;
+                Ok(FsResponse {
+                    path,
+                    data: FsResponseData::MultipartAlreadyComplete,
+                })
+            }
+        }
+    })
+}
+
 pub fn create_single_file_upload_future(
     storage: Arc<StorageProvider>,
     path: Arc<Path>,
@@ -106,6 +165,41 @@ pub fn create_single_file_upload_future(
     })
 }
 
+async fn validate_already_there(
+    storage: &StorageProvider,
+    path: &Path,
+    expected_size: u64,
+    started: Instant,
+    logger: &FsEventLogger,
+    e: StorageError,
+) -> DataflowResult<()> {
+    // check if the file is already there with the correct size -- in which case it means
+    // that we've already finalized it
+    if let Ok(meta) = storage.head(path.as_ref()).await.map_err(map_storage_error) {
+        if meta.size != expected_size {
+            Err(connector_err!(
+                External,
+                NoRetry,
+                "file written to {} should have length of {}, not {}",
+                path,
+                expected_size,
+                meta.size,
+            ))
+        } else {
+            debug!(
+                path = %path,
+                size = expected_size,
+                original_error = %e,
+                "file already exists with expected size; \
+                 treating as successful recovery from prior finalization"
+            );
+            Ok(())
+        }
+    } else {
+        Err(handle_error(started, logger, e))
+    }
+}
+
 pub fn create_multipart_finalize_future(
     storage: Arc<StorageProvider>,
     path: Arc<Path>,
@@ -125,30 +219,13 @@ pub fn create_multipart_finalize_future(
             .close_multipart(&path, &multipart_id, parts.clone())
             .await
         {
-            // check if the file is already there with the correct size -- in which case it means
-            // that we've already finalized it
-            if let Ok(meta) = storage
-                .head(path.as_ref().clone())
-                .await
-                .map_err(map_storage_error)
-            {
-                if meta.size != expected_size as u64 {
-                    return Err(connector_err!(
-                        External,
-                        NoRetry,
-                        "file written to {} should have length of {}, not {}",
-                        path,
-                        expected_size,
-                        meta.size,
-                    ));
-                }
-            } else {
-                return Err(handle_error(started, &logger, e));
-            }
+            // if we fail to close the multipart, check if it's because we've already finalized this
+            // multipart
+            validate_already_there(&storage, &path, expected_size as u64, started, &logger, e)
+                .await?;
         }
 
         logger.log_fs_event(0, 1, started.elapsed(), 0, None, 0, 0, 0);
-
         Ok(FsResponse {
             path,
             data: FsResponseData::MultipartFinalized,


### PR DESCRIPTION
This PR fixes a bug in the filesystem v2 sink which could cause panics on recovery due to an attempt to perform one or more final put part calls on an already completed multipart. The fix is to add logic to the final put parts that checks if the file has already been completed with the correct size, which is the same logic we already had for complete multipart.

In more detail:

The error occurs when we have a a multipart upload in the MultipartStarted phase with buffered data that is being finalized in a commit. At this point, we need to write the final bytes of the file as one or more final parts, and then finalize it. If we fail after the multipart has been finalized but before the commit is acknowledged, on the next recovery we will re-attempt to upload final parts, but this will fail because the multipart is already finalized and cannot be modified. However, we have already written the correct data, just not recorded that we have, so the correct thing to do is, well, nothing. The fix accomplishes that by checking that the file does in fact exist and has the correct size.

This change has been tested by injecting failures into the commit phase at the right point to trigger the issue and validating that we recover correctly.