### PR TITLE
Improve Iceberg error mappings

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/iceberg/metadata.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/iceberg/metadata.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, bail};
 use std::collections::HashMap;
 
 use crate::filesystem::config::IcebergPartitioning;
+use arroyo_rpc::connector_err;
+use arroyo_rpc::errors::DataflowResult;
 use bincode::{Decode, Encode};
 use iceberg::spec::{
     DataContentType, DataFile, DataFileBuilder, DataFileFormat, Datum, ListType, Literal, MapType,
@@ -124,7 +126,7 @@ pub fn build_datafile_from_meta(
     file_path: String,
     file_size_bytes: u64,
     partition_spec_id: i32,
-) -> anyhow::Result<DataFile> {
+) -> DataflowResult<DataFile> {
     let mut column_sizes: HashMap<i32, u64> = HashMap::new();
     let mut value_counts: HashMap<i32, u64> = HashMap::new();
     let mut null_counts: HashMap<i32, u64> = HashMap::new();
@@ -146,11 +148,13 @@ pub fn build_datafile_from_meta(
         };
 
         if let Some(min) = &acc.bounds.min {
-            lower_bounds.insert(*fid, Datum::try_from_bytes(min, pt.clone())?);
+            lower_bounds.insert(*fid, Datum::try_from_bytes(min, pt.clone())
+                .map_err(|e| connector_err!(Internal, WithBackoff, source: e.into(), "error computing lower bound"))?);
         }
 
         if let Some(max) = &acc.bounds.max {
-            upper_bounds.insert(*fid, Datum::try_from_bytes(max, pt.clone())?);
+            upper_bounds.insert(*fid, Datum::try_from_bytes(max, pt.clone())
+                .map_err(|e| connector_err!(Internal, WithBackoff, source: e.into(), "error computing upper bound"))?);
         }
     }
 
@@ -165,15 +169,15 @@ pub fn build_datafile_from_meta(
                 .get(&f_id)
                 .ok_or_else(|| anyhow!("no metadata for partition field '{}'", f.field))?;
             let fun = create_transform_function(&f.transform_fn.into())?;
-            let result = fun
-                .transform_literal_result(v)
-                .map_err(|_| anyhow!("failed to compute partition function {}", f))?;
+            let result = fun.transform_literal_result(v)?;
 
             Ok(Some(Literal::Primitive(result.literal().clone())))
         })
         .collect();
 
-    let partition = iceberg::spec::Struct::from_iter(partition?);
+    let partition = iceberg::spec::Struct::from_iter(partition.map_err(
+        |e| connector_err!(Internal, WithBackoff, source: e, "error computing partition"),
+    )?);
 
     let df = DataFileBuilder::default()
         .file_path(file_path)
@@ -189,7 +193,8 @@ pub fn build_datafile_from_meta(
         .null_value_counts(null_counts)
         .lower_bounds(lower_bounds)
         .upper_bounds(upper_bounds)
-        .build()?;
+        .build()
+        .expect("missing required field in DataFileBuilder");
 
     Ok(df)
 }

--- a/crates/arroyo-connectors/src/filesystem/sink/iceberg/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/iceberg/mod.rs
@@ -9,7 +9,7 @@ use crate::filesystem::sink::iceberg::schema::add_parquet_field_ids;
 use anyhow::anyhow;
 use arrow::datatypes::Schema;
 use arroyo_rpc::connector_err;
-use arroyo_rpc::errors::{DataflowError, ErrorDomain, RetryHint};
+use arroyo_rpc::errors::{DataflowError, DataflowResult, ErrorDomain, RetryHint};
 use arroyo_storage::StorageProvider;
 use arroyo_types::TaskInfo;
 use iceberg::spec::ManifestFile;
@@ -310,7 +310,7 @@ impl IcebergTable {
         &mut self,
         epoch: u32,
         finished_files: &[FinishedFile],
-    ) -> anyhow::Result<()> {
+    ) -> DataflowResult<()> {
         if finished_files.is_empty() {
             debug!("no new files, skipping commit");
             return Ok(());
@@ -373,13 +373,19 @@ impl IcebergTable {
             )
             .add_data_files(files)
             .with_check_duplicate(false)
-            .apply(tx)?;
+            .apply(tx)
+            .map_err(map_iceberg_error)?;
 
-        tx.commit(&self.catalog).await?;
+        tx.commit(&self.catalog).await.map_err(map_iceberg_error)?;
         debug!("finished iceberg commit");
         // the tx.commit call returns the table but the FileIO somehow ends up misconfigured in such
         // a way that breaks future IO operations
-        self.table = Some(self.catalog.load_table(&self.table_ident).await?);
+        self.table = Some(
+            self.catalog
+                .load_table(&self.table_ident)
+                .await
+                .map_err(map_iceberg_error)?,
+        );
 
         Ok(())
     }

--- a/crates/arroyo-connectors/src/filesystem/sink/json.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/json.rs
@@ -7,6 +7,7 @@ use crate::filesystem::config;
 use crate::filesystem::sink::iceberg::metadata::IcebergFileMetadata;
 use arrow::record_batch::RecordBatch;
 use arroyo_formats::ser::ArrowSerializer;
+use arroyo_rpc::errors::DataflowResult;
 use arroyo_rpc::{
     df::ArroyoSchemaRef,
     formats::{Format, JsonCompression, JsonFormat},
@@ -140,7 +141,7 @@ impl BatchBufferingWriter for JsonWriter {
         _schema: ArroyoSchemaRef,
         _: Option<::iceberg::spec::SchemaRef>,
         event_logger: FsEventLogger,
-    ) -> Self {
+    ) -> DataflowResult<Self> {
         let compression = if let Format::Json(ref json) = format {
             json.compression
         } else {
@@ -158,11 +159,11 @@ impl BatchBufferingWriter for JsonWriter {
             },
         };
 
-        Self {
+        Ok(Self {
             buffer,
             serializer: ArrowSerializer::new(format),
             event_logger,
-        }
+        })
     }
 
     fn suffix_for_format(format: &Format) -> &str {
@@ -454,7 +455,7 @@ mod tests {
             None,
         ));
 
-        JsonWriter::new(&config, format, arroyo_schema, None, event_logger)
+        JsonWriter::new(&config, format, arroyo_schema, None, event_logger).unwrap()
     }
 
     #[test]

--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -2,7 +2,7 @@ use ::arrow::record_batch::RecordBatch;
 use ::arrow::row::OwnedRow;
 use arroyo_operator::context::OperatorContext;
 use arroyo_rpc::connector_err;
-use arroyo_rpc::errors::{DataflowError, DataflowResult as Result, StorageError};
+use arroyo_rpc::errors::{DataflowError, DataflowResult as Result, DataflowResult, StorageError};
 use arroyo_rpc::{df::ArroyoSchemaRef, formats::Format, log_trace_event};
 use arroyo_storage::StorageProvider;
 use arroyo_types::*;
@@ -794,7 +794,7 @@ where
                 Some(message) = self.receiver.recv() => {
                     match message {
                         FileSystemMessages::Data{value, partition} => {
-                            if let Some(future) = self.get_or_insert_writer(&partition).insert_batch(value).await? {
+                            if let Some(future) = self.get_or_insert_writer(&partition)?.insert_batch(value).await? {
                                 self.futures.push(future);
                             }
                         },
@@ -882,19 +882,23 @@ where
     fn get_or_insert_writer(
         &mut self,
         partition: &Option<OwnedRow>,
-    ) -> &mut BatchMultipartWriter<BBW> {
+    ) -> DataflowResult<&mut BatchMultipartWriter<BBW>> {
         if !self.active_writers.contains_key(partition) {
-            let new_writer = self.new_writer(partition);
+            let new_writer = self.new_writer(partition)?;
             self.active_writers
                 .insert(partition.clone(), new_writer.name());
             self.writers.insert(new_writer.name(), new_writer);
         }
-        self.writers
+        Ok(self
+            .writers
             .get_mut(self.active_writers.get(partition).unwrap())
-            .unwrap()
+            .unwrap())
     }
 
-    fn new_writer(&mut self, partition: &Option<OwnedRow>) -> BatchMultipartWriter<BBW> {
+    fn new_writer(
+        &mut self,
+        partition: &Option<OwnedRow>,
+    ) -> DataflowResult<BatchMultipartWriter<BBW>> {
         let filename_strategy = self.file_naming.strategy.unwrap_or_default();
 
         // This forms the base for naming files depending on strategy
@@ -1502,7 +1506,9 @@ pub trait BatchBufferingWriter: Send {
         schema: ArroyoSchemaRef,
         iceberg_schema: Option<::iceberg::spec::SchemaRef>,
         event_logger: FsEventLogger,
-    ) -> Self;
+    ) -> DataflowResult<Self>
+    where
+        Self: Sized;
 
     /// Returns the file suffix based on the format configuration.
     /// This allows writers to customize the suffix based on format options
@@ -1544,16 +1550,16 @@ impl<BBW: BatchBufferingWriter> BatchMultipartWriter<BBW> {
         schema: ArroyoSchemaRef,
         iceberg_schema: Option<::iceberg::spec::SchemaRef>,
         event_logger: FsEventLogger,
-    ) -> Self {
+    ) -> DataflowResult<Self> {
         let batch_buffering_writer = BBW::new(
             config,
             format,
             schema.clone(),
             iceberg_schema,
             event_logger.clone(),
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             batch_buffering_writer,
             multipart_manager: MultipartManager::new(object_store, path, event_logger),
             stats: None,
@@ -1564,7 +1570,7 @@ impl<BBW: BatchBufferingWriter> BatchMultipartWriter<BBW> {
                 .map(|t| t as usize)
                 .unwrap_or(DEFAULT_TARGET_PART_SIZE),
             metadata: None,
-        }
+        })
     }
 
     fn name(&self) -> String {

--- a/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/parquet.rs
@@ -10,8 +10,9 @@ use crate::filesystem::sink::iceberg::schema::{
 use anyhow::Result;
 use arrow::array::{Array, RecordBatch, TimestampNanosecondArray};
 use arrow::datatypes::SchemaRef;
+use arroyo_rpc::errors::DataflowResult;
 use arroyo_rpc::formats::{ParquetCompression, ParquetFormat};
-use arroyo_rpc::{df::ArroyoSchemaRef, formats::Format};
+use arroyo_rpc::{connector_err, df::ArroyoSchemaRef, formats::Format};
 use arroyo_types::from_nanos;
 use bytes::{BufMut, Bytes, BytesMut};
 use parquet::{
@@ -104,7 +105,7 @@ impl BatchBufferingWriter for ParquetBatchBufferingWriter {
         schema: ArroyoSchemaRef,
         iceberg_schema: Option<iceberg::spec::SchemaRef>,
         event_logger: FsEventLogger,
-    ) -> Self {
+    ) -> DataflowResult<Self> {
         let Format::Parquet(parquet) = format else {
             panic!("ParquetBatchBufferingWriter configured with non-parquet format {format:?}");
         };
@@ -116,7 +117,8 @@ impl BatchBufferingWriter for ParquetBatchBufferingWriter {
         let mut writer_schema = schema.schema_without_timestamp();
         if let Some(iceberg) = &iceberg_schema {
             writer_schema = update_field_ids_to_iceberg(&writer_schema, iceberg)
-                .expect("failed to assign iceberg ids to schema")
+                .map_err(|e|
+                    connector_err!(User, NoRetry, source: e, "schema in Iceberg table has been modified: {}", e))?;
         };
 
         let writer_schema = Arc::new(writer_schema);
@@ -128,7 +130,7 @@ impl BatchBufferingWriter for ParquetBatchBufferingWriter {
         )
         .unwrap();
 
-        Self {
+        Ok(Self {
             writer: Some(writer),
             buffer,
             row_group_size_bytes,
@@ -136,7 +138,7 @@ impl BatchBufferingWriter for ParquetBatchBufferingWriter {
             schema,
             iceberg_schema,
             event_logger,
-        }
+        })
     }
 
     fn suffix_for_format(format: &Format) -> &str {

--- a/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/mod.rs
@@ -212,7 +212,7 @@ impl<BBW: BatchBufferingWriter> ActiveState<BBW> {
         context: &SinkContext,
         partition: &Option<OwnedRow>,
         representative_ts: SystemTime,
-    ) -> &mut OpenFile<BBW> {
+    ) -> DataflowResult<&mut OpenFile<BBW>> {
         let file = self
             .active_partitions
             .get(partition)
@@ -228,7 +228,7 @@ impl<BBW: BatchBufferingWriter> ActiveState<BBW> {
                 context.schema.clone(),
                 context.iceberg_schema.clone(),
                 logger.clone(),
-            );
+            )?;
 
             let open_file = OpenFile::new(
                 path.clone(),
@@ -247,7 +247,7 @@ impl<BBW: BatchBufferingWriter> ActiveState<BBW> {
         }
 
         let file_path = self.active_partitions.get(partition).unwrap();
-        self.open_files.get_mut(file_path).unwrap()
+        Ok(self.open_files.get_mut(file_path).unwrap())
     }
 }
 
@@ -522,7 +522,7 @@ impl<BBW: BatchBufferingWriter + Send + 'static> ArrowOperator for FileSystemSin
                 self.context.as_ref().unwrap(),
                 &partition_key,
                 representative_timestamp,
-            );
+            )?;
             let future = file.add_batch(&sub_batch)?;
 
             if let Some(future) = future {
@@ -812,15 +812,13 @@ impl<BBW: BatchBufferingWriter + Send + 'static> ArrowOperator for FileSystemSin
                     )
                         .await
                         .map_err(
-                            |e| connector_err!(External, WithBackoff, source: e, "failed to commit to delta"),
+                            |e| connector_err!(External, WithBackoff, source: e, "failed to commit to delta: {e}"),
                         )? {
                         *last_version = new_version;
                     }
                 }
                 CommitState::Iceberg(table) => {
-                    table.commit(epoch, &finished_files).await.map_err(
-                        |e| connector_err!(External, WithBackoff, source: e, "failed to commit to iceberg"),
-                    )?;
+                    table.commit(epoch, &finished_files).await?;
                 }
                 CommitState::VanillaParquet => {
                     // Nothing to do


### PR DESCRIPTION
Addresses a panic when there is a schema mismatch between arroyo and the iceberg table (i.e., the user changed the iceberg schema externally) and improves mapping from commit errors.