### PR TITLE
Introduce worker job controller mode

### DIFF
--- a/crates/arroyo-api/src/metrics.rs
+++ b/crates/arroyo-api/src/metrics.rs
@@ -8,7 +8,7 @@ use arroyo_rpc::api_types::OperatorMetricGroupCollection;
 use arroyo_rpc::api_types::metrics::OperatorMetricGroup;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc::JobMetricsReq;
-use arroyo_rpc::grpc::rpc::controller_grpc_client::ControllerGrpcClient;
+use arroyo_rpc::grpc::rpc::job_controller_grpc_client::JobControllerGrpcClient;
 use tonic::Code;
 use tonic::codec::CompressionEncoding;
 use tracing::error;
@@ -53,7 +53,7 @@ pub async fn get_operator_metric_groups(
         service_unavailable("controller-service")
     })?;
 
-    let mut controller = ControllerGrpcClient::new(channel)
+    let mut controller = JobControllerGrpcClient::new(channel)
         .accept_compressed(CompressionEncoding::Zstd)
         .send_compressed(CompressionEncoding::Zstd);
 

--- a/crates/arroyo-controller/src/job_controller/checkpoint_store.rs
+++ b/crates/arroyo-controller/src/job_controller/checkpoint_store.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use arroyo_rpc::checkpoints::{
+    CheckpointMetadataStore, CheckpointStatus, CreateCheckpointReq, FinishCheckpointReq,
+    UpdateCheckpointReq,
+};
+use arroyo_rpc::notify_db;
+use cornucopia_async::DatabaseSource;
+use std::sync::Arc;
+use time::OffsetDateTime;
+
+use crate::queries::controller_queries;
+use crate::types::public::CheckpointState as DbCheckpointState;
+
+pub struct DbCheckpointMetadataStore {
+    pub organization_id: String,
+    pub job_id: Arc<String>,
+    pub db: DatabaseSource,
+    pub state_backend: &'static str,
+}
+
+fn to_db_state(status: CheckpointStatus) -> DbCheckpointState {
+    match status {
+        CheckpointStatus::InProgress => DbCheckpointState::inprogress,
+        CheckpointStatus::Committing => DbCheckpointState::committing,
+        CheckpointStatus::Ready => DbCheckpointState::ready,
+        CheckpointStatus::Failed => DbCheckpointState::failed,
+        CheckpointStatus::Compacting => DbCheckpointState::compacting,
+        CheckpointStatus::Compacted => DbCheckpointState::compacted,
+    }
+}
+
+#[async_trait::async_trait]
+impl CheckpointMetadataStore for DbCheckpointMetadataStore {
+    async fn create_checkpoint(&self, req: CreateCheckpointReq) -> Result<()> {
+        let c = self.db.client().await?;
+        controller_queries::execute_create_checkpoint(
+            &c,
+            &req.checkpoint_id,
+            &self.organization_id,
+            &*self.job_id,
+            &self.state_backend,
+            &(req.epoch as i32),
+            &(req.min_epoch as i32),
+            &OffsetDateTime::from(req.start_time),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn update_checkpoint(&self, req: UpdateCheckpointReq) -> Result<()> {
+        let c = self.db.client().await?;
+        let finish_time: Option<OffsetDateTime> = req.finish_time.map(OffsetDateTime::from);
+        controller_queries::execute_update_checkpoint(
+            &c,
+            &req.operator_details,
+            &finish_time,
+            &to_db_state(req.status),
+            &req.event_spans,
+            &req.checkpoint_id,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn finish_checkpoint(&self, req: FinishCheckpointReq) -> Result<()> {
+        let c = self.db.client().await?;
+        controller_queries::execute_commit_checkpoint(
+            &c,
+            &OffsetDateTime::from(req.finish_time),
+            &req.event_spans,
+            &req.checkpoint_id,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn mark_compacting(&self, job_id: &str, min_epoch: u32, new_min: u32) -> Result<()> {
+        let c = self.db.client().await?;
+        controller_queries::execute_mark_compacting(
+            &c,
+            &job_id,
+            &(min_epoch as i32),
+            &(new_min as i32),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn mark_checkpoints_compacted(&self, job_id: &str, epoch: u32) -> Result<()> {
+        let c = self.db.client().await?;
+        controller_queries::execute_mark_checkpoints_compacted(&c, &job_id, &(epoch as i32))
+            .await?;
+        Ok(())
+    }
+
+    async fn drop_old_checkpoint_rows(&self, job_id: &str, epoch: u32) -> Result<()> {
+        let c = self.db.client().await?;
+        controller_queries::execute_drop_old_checkpoint_rows(&c, &job_id, &(epoch as i32)).await?;
+        Ok(())
+    }
+
+    fn notify_checkpoint_complete(&self) {
+        notify_db();
+    }
+}

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -66,6 +66,14 @@ impl LeaderManager {
             );
         }
 
+        if response.run_id != self.run_id {
+            bail!(
+                "leader returned job status for wrong run: expected {}, got {}",
+                self.run_id,
+                response.run_id
+            );
+        }
+
         let status = response
             .job_status
             .ok_or_else(|| anyhow!("leader returned empty job status"))?;

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -1,0 +1,205 @@
+use crate::JobMessage;
+use crate::states::leader_stopping::{LeaderStopBehavior, LeaderStopping};
+use crate::states::recovering::Recovering;
+use crate::states::{JobContext, State, StateError, Transition, TransitionTo, fatal};
+use crate::types::public::StopMode as SqlStopMode;
+use anyhow::{anyhow, bail};
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient;
+use arroyo_rpc::grpc::rpc::{JobFailure, JobState, JobStatusReq, JobStopMode, StopJobReq};
+use arroyo_rpc::{job_status_client, retry};
+use arroyo_types::JobId;
+use std::time::{Duration, Instant};
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+pub struct LeaderManager {
+    leader_client: JobStatusGrpcClient<Channel>,
+    pub job_id: JobId,
+    pub run_id: u64,
+    pub last_heartbeat: Instant,
+}
+
+impl LeaderManager {
+    pub async fn connect(job_id: JobId, run_id: u64, addr: String) -> anyhow::Result<Self> {
+        let leader_client = retry!(
+            job_status_client("controller", &config().worker.tls, addr.clone()).await,
+            5,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+            |e| warn!(job_id = *job_id.0, message = "failed to connect to worker leader", error = ?e)
+        )?;
+
+        Ok(Self {
+            job_id,
+            run_id,
+            leader_client,
+            last_heartbeat: Instant::now(),
+        })
+    }
+
+    pub async fn poll_leader_status(&mut self) -> anyhow::Result<rpc::JobStatus> {
+        let response = retry!(
+            self.leader_client.get_job_status(JobStatusReq {
+                  job_id: self.job_id.to_string(),
+                }).await,
+                5,
+                Duration::from_millis(100),
+                Duration::from_secs(2),
+                |e| warn!(job_id = *self.job_id.0, message = "failed to poll for job status", error = ?e)
+        )?.into_inner();
+
+        if response.job_id != *self.job_id.0 {
+            bail!(
+                "leader returned job status for wrong job: expected {}, got {}",
+                self.job_id,
+                response.job_id
+            );
+        }
+
+        if response.run_id != self.run_id {
+            bail!(
+                "leader returned job status for wrong run: expected {}, got {}",
+                self.run_id,
+                response.run_id
+            );
+        }
+
+        let status = response
+            .job_status
+            .ok_or_else(|| anyhow!("leader returned empty job status"))?;
+
+        self.last_heartbeat = Instant::now();
+
+        Ok(status)
+    }
+
+    pub async fn stop_leader(&mut self, stop_mode: JobStopMode) -> anyhow::Result<()> {
+        info!(
+            message = "sending stop request to leader",
+            job_id = *self.job_id.0,
+            stop_mode = ?stop_mode,
+        );
+
+        self.leader_client
+            .stop_job(StopJobReq {
+                stop_mode: stop_mode as i32,
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn wait_for_state(&mut self, expected: rpc::JobState) -> anyhow::Result<()> {
+        let mut timer = tokio::time::interval(Duration::from_millis(200));
+        loop {
+            let status = self.poll_leader_status().await?;
+
+            let state = JobState::try_from(status.job_state)
+                .map_err(|e| anyhow!("received invalid job state from leader: {e}"))?;
+
+            if state == expected {
+                return Ok(());
+            }
+
+            match state {
+                JobState::JobUnknown => bail!("received unknown job status"),
+                JobState::JobInitializing
+                | JobState::JobRunning
+                | JobState::JobStopping
+                | JobState::JobFinishing
+                | JobState::JobFailing => {
+                    // non-terminal states, continue waiting
+                }
+                JobState::JobStopped | JobState::JobFinished | JobState::JobFailed => {
+                    bail!(
+                        "reached unexpected terminal state {:?} while waiting for {:?}",
+                        state,
+                        expected
+                    );
+                }
+            }
+
+            timer.tick().await;
+        }
+    }
+}
+
+pub async fn handle_leader_stopping<'a, S, T>(
+    state: S,
+    ctx: &mut JobContext<'a>,
+    expected_state: rpc::JobState,
+    next: T,
+    timeout: Option<Duration>,
+) -> Result<Transition, StateError>
+where
+    S: State,
+    T: State,
+    S: TransitionTo<T>,
+    S: TransitionTo<LeaderStopping>,
+    S: TransitionTo<Recovering>,
+{
+    let started = Instant::now();
+
+    loop {
+        let timeout = timeout
+            .map(|t| (started + t).saturating_duration_since(Instant::now()))
+            .unwrap_or(Duration::MAX);
+
+        tokio::select! {
+            msg = ctx.rx.recv() => {
+                match msg {
+                    Some(JobMessage::ConfigUpdate(c)) => {
+                        let next = match c.stop_mode {
+                            SqlStopMode::force => {
+                                Some(LeaderStopBehavior::StopWorkers)
+                            }
+                            SqlStopMode::immediate => {
+                                Some(LeaderStopBehavior::StopJob(JobStopMode::JobStopImmediate))
+                            }
+                            SqlStopMode::graceful => {
+                                Some(LeaderStopBehavior::StopJob(JobStopMode::JobStopGraceful))
+                            }
+                            SqlStopMode::none | SqlStopMode::checkpoint => {
+                                // do nothing
+                                None
+                            }
+                        };
+
+                        if let Some(stop_behavior) = next {
+                            return Ok(Transition::next(state, LeaderStopping {
+                                stop_behavior
+                            }));
+                        }
+                    }
+                    Some(msg) => {
+                        warn!(job_id = *ctx.config.id, ?msg, "unexpected job message in leader leader mode");
+                    }
+                    None => {
+                        panic!("job queue shut down");
+                    }
+                }
+            }
+            resp = ctx.leader_manager.as_mut().expect("leader manager not initialized").wait_for_state(expected_state) => {
+                if let Err(e) = resp {
+                    return Err(fatal("failed while waiting for final checkpoint", e));
+                }
+                return Ok(Transition::next(
+                    state,
+                    next,
+                ));
+            }
+            _ = tokio::time::sleep(timeout) => {
+                return ctx.handle_job_failure(state, JobFailure {
+                    operator_id: None,
+                    task_id: None,
+                    subtask_index: None,
+                    message: "timed out while taking final checkpoint".to_string(),
+                    error_domain: rpc::ErrorDomain::Internal as i32,
+                    retry_hint: rpc::RetryHint::WithBackoff as i32,
+                }).await;
+            }
+        }
+    }
+}

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -2,610 +2,46 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{
     collections::HashMap,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use crate::types::public::StopMode as SqlStopMode;
 use anyhow::bail;
+use arroyo_rpc::checkpoints::CheckpointMetadataStore;
 use arroyo_rpc::grpc::rpc::{
-    CheckpointReq, CommitReq, JobFinishedReq, LabelPair, LoadCompactedDataReq, MetricsReq,
-    StopExecutionReq, StopMode, TaskCheckpointEventType, worker_grpc_client::WorkerGrpcClient,
+    CommitReq, LabelPair, MetricsReq, StopExecutionReq, StopMode,
+    worker_grpc_client::WorkerGrpcClient,
 };
 use arroyo_state::{BackingStore, StateBackend};
-use arroyo_types::{WorkerId, to_micros};
-use cornucopia_async::DatabaseSource;
+use arroyo_types::WorkerId;
 use rand::{Rng, rng};
 
-use time::OffsetDateTime;
-
 use crate::job_controller::job_metrics::{JobMetrics, get_metric_name};
-use crate::types::public::CheckpointState as DbCheckpointState;
-use crate::{JobConfig, JobMessage, queries::controller_queries};
+use crate::{JobConfig, JobMessage};
 use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::api_types::checkpoints::{JobCheckpointEventType, JobCheckpointSpan};
 use arroyo_rpc::api_types::metrics::MetricName;
-use arroyo_rpc::config::config;
-use arroyo_rpc::notify_db;
-use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
-use arroyo_state::checkpoint_state::CheckpointState;
 use arroyo_state::committing_state::CommittingState;
-use arroyo_state::parquet::ParquetBackend;
-use futures::future::try_join_all;
+use arroyo_worker::job_controller::model::{
+    CheckpointingOrCommittingState, JobState, RunningJobModel, TaskState, TaskStatus, WorkerState,
+    WorkerStatus,
+};
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
-use tonic::{Request, transport::Channel};
-use tracing::{debug, error, info, warn};
+use tonic::transport::Channel;
+use tracing::{error, info, warn};
 
+pub mod checkpoint_store;
 pub mod job_metrics;
+pub mod leader_manager;
 
-const CHECKPOINTS_TO_KEEP: u32 = 4;
 const CHECKPOINT_ROWS_TO_KEEP: u32 = 100;
-const COMPACT_EVERY: u32 = 2;
-
-pub enum CheckpointingOrCommittingState {
-    Checkpointing(CheckpointState),
-    Committing(CommittingState),
-}
-
-impl CheckpointingOrCommittingState {
-    pub(crate) fn done(&self) -> bool {
-        match self {
-            CheckpointingOrCommittingState::Checkpointing(checkpointing) => checkpointing.done(),
-            CheckpointingOrCommittingState::Committing(committing) => committing.done(),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum WorkerState {
-    Running,
-    Stopped,
-}
-
-#[allow(unused)]
-pub struct WorkerStatus {
-    id: WorkerId,
-    connect: WorkerGrpcClient<Channel>,
-    last_heartbeat: Instant,
-    state: WorkerState,
-}
-
-impl WorkerStatus {
-    fn heartbeat_timeout(&self) -> bool {
-        self.last_heartbeat.elapsed() > *config().pipeline.worker_heartbeat_timeout
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum TaskState {
-    Running,
-    Finished,
-    Failed(TaskFailedEvent),
-}
-
-#[derive(Debug)]
-pub struct TaskStatus {
-    state: TaskState,
-}
-
-// Stores a model of the current state of a running job to use in the state machine
-#[derive(Debug, PartialEq, Eq)]
-pub enum JobState {
-    Running,
-    Stopped,
-}
-
-pub struct RunningJobModel {
-    job_id: Arc<String>,
-    state: JobState,
-    program: Arc<LogicalProgram>,
-    checkpoint_state: Option<CheckpointingOrCommittingState>,
-    epoch: u32,
-    min_epoch: u32,
-    last_checkpoint: Instant,
-    workers: HashMap<WorkerId, WorkerStatus>,
-    tasks: HashMap<(u32, u32), TaskStatus>,
-    operator_parallelism: HashMap<u32, usize>,
-    metrics: JobMetrics,
-    metric_update_task: Option<JoinHandle<()>>,
-    last_updated_metrics: Instant,
-
-    // checkpoint-wide events
-    pub checkpoint_spans: Vec<JobCheckpointSpan>,
-}
-
-impl std::fmt::Debug for RunningJobModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RunningJobModel")
-            .field("job_id", &self.job_id)
-            .field("state", &self.state)
-            .field("checkpointing", &self.checkpoint_state.is_some())
-            .field("epoch", &self.epoch)
-            .field("min_epoch", &self.min_epoch)
-            .field("last_checkpoint", &self.last_checkpoint)
-            .finish()
-    }
-}
-
-impl RunningJobModel {
-    pub async fn update_db(&self, db: &DatabaseSource) -> anyhow::Result<()> {
-        let c = db.client().await?;
-
-        if let Some(CheckpointingOrCommittingState::Checkpointing(checkpoint_state)) =
-            &self.checkpoint_state
-        {
-            controller_queries::execute_update_checkpoint(
-                &c,
-                &serde_json::to_value(&checkpoint_state.operator_details).unwrap(),
-                &None,
-                &DbCheckpointState::inprogress,
-                &serde_json::to_value(&self.checkpoint_spans).unwrap(),
-                &checkpoint_state.checkpoint_id(),
-            )
-            .await?;
-        }
-
-        Ok(())
-    }
-
-    pub async fn update_checkpoint_in_db(
-        &self,
-        checkpoint_state: &CheckpointState,
-        db: &DatabaseSource,
-        db_checkpoint_state: DbCheckpointState,
-    ) -> anyhow::Result<()> {
-        let c = db.client().await?;
-        let finish_time = if db_checkpoint_state == DbCheckpointState::ready {
-            Some(SystemTime::now().into())
-        } else {
-            None
-        };
-        let operator_state = serde_json::to_value(&checkpoint_state.operator_details).unwrap();
-        controller_queries::execute_update_checkpoint(
-            &c,
-            &operator_state,
-            &finish_time,
-            &db_checkpoint_state,
-            &serde_json::to_value(&self.checkpoint_spans).unwrap(),
-            &checkpoint_state.checkpoint_id(),
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    pub async fn finish_committing(
-        &self,
-        checkpoint_id: &str,
-        db: &DatabaseSource,
-    ) -> anyhow::Result<()> {
-        info!("finishing committing");
-        let finish_time = SystemTime::now();
-
-        let c = db.client().await?;
-        controller_queries::execute_commit_checkpoint(
-            &c,
-            &finish_time.into(),
-            &serde_json::to_value(&self.checkpoint_spans).unwrap(),
-            &checkpoint_id,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    pub async fn handle_message(
-        &mut self,
-        msg: RunningMessage,
-        db: &DatabaseSource,
-    ) -> anyhow::Result<()> {
-        match msg {
-            RunningMessage::TaskCheckpointEvent(c) => {
-                if let Some(checkpoint_state) = &mut self.checkpoint_state {
-                    if c.epoch != self.epoch {
-                        warn!(
-                            message = "Received checkpoint event for wrong epoch",
-                            epoch = c.epoch,
-                            expected = self.epoch,
-                            job_id = *self.job_id,
-                        );
-                    } else {
-                        match checkpoint_state {
-                            CheckpointingOrCommittingState::Checkpointing(checkpoint_state) => {
-                                checkpoint_state.checkpoint_event(c)?;
-                            }
-                            CheckpointingOrCommittingState::Committing(committing_state) => {
-                                if matches!(c.event_type(), TaskCheckpointEventType::FinishedCommit)
-                                {
-                                    committing_state
-                                        .subtask_committed(c.operator_id.clone(), c.subtask_idx);
-                                    self.compact_state().await?;
-                                } else {
-                                    warn!("unexpected checkpoint event type {:?}", c.event_type())
-                                }
-                            }
-                        };
-                        self.update_db(db).await?;
-                    }
-                } else {
-                    debug!(
-                        message = "Received checkpoint event but not checkpointing",
-                        job_id = *self.job_id,
-                        event = format!("{:?}", c)
-                    )
-                }
-            }
-            RunningMessage::TaskCheckpointFinished(c) => {
-                if let Some(checkpoint_state) = &mut self.checkpoint_state {
-                    if c.epoch != self.epoch {
-                        warn!(
-                            message = "Received checkpoint finished for wrong epoch",
-                            epoch = c.epoch,
-                            expected = self.epoch,
-                            job_id = *self.job_id,
-                        );
-                    } else {
-                        let CheckpointingOrCommittingState::Checkpointing(checkpoint_state) =
-                            checkpoint_state
-                        else {
-                            bail!("Received checkpoint finished but not checkpointing");
-                        };
-                        checkpoint_state.checkpoint_finished(c).await?;
-
-                        if checkpoint_state.done()
-                            && let Some(e) = self
-                                .checkpoint_spans
-                                .iter_mut()
-                                .find(|e| e.event == JobCheckpointEventType::CheckpointingOperators)
-                        {
-                            e.finish()
-                        }
-
-                        self.update_db(db).await?;
-                    }
-                } else {
-                    warn!(
-                        message = "Received checkpoint finished but not checkpointing",
-                        job_id = *self.job_id
-                    )
-                }
-            }
-            RunningMessage::TaskFinished {
-                worker_id: _,
-                time: _,
-                task_id,
-                subtask_idx,
-            } => {
-                let key = (task_id, subtask_idx);
-                if let Some(status) = self.tasks.get_mut(&key) {
-                    status.state = TaskState::Finished;
-                } else {
-                    warn!(
-                        message = "Received task finished for unknown task",
-                        job_id = *self.job_id,
-                        task_id = key.0,
-                        subtask_idx
-                    );
-                }
-            }
-            RunningMessage::TaskFailed(event) => {
-                let key = (event.task_id, event.subtask_idx);
-                if let Some(status) = self.tasks.get_mut(&key) {
-                    status.state = TaskState::Failed(event);
-                } else {
-                    warn!(
-                        message = "Received task failed message for unknown task",
-                        job_id = *self.job_id,
-                        task_id = key.0,
-                        subtask_idx = key.1,
-                        reason = event.reason,
-                    );
-                }
-            }
-            RunningMessage::WorkerHeartbeat { worker_id, time } => {
-                if let Some(worker) = self.workers.get_mut(&worker_id) {
-                    worker.last_heartbeat = time;
-                } else {
-                    warn!(
-                        message = "Received heartbeat for unknown worker",
-                        job_id = *self.job_id,
-                        worker_id = worker_id.0
-                    );
-                }
-            }
-            RunningMessage::WorkerFinished { worker_id } => {
-                if let Some(worker) = self.workers.get_mut(&worker_id) {
-                    worker.state = WorkerState::Stopped;
-                } else {
-                    warn!(
-                        message = "Received finish message for unknown worker",
-                        job_id = *self.job_id,
-                        worker_id = worker_id.0
-                    );
-                }
-            }
-        }
-
-        if self.state == JobState::Running
-            && self.all_tasks_finished()
-            && self.checkpoint_state.is_none()
-        {
-            for w in &mut self.workers.values_mut() {
-                if let Err(e) = w.connect.job_finished(JobFinishedReq {}).await {
-                    warn!(
-                        message = "Failed to connect to work to send job finish",
-                        job_id = *self.job_id,
-                        worker_id = w.id.0,
-                        error = format!("{:?}", e),
-                    )
-                }
-            }
-            self.state = JobState::Stopped;
-        }
-
-        Ok(())
-    }
-
-    pub async fn start_checkpoint(
-        &mut self,
-        organization_id: &str,
-        db: &DatabaseSource,
-        then_stop: bool,
-    ) -> anyhow::Result<()> {
-        self.epoch += 1;
-
-        info!(
-            message = "Starting checkpointing",
-            job_id = *self.job_id,
-            epoch = self.epoch,
-            then_stop
-        );
-
-        self.checkpoint_spans.clear();
-        self.start_or_get_span(JobCheckpointEventType::Checkpointing);
-        self.start_or_get_span(JobCheckpointEventType::CheckpointingOperators);
-
-        let checkpoints = self.workers.values_mut().map(|worker| {
-            worker.connect.checkpoint(Request::new(CheckpointReq {
-                epoch: self.epoch,
-                timestamp: to_micros(SystemTime::now()),
-                min_epoch: self.min_epoch,
-                then_stop,
-                is_commit: false,
-            }))
-        });
-
-        try_join_all(checkpoints).await?;
-
-        let checkpoint_id = generate_id(IdTypes::Checkpoint);
-
-        let c = db.client().await?;
-        controller_queries::execute_create_checkpoint(
-            &c,
-            &checkpoint_id,
-            &organization_id,
-            &*self.job_id,
-            &StateBackend::name().to_string(),
-            &(self.epoch as i32),
-            &(self.min_epoch as i32),
-            &OffsetDateTime::now_utc(),
-        )
-        .await?;
-
-        let state = CheckpointState::new(
-            self.job_id.clone(),
-            checkpoint_id,
-            self.epoch,
-            self.min_epoch,
-            self.program.clone(),
-        );
-
-        self.checkpoint_state = Some(CheckpointingOrCommittingState::Checkpointing(state));
-
-        Ok(())
-    }
-
-    async fn compact_state(&mut self) -> anyhow::Result<()> {
-        if !config().pipeline.compaction.enabled {
-            debug!("Compaction is disabled, skipping compaction");
-            return Ok(());
-        }
-
-        self.start_or_get_span(JobCheckpointEventType::Compacting);
-        info!(
-            message = "Compacting state",
-            job_id = *self.job_id,
-            epoch = self.epoch,
-        );
-
-        let mut worker_clients: Vec<WorkerGrpcClient<Channel>> =
-            self.workers.values().map(|w| w.connect.clone()).collect();
-        for node in self.program.graph.node_weights() {
-            for (op, _) in node.operator_chain.iter() {
-                let compacted_tables = ParquetBackend::compact_operator(
-                    // compact the operator's state and notify the workers to load the new files
-                    self.job_id.clone(),
-                    &op.operator_id,
-                    self.epoch,
-                )
-                .await?;
-
-                if compacted_tables.is_empty() {
-                    continue;
-                }
-
-                // TODO: these should be put on separate tokio tasks.
-                for worker_client in &mut worker_clients {
-                    worker_client
-                        .load_compacted_data(LoadCompactedDataReq {
-                            operator_id: op.operator_id.clone(),
-                            compacted_metadata: compacted_tables.clone(),
-                        })
-                        .await?;
-                }
-            }
-        }
-        self.start_or_get_span(JobCheckpointEventType::Compacting)
-            .finish();
-
-        info!(
-            message = "Finished compaction",
-            job_id = *self.job_id,
-            epoch = self.epoch,
-        );
-        Ok(())
-    }
-
-    pub async fn finish_checkpoint_if_done(&mut self, db: &DatabaseSource) -> anyhow::Result<()> {
-        if self.checkpoint_state.as_ref().unwrap().done() {
-            let state = self.checkpoint_state.take().unwrap();
-            match state {
-                CheckpointingOrCommittingState::Checkpointing(mut checkpointing) => {
-                    let metadata_span =
-                        self.start_or_get_span(JobCheckpointEventType::WritingMetadata);
-                    checkpointing.write_metadata().await?;
-                    metadata_span.finish();
-
-                    let committing_state = checkpointing.committing_state();
-                    let duration = checkpointing
-                        .start_time()
-                        .elapsed()
-                        .unwrap_or(Duration::ZERO)
-                        .as_secs_f32();
-                    // shortcut if committing is unnecessary
-                    if committing_state.done() {
-                        self.start_or_get_span(JobCheckpointEventType::Checkpointing)
-                            .finish();
-                        self.update_checkpoint_in_db(&checkpointing, db, DbCheckpointState::ready)
-                            .await?;
-                        self.last_checkpoint = Instant::now();
-                        self.checkpoint_state = None;
-                        self.compact_state().await?;
-
-                        info!(
-                            message = "Finished checkpointing",
-                            job_id = *self.job_id,
-                            epoch = self.epoch,
-                            duration
-                        );
-                        // trigger a DB backup now that we're done checkpointing
-                        notify_db();
-                    } else {
-                        self.update_checkpoint_in_db(
-                            &checkpointing,
-                            db,
-                            DbCheckpointState::committing,
-                        )
-                        .await?;
-
-                        let committing_data = committing_state.committing_data();
-                        self.checkpoint_state =
-                            Some(CheckpointingOrCommittingState::Committing(committing_state));
-                        info!(
-                            message = "Committing checkpoint",
-                            job_id = *self.job_id,
-                            epoch = self.epoch,
-                        );
-
-                        self.start_or_get_span(JobCheckpointEventType::Committing);
-
-                        for worker in self.workers.values_mut() {
-                            worker
-                                .connect
-                                .commit(Request::new(CommitReq {
-                                    epoch: self.epoch,
-                                    committing_data: committing_data.clone(),
-                                }))
-                                .await?;
-                        }
-                    }
-                }
-                CheckpointingOrCommittingState::Committing(committing) => {
-                    self.start_or_get_span(JobCheckpointEventType::Committing)
-                        .finish();
-                    self.start_or_get_span(JobCheckpointEventType::Checkpointing)
-                        .finish();
-                    self.finish_committing(committing.checkpoint_id(), db)
-                        .await?;
-                    self.last_checkpoint = Instant::now();
-                    self.checkpoint_state = None;
-                    info!(
-                        message = "Finished committing checkpointing",
-                        job_id = *self.job_id,
-                        epoch = self.epoch,
-                    );
-                    // trigger a DB backup now that we're done checkpointing
-                    notify_db();
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn cleanup_needed(&self) -> Option<u32> {
-        if self.epoch - self.min_epoch > CHECKPOINTS_TO_KEEP
-            && self.epoch.is_multiple_of(COMPACT_EVERY)
-        {
-            Some(self.epoch - CHECKPOINTS_TO_KEEP)
-        } else {
-            None
-        }
-    }
-
-    pub fn worker_timedout(&self) -> bool {
-        for (worker, status) in &self.workers {
-            if status.heartbeat_timeout() {
-                error!(
-                    message = "worker failed to heartbeat",
-                    job_id = *self.job_id,
-                    worker_id = worker.0
-                );
-                return true;
-            }
-        }
-
-        false
-    }
-
-    pub fn task_failed(&self) -> Option<TaskFailedEvent> {
-        for status in self.tasks.values() {
-            if let TaskState::Failed(reason) = &status.state {
-                return Some(reason.clone());
-            }
-        }
-
-        None
-    }
-
-    pub fn any_finished_sources(&self) -> bool {
-        let source_tasks = self.program.sources();
-
-        self.tasks.iter().any(|((operator, _), t)| {
-            source_tasks.contains(operator) && t.state == TaskState::Finished
-        })
-    }
-
-    pub fn all_tasks_finished(&self) -> bool {
-        self.tasks
-            .iter()
-            .all(|(_, t)| t.state == TaskState::Finished)
-    }
-
-    pub fn start_or_get_span(&mut self, event: JobCheckpointEventType) -> &mut JobCheckpointSpan {
-        if let Some(idx) = self.checkpoint_spans.iter().position(|e| e.event == event) {
-            return &mut self.checkpoint_spans[idx];
-        }
-
-        self.checkpoint_spans.push(JobCheckpointSpan::now(event));
-        self.checkpoint_spans.last_mut().unwrap()
-    }
-}
 
 pub struct JobController {
-    db: DatabaseSource,
+    checkpoint_store: Arc<dyn CheckpointMetadataStore>,
     config: JobConfig,
     model: RunningJobModel,
     cleanup_task: Option<JoinHandle<anyhow::Result<u32>>>,
+    metrics: JobMetrics,
 }
 
 impl std::fmt::Debug for JobController {
@@ -627,7 +63,7 @@ pub enum ControllerProgress {
 impl JobController {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        db: DatabaseSource,
+        checkpoint_store: Arc<dyn CheckpointMetadataStore>,
         config: JobConfig,
         program: Arc<LogicalProgram>,
         epoch: u32,
@@ -637,7 +73,8 @@ impl JobController {
         metrics: JobMetrics,
     ) -> Self {
         Self {
-            db,
+            checkpoint_store,
+            metrics,
             model: RunningJobModel {
                 job_id: config.id.clone(),
                 state: JobState::Running,
@@ -679,7 +116,6 @@ impl JobController {
                     })
                     .collect(),
                 operator_parallelism: program.tasks_per_node(),
-                metrics,
                 metric_update_task: None,
                 last_updated_metrics: Instant::now(),
                 program,
@@ -695,7 +131,9 @@ impl JobController {
     }
 
     pub async fn handle_message(&mut self, msg: RunningMessage) -> anyhow::Result<()> {
-        self.model.handle_message(msg, &self.db).await
+        self.model
+            .handle_message(msg, &*self.checkpoint_store)
+            .await
     }
 
     async fn update_metrics(&mut self) {
@@ -710,7 +148,7 @@ impl JobController {
             return;
         }
 
-        let job_metrics = self.model.metrics.clone();
+        let job_metrics = self.metrics.clone();
         let workers: Vec<_> = self
             .model
             .workers
@@ -841,7 +279,9 @@ impl JobController {
 
         // check on checkpointing
         if self.model.checkpoint_state.is_some() {
-            self.model.finish_checkpoint_if_done(&self.db).await?;
+            self.model
+                .finish_checkpoint_if_done(&*self.checkpoint_store)
+                .await?;
         } else if self.model.last_checkpoint.elapsed() > self.config.checkpoint_interval
             && self.cleanup_task.is_none()
         {
@@ -873,7 +313,7 @@ impl JobController {
     pub async fn checkpoint(&mut self, then_stop: bool) -> anyhow::Result<bool> {
         if self.model.checkpoint_state.is_none() {
             self.model
-                .start_checkpoint(&self.config.organization_id, &self.db, then_stop)
+                .start_checkpoint(&*self.checkpoint_store, then_stop)
                 .await?;
             Ok(true)
         } else {
@@ -887,7 +327,9 @@ impl JobController {
 
     pub async fn checkpoint_finished(&mut self) -> anyhow::Result<bool> {
         if self.model.checkpoint_state.is_some() {
-            self.model.finish_checkpoint_if_done(&self.db).await?;
+            self.model
+                .finish_checkpoint_if_done(&*self.checkpoint_store)
+                .await?;
         }
         Ok(self.model.checkpoint_state.is_none())
     }
@@ -922,7 +364,9 @@ impl JobController {
                 .ok_or_else(|| anyhow::anyhow!("channel closed while receiving"))?
             {
                 JobMessage::RunningMessage(msg) => {
-                    self.model.handle_message(msg, &self.db).await?;
+                    self.model
+                        .handle_message(msg, &*self.checkpoint_store)
+                        .await?;
                 }
                 JobMessage::ConfigUpdate(c) => {
                     if c.stop_mode == SqlStopMode::immediate {
@@ -947,7 +391,7 @@ impl JobController {
     fn start_cleanup(&mut self, new_min: u32) -> JoinHandle<anyhow::Result<u32>> {
         let min_epoch = self.model.min_epoch.max(1);
         let job_id = self.config.id.clone();
-        let db = self.db.clone();
+        let store = self.checkpoint_store.clone();
 
         info!(
             message = "Starting cleaning",
@@ -961,30 +405,16 @@ impl JobController {
         tokio::spawn(async move {
             let checkpoint = StateBackend::load_checkpoint_metadata(&job_id, cur_epoch).await?;
 
-            controller_queries::execute_mark_compacting(
-                &db.client().await?,
-                &*job_id,
-                &(min_epoch as i32),
-                &(new_min as i32),
-            )
-            .await?;
+            store.mark_compacting(&job_id, min_epoch, new_min).await?;
 
             StateBackend::cleanup_checkpoint(checkpoint, min_epoch, new_min).await?;
 
-            controller_queries::execute_mark_checkpoints_compacted(
-                &db.client().await?,
-                &*job_id,
-                &(new_min as i32),
-            )
-            .await?;
+            store.mark_checkpoints_compacted(&job_id, new_min).await?;
 
             if let Some(epoch_to_filter_before) = min_epoch.checked_sub(CHECKPOINT_ROWS_TO_KEEP) {
-                controller_queries::execute_drop_old_checkpoint_rows(
-                    &db.client().await?,
-                    &*job_id,
-                    &(epoch_to_filter_before as i32),
-                )
-                .await?;
+                store
+                    .drop_old_checkpoint_rows(&job_id, epoch_to_filter_before)
+                    .await?;
             }
 
             info!(

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -8,17 +8,17 @@ use anyhow::Result;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::controller_grpc_server::{ControllerGrpc, ControllerGrpcServer};
-use arroyo_rpc::grpc::rpc::{
-    GrpcOutputSubscription, HeartbeatNodeReq, HeartbeatNodeResp, HeartbeatReq, HeartbeatResp,
-    JobMetricsReq, JobMetricsResp, OutputData, RegisterNodeReq, RegisterNodeResp,
-    RegisterWorkerReq, RegisterWorkerResp, TaskCheckpointCompletedReq, TaskCheckpointCompletedResp,
-    TaskFailedReq, TaskFailedResp, TaskFinishedReq, TaskFinishedResp, TaskStartedReq,
-    TaskStartedResp, WorkerFinishedReq, WorkerFinishedResp, WorkerInitializationCompleteReq,
-    WorkerInitializationCompleteResp,
+use arroyo_rpc::grpc::rpc::job_controller_grpc_server::{
+    JobControllerGrpc, JobControllerGrpcServer,
 };
 use arroyo_rpc::grpc::rpc::{
-    NonfatalErrorReq, SinkDataReq, SinkDataResp, TaskCheckpointEventReq, TaskCheckpointEventResp,
-    WorkerErrorRes,
+    GrpcOutputSubscription, HeartbeatNodeReq, HeartbeatNodeResp, HeartbeatReq, HeartbeatResp,
+    JobMetricsReq, JobMetricsResp, NonfatalErrorReq, OutputData, RegisterNodeReq, RegisterNodeResp,
+    RegisterWorkerReq, RegisterWorkerResp, SinkDataReq, SinkDataResp, TaskCheckpointCompletedReq,
+    TaskCheckpointCompletedResp, TaskCheckpointEventReq, TaskCheckpointEventResp, TaskFailedReq,
+    TaskFailedResp, TaskFinishedReq, TaskFinishedResp, TaskStartedReq, TaskStartedResp,
+    WorkerErrorRes, WorkerFinishedReq, WorkerFinishedResp, WorkerInitializationCompleteReq,
+    WorkerInitializationCompleteResp,
 };
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
@@ -161,6 +161,15 @@ pub struct ControllerServer {
     db: DatabaseSource,
 }
 
+#[allow(clippy::result_large_err)]
+fn job_id_from_context(worker_context: &Option<rpc::WorkerContext>) -> Result<String, Status> {
+    Ok(worker_context
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("missing worker_context"))?
+        .job_id
+        .clone())
+}
+
 #[tonic::async_trait]
 impl ControllerGrpc for ControllerServer {
     async fn register_worker(
@@ -174,16 +183,16 @@ impl ControllerGrpc for ControllerServer {
         );
 
         let req = request.into_inner();
-        let ctx = req
+        let worker = req
             .worker_context
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
 
         self.send_to_job_queue(
-            &ctx.job_id,
+            &worker.job_id,
             JobMessage::WorkerConnect {
-                worker_id: WorkerId(ctx.worker_id),
-                machine_id: MachineId(ctx.machine_id.into()),
-                run_id: ctx.run_id,
+                worker_id: WorkerId(worker.worker_id),
+                machine_id: MachineId(worker.machine_id.into()),
+                run_id: worker.run_id,
                 rpc_address: req.rpc_address,
                 data_address: req.data_address,
                 slots: req.slots as usize,
@@ -192,28 +201,6 @@ impl ControllerGrpc for ControllerServer {
         .await?;
 
         Ok(Response::new(RegisterWorkerResp {}))
-    }
-
-    async fn heartbeat(
-        &self,
-        request: Request<HeartbeatReq>,
-    ) -> Result<Response<HeartbeatResp>, Status> {
-        let req = request.into_inner();
-        let ctx = req
-            .worker_context
-            .as_ref()
-            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
-
-        self.send_to_job_queue(
-            &ctx.job_id,
-            JobMessage::RunningMessage(RunningMessage::WorkerHeartbeat {
-                worker_id: WorkerId(ctx.worker_id),
-                time: Instant::now(),
-            }),
-        )
-        .await?;
-
-        return Ok(Response::new(HeartbeatResp {}));
     }
 
     async fn task_started(
@@ -225,7 +212,6 @@ impl ControllerGrpc for ControllerServer {
 
         let ctx = req
             .worker_context
-            .as_ref()
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
 
         self.send_to_job_queue(
@@ -239,96 +225,6 @@ impl ControllerGrpc for ControllerServer {
         .await?;
 
         Ok(Response::new(TaskStartedResp {}))
-    }
-
-    async fn task_checkpoint_event(
-        &self,
-        request: Request<TaskCheckpointEventReq>,
-    ) -> Result<Response<TaskCheckpointEventResp>, Status> {
-        let req = request.into_inner();
-
-        debug!("received task checkpoint event {:?}", req);
-        let job_id = job_id_from_context(&req.worker_context)?;
-        self.send_to_job_queue(
-            &job_id,
-            JobMessage::RunningMessage(RunningMessage::TaskCheckpointEvent(req)),
-        )
-        .await?;
-
-        Ok(Response::new(TaskCheckpointEventResp {}))
-    }
-
-    async fn task_checkpoint_completed(
-        &self,
-        request: Request<TaskCheckpointCompletedReq>,
-    ) -> Result<Response<TaskCheckpointCompletedResp>, Status> {
-        let req = request.into_inner();
-
-        debug!("received task checkpoint completed {:?}", req);
-        let job_id = job_id_from_context(&req.worker_context)?;
-
-        self.send_to_job_queue(
-            &job_id,
-            JobMessage::RunningMessage(RunningMessage::TaskCheckpointFinished(req)),
-        )
-        .await?;
-
-        Ok(Response::new(TaskCheckpointCompletedResp {}))
-    }
-
-    async fn task_finished(
-        &self,
-        request: Request<TaskFinishedReq>,
-    ) -> Result<Response<TaskFinishedResp>, Status> {
-        let req = request.into_inner();
-        let ctx = req
-            .worker_context
-            .as_ref()
-            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
-
-        self.send_to_job_queue(
-            &ctx.job_id,
-            JobMessage::RunningMessage(RunningMessage::TaskFinished {
-                worker_id: WorkerId(ctx.worker_id),
-                time: from_micros(req.time),
-                task_id: req.task_id,
-                subtask_idx: req.subtask_idx,
-            }),
-        )
-        .await?;
-
-        Ok(Response::new(TaskFinishedResp {}))
-    }
-
-    async fn task_failed(
-        &self,
-        request: Request<TaskFailedReq>,
-    ) -> Result<Response<TaskFailedResp>, Status> {
-        let req = request.into_inner();
-        let ctx = req
-            .worker_context
-            .as_ref()
-            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
-        let err = req
-            .error
-            .ok_or_else(|| Status::invalid_argument("TaskFailedReq missing error"))?;
-
-        self.send_to_job_queue(
-            &ctx.job_id,
-            JobMessage::RunningMessage(RunningMessage::TaskFailed(TaskFailedEvent {
-                worker_id: WorkerId(ctx.worker_id),
-                task_id: err.task_id,
-                subtask_idx: err.subtask_idx,
-                error_domain: err.error_domain().into(),
-                retry_hint: err.retry_hint().into(),
-                operator_id: err.operator_id,
-                reason: err.error,
-                details: err.details,
-            })),
-        )
-        .await?;
-
-        Ok(Response::new(TaskFailedResp {}))
     }
 
     async fn register_node(
@@ -432,6 +328,145 @@ impl ControllerGrpc for ControllerServer {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
+    async fn worker_initialization_complete(
+        &self,
+        request: Request<WorkerInitializationCompleteReq>,
+    ) -> Result<Response<WorkerInitializationCompleteResp>, Status> {
+        let req = request.into_inner();
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
+        info!(
+            "Worker {} initialization completed: success={}, error={:?}",
+            ctx.worker_id, req.success, req.error_message
+        );
+
+        self.send_to_job_queue(
+            &ctx.job_id,
+            JobMessage::WorkerInitializationComplete {
+                worker_id: WorkerId(ctx.worker_id),
+                success: req.success,
+                error_message: req.error_message,
+            },
+        )
+        .await?;
+
+        Ok(Response::new(WorkerInitializationCompleteResp {}))
+    }
+}
+
+#[tonic::async_trait]
+impl JobControllerGrpc for ControllerServer {
+    async fn task_checkpoint_event(
+        &self,
+        request: Request<TaskCheckpointEventReq>,
+    ) -> Result<Response<TaskCheckpointEventResp>, Status> {
+        let req = request.into_inner();
+
+        debug!("received task checkpoint event {:?}", req);
+        let job_id = job_id_from_context(&req.worker_context)?;
+
+        self.send_to_job_queue(
+            &job_id,
+            JobMessage::RunningMessage(RunningMessage::TaskCheckpointEvent(req)),
+        )
+        .await?;
+
+        Ok(Response::new(TaskCheckpointEventResp {}))
+    }
+
+    async fn task_checkpoint_completed(
+        &self,
+        request: Request<TaskCheckpointCompletedReq>,
+    ) -> Result<Response<TaskCheckpointCompletedResp>, Status> {
+        let req = request.into_inner();
+
+        debug!("received task checkpoint completed {:?}", req);
+        let job_id = job_id_from_context(&req.worker_context)?;
+
+        self.send_to_job_queue(
+            &job_id,
+            JobMessage::RunningMessage(RunningMessage::TaskCheckpointFinished(req)),
+        )
+        .await?;
+
+        Ok(Response::new(TaskCheckpointCompletedResp {}))
+    }
+
+    async fn task_finished(
+        &self,
+        request: Request<TaskFinishedReq>,
+    ) -> Result<Response<TaskFinishedResp>, Status> {
+        let req = request.into_inner();
+
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
+
+        self.send_to_job_queue(
+            &ctx.job_id,
+            JobMessage::RunningMessage(RunningMessage::TaskFinished {
+                worker_id: WorkerId(ctx.worker_id),
+                time: from_micros(req.time),
+                task_id: req.task_id,
+                subtask_idx: req.subtask_idx,
+            }),
+        )
+        .await?;
+
+        Ok(Response::new(TaskFinishedResp {}))
+    }
+
+    async fn task_failed(
+        &self,
+        request: Request<TaskFailedReq>,
+    ) -> Result<Response<TaskFailedResp>, Status> {
+        let req = request.into_inner();
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("TaskFailedReq missing worker_context"))?;
+        let err = req
+            .error
+            .ok_or_else(|| Status::invalid_argument("TaskFailedReq missing error"))?;
+
+        self.send_to_job_queue(
+            &ctx.job_id,
+            JobMessage::RunningMessage(RunningMessage::TaskFailed(TaskFailedEvent {
+                worker_id: WorkerId(ctx.worker_id),
+                task_id: err.task_id,
+                subtask_idx: err.subtask_idx,
+                error_domain: err.error_domain().into(),
+                retry_hint: err.retry_hint().into(),
+                operator_id: err.operator_id,
+                reason: err.error,
+                details: err.details,
+            })),
+        )
+        .await?;
+
+        Ok(Response::new(TaskFailedResp {}))
+    }
+
+    async fn heartbeat(
+        &self,
+        request: Request<HeartbeatReq>,
+    ) -> Result<Response<HeartbeatResp>, Status> {
+        let req = request.into_inner();
+
+        let job_id = job_id_from_context(&req.worker_context)?;
+
+        self.send_to_job_queue(
+            &job_id,
+            JobMessage::RunningMessage(RunningMessage::WorkerHeartbeat {
+                worker_id: WorkerId(req.worker_context.as_ref().unwrap().worker_id),
+                time: Instant::now(),
+            }),
+        )
+        .await?;
+
+        return Ok(Response::new(HeartbeatResp {}));
+    }
+
     async fn nonfatal_error(
         &self,
         request: Request<NonfatalErrorReq>,
@@ -439,8 +474,7 @@ impl ControllerGrpc for ControllerServer {
         let req = request.into_inner();
         let ctx = req
             .worker_context
-            .as_ref()
-            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
+            .ok_or_else(|| Status::invalid_argument("NonfatalErrorReq missing worker_context"))?;
         let err = req
             .error
             .ok_or_else(|| Status::invalid_argument("NonfatalErrorReq missing error"))?;
@@ -491,42 +525,6 @@ impl ControllerGrpc for ControllerServer {
             metrics: serde_json::to_string(&metrics.get_groups()).unwrap(),
         }))
     }
-
-    async fn worker_initialization_complete(
-        &self,
-        request: Request<WorkerInitializationCompleteReq>,
-    ) -> Result<Response<WorkerInitializationCompleteResp>, Status> {
-        let req = request.into_inner();
-        let ctx = req
-            .worker_context
-            .as_ref()
-            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
-        info!(
-            "Worker {} initialization completed: success={}, error={:?}",
-            ctx.worker_id, req.success, req.error_message
-        );
-
-        self.send_to_job_queue(
-            &ctx.job_id,
-            JobMessage::WorkerInitializationComplete {
-                worker_id: WorkerId(ctx.worker_id),
-                success: req.success,
-                error_message: req.error_message,
-            },
-        )
-        .await?;
-
-        Ok(Response::new(WorkerInitializationCompleteResp {}))
-    }
-}
-
-#[allow(clippy::result_large_err)]
-fn job_id_from_context(worker_context: &Option<rpc::WorkerContext>) -> Result<String, Status> {
-    Ok(worker_context
-        .as_ref()
-        .ok_or_else(|| Status::invalid_argument("missing worker_context"))?
-        .job_id
-        .clone())
 }
 
 impl ControllerServer {
@@ -684,7 +682,11 @@ impl ControllerServer {
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
 
-        let service = ControllerGrpcServer::new(self.clone())
+        let controller_service = ControllerGrpcServer::new(self.clone())
+            .send_compressed(CompressionEncoding::Zstd)
+            .accept_compressed(CompressionEncoding::Zstd);
+
+        let job_controller_service = JobControllerGrpcServer::new(self.clone())
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
 
@@ -696,9 +698,8 @@ impl ControllerServer {
             let server = arroyo_server_common::grpc_server_with_tls(tls_config)
                 .await?
                 .accept_http1(true)
-                .add_service(service);
-            // TODO: re-enable once tonic 0.13 is released
-            //.add_service(reflection);
+                .add_service(controller_service)
+                .add_service(job_controller_service);
 
             guard.into_spawn_task(wrap_start(
                 "controller",
@@ -713,9 +714,8 @@ impl ControllerServer {
                 local_addr,
                 arroyo_server_common::grpc_server()
                     .accept_http1(true)
-                    .add_service(service)
-                    // TODO: re-enable once tonic 0.13 is released
-                    //.add_service(reflection)
+                    .add_service(controller_service)
+                    .add_service(job_controller_service)
                     .serve_with_incoming(TcpListenerStream::new(listener)),
             ));
         }

--- a/crates/arroyo-controller/src/schedulers/embedded.rs
+++ b/crates/arroyo-controller/src/schedulers/embedded.rs
@@ -54,7 +54,7 @@ impl Scheduler for EmbeddedScheduler {
         let worker_id = WorkerId(self.worker_counter.fetch_add(1, Ordering::SeqCst));
         let handle = tokio::task::spawn(async move {
             let server = WorkerServer::new(
-                MachineId(Arc::new("job".to_string())),
+                MachineId(Arc::new("embedded".to_string())),
                 worker_id,
                 JobId(req.job_id.clone()),
                 req.run_id,

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -1,0 +1,29 @@
+use super::{JobContext, State, Stopped, Transition};
+use crate::job_controller::leader_manager::handle_leader_stopping;
+use crate::states::StateError;
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
+
+#[derive(Debug)]
+pub struct LeaderCheckpointStopping {}
+
+#[async_trait::async_trait]
+impl State for LeaderCheckpointStopping {
+    fn name(&self) -> &'static str {
+        "CheckpointStopping"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        if let Err(e) = ctx
+            .leader_manager()
+            .stop_leader(JobStopMode::JobStopCheckpoint)
+            .await
+        {
+            return Err(ctx.retryable(self, "failed to send stop message to leader", e, 10));
+        }
+
+        let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
+
+        handle_leader_stopping(*self, ctx, JobState::JobStopped, Stopped {}, timeout).await
+    }
+}

--- a/crates/arroyo-controller/src/states/leader_finishing.rs
+++ b/crates/arroyo-controller/src/states/leader_finishing.rs
@@ -1,0 +1,18 @@
+use super::{Finished, JobContext, State, Transition};
+use crate::job_controller::leader_manager::handle_leader_stopping;
+use crate::states::StateError;
+use arroyo_rpc::grpc::rpc::JobState;
+
+#[derive(Debug)]
+pub struct LeaderFinishing {}
+
+#[async_trait::async_trait]
+impl State for LeaderFinishing {
+    fn name(&self) -> &'static str {
+        "Finishing"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        handle_leader_stopping(*self, ctx, JobState::JobFinished, Finished {}, None).await
+    }
+}

--- a/crates/arroyo-controller/src/states/leader_rescaling.rs
+++ b/crates/arroyo-controller/src/states/leader_rescaling.rs
@@ -1,0 +1,32 @@
+use super::{JobContext, State, StateError, Transition, scheduling::Scheduling};
+use crate::job_controller::leader_manager::handle_leader_stopping;
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
+
+#[derive(Debug)]
+pub struct LeaderRescaling {}
+
+#[async_trait::async_trait]
+impl State for LeaderRescaling {
+    fn name(&self) -> &'static str {
+        "Rescaling"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        if let Err(e) = ctx
+            .leader_manager()
+            .stop_leader(JobStopMode::JobStopCheckpoint)
+            .await
+        {
+            return Err(ctx.retryable(
+                self,
+                "failed to send checkpoint-stop to leader for rescaling",
+                e,
+                10,
+            ));
+        }
+
+        let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
+        handle_leader_stopping(*self, ctx, JobState::JobStopped, Scheduling {}, timeout).await
+    }
+}

--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -1,0 +1,101 @@
+use super::{
+    JobContext, State, StateError, Transition, fatal, leader_stop_if_desired_running,
+    scheduling::Scheduling,
+};
+use crate::JobMessage;
+use crate::states::recovering::Recovering;
+use crate::types::public::RestartMode;
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::{JobFailure, JobState, JobStopMode};
+use std::time::{Duration, Instant};
+use tracing::{info, warn};
+
+#[derive(Debug)]
+pub struct LeaderRestarting {
+    pub mode: RestartMode,
+}
+
+#[async_trait::async_trait]
+impl State for LeaderRestarting {
+    fn name(&self) -> &'static str {
+        "Restarting"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        match self.mode {
+            RestartMode::safe => {
+                if let Err(e) = ctx
+                    .leader_manager()
+                    .stop_leader(JobStopMode::JobStopCheckpoint)
+                    .await
+                {
+                    return Err(ctx.retryable(
+                        self,
+                        "failed to send checkpoint-stop to leader",
+                        e,
+                        10,
+                    ));
+                }
+
+                let started = Instant::now();
+
+                loop {
+                    let timeout = config()
+                        .pipeline
+                        .checkpoint
+                        .timeout
+                        .as_ref()
+                        .map(|t| (started + **t).saturating_duration_since(Instant::now()))
+                        .unwrap_or(Duration::MAX);
+
+                    tokio::select! {
+                        msg = ctx.rx.recv() => {
+                            match msg {
+                                Some(JobMessage::ConfigUpdate(c)) => {
+                                    leader_stop_if_desired_running!(self, c, ctx);
+
+                                }
+                                Some(msg) => {
+                                    warn!(job_id = *ctx.config.id, ?msg, "unexpected job message in leader mode");
+                                }
+                                None => {
+                                    panic!("job queue shut down");
+                                }
+                            }
+                        }
+                        resp = ctx.leader_manager.as_mut().expect("leader manager not initialized").wait_for_state(JobState::JobStopped) => {
+                            return if let Err(e) = resp {
+                                Err(fatal("failed while waiting for checkpoint-stop during restart",e))
+                            } else {
+                                Ok(Transition::next(*self, Scheduling {}))
+                            };
+                        }
+                        _ = tokio::time::sleep(timeout) => {
+                            return ctx.handle_job_failure(*self, JobFailure {
+                                operator_id: None,
+                                task_id: None,
+                                subtask_index: None,
+                                message: "timed out while taking final checkpoint".to_string(),
+                                error_domain: rpc::ErrorDomain::Internal as i32,
+                                retry_hint: rpc::RetryHint::WithBackoff as i32,
+                            }).await;
+                        }
+                    }
+                }
+            }
+            RestartMode::force => {
+                info!(
+                    job_id = *ctx.config.id,
+                    "force restarting job, tearing down cluster"
+                );
+
+                if let Err(e) = Recovering::cleanup(ctx).await {
+                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
+                }
+
+                Ok(Transition::next(*self, Scheduling {}))
+            }
+        }
+    }
+}

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -1,0 +1,207 @@
+use super::{JobContext, State, Transition};
+use crate::JobMessage;
+use crate::states::leader_finishing::LeaderFinishing;
+use crate::states::leader_rescaling::LeaderRescaling;
+use crate::states::leader_restarting::LeaderRestarting;
+use crate::states::leader_stop_if_desired_running;
+use crate::states::{StateError, fatal};
+use anyhow::anyhow;
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::{ErrorDomain, JobFailure, RetryHint};
+use arroyo_rpc::log_event;
+use std::time::{Duration, Instant};
+use tokio::time::MissedTickBehavior;
+use tracing::{error, warn};
+
+const LEADER_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug)]
+pub struct LeaderRunning {
+    pub started: Instant,
+}
+
+#[async_trait::async_trait]
+impl State for LeaderRunning {
+    fn name(&self) -> &'static str {
+        "Running"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        let pipeline_config = &config().clone().pipeline;
+
+        let mut log_interval = tokio::time::interval(Duration::from_secs(60));
+        log_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        let mut poll_interval = tokio::time::interval(LEADER_POLL_INTERVAL);
+        poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        leader_stop_if_desired_running!(self, ctx.config, ctx);
+
+        let operator_parallelism = ctx.program.tasks_per_node();
+
+        loop {
+            if ctx.leader_manager().last_heartbeat.elapsed()
+                > *pipeline_config.worker_heartbeat_timeout
+            {
+                return ctx
+                    .handle_job_failure(
+                        *self,
+                        JobFailure {
+                            operator_id: None,
+                            task_id: None,
+                            subtask_index: None,
+                            message: format!(
+                                "no response from job controller after {} seconds",
+                                pipeline_config.worker_heartbeat_timeout.as_secs()
+                            ),
+                            error_domain: ErrorDomain::Internal as i32,
+                            retry_hint: RetryHint::WithBackoff as i32,
+                        },
+                    )
+                    .await;
+            }
+
+            if let Some(ttl) = ctx.config.ttl
+                && self.started.elapsed() > ttl
+            {
+                return Ok(Transition::next(
+                    *self,
+                    LeaderStopping {
+                        stop_behavior: LeaderStopBehavior::StopWorkers,
+                    },
+                ));
+            }
+
+            tokio::select! {
+                msg = ctx.rx.recv() => {
+                    match msg {
+                        Some(JobMessage::ConfigUpdate(c)) => {
+                            leader_stop_if_desired_running!(self, c, ctx);
+
+                            if c.restart_nonce != ctx.status.restart_nonce {
+                                return Ok(Transition::next(
+                                    *self,
+                                    LeaderRestarting {
+                                        mode: c.restart_mode,
+                                    },
+                                ));
+                            }
+
+                            for (node_id, p) in &c.parallelism_overrides {
+                                if let Some(actual) = operator_parallelism.get(node_id)
+                                    && *actual != *p {
+                                    return Ok(Transition::next(
+                                        *self,
+                                        LeaderRescaling {},
+                                    ));
+                                }
+                            }
+
+                        }
+                        Some(msg) => {
+                            warn!(job_id = *ctx.config.id, msg =? msg, "unexpected job message in leader mode");
+                        }
+                        None => {
+                            panic!("job queue shut down");
+                        }
+                    }
+                }
+                _ = poll_interval.tick() => {
+                    if ctx.status.restarts > 0 && self.started.elapsed() > *pipeline_config.healthy_duration {
+                        let restarts = ctx.status.restarts;
+                        ctx.status.restarts = 0;
+                        if let Err(e) = ctx.status.update_db(&ctx.db).await {
+                            error!(message = "Failed to update status", error = format!("{:?}", e),
+                                job_id = *ctx.config.id);
+                            ctx.status.restarts = restarts;
+                        }
+                    }
+
+                    match ctx.leader_manager().poll_leader_status().await {
+                        Ok(status) => {
+                            let state = match rpc::JobState::try_from(status.job_state) {
+                                Ok(state) => state,
+                                Err(e) => {
+                                    return Err(ctx.retryable(
+                                        self,
+                                        "leader returned invalid job state",
+                                        e.into(),
+                                        10,
+                                    ));
+                                }
+                            };
+                            match state {
+                                rpc::JobState::JobInitializing => {
+                                    return ctx.handle_job_failure(*self, JobFailure {
+                                        operator_id: None,
+                                        task_id: None,
+                                        subtask_index: None,
+                                        message: "job unexpectedly in Initializing state, should be running".to_string(),
+                                        error_domain: ErrorDomain::Internal as i32,
+                                        retry_hint: RetryHint::WithBackoff as i32,
+                                    }).await;
+                                }
+                                rpc::JobState::JobRunning => {
+                                    // in progress
+                                }
+                                rpc::JobState::JobStopping | rpc::JobState::JobStopped => {
+                                    // the job somehow is stopping without us telling it to
+                                    // we may want to automatically handle this in the future, but
+                                    // initially I'm being conservative about automation
+                                    return Err(fatal("job unexpectedly stopped",
+                                        anyhow!("job unexpectedly entered {:?} state", state)));
+                                }
+                                rpc::JobState::JobFinishing | rpc::JobState::JobFinished => {
+                                    // finishing is initiated by the workers themselves (via the
+                                    // sources consuming all of their input) so we just respond
+                                    // to it
+                                    return Ok(Transition::next(
+                                        *self,
+                                        LeaderFinishing {},
+                                    ));
+                                }
+                                rpc::JobState::JobFailing | rpc::JobState::JobFailed => {
+                                    let Some(failure) = status.job_failure else {
+                                        return Err(ctx.retryable(
+                                            self,
+                                            "leader reported failing status without failure payload",
+                                            anyhow!("missing job failure"),
+                                            10,
+                                        ));
+                                    };
+                                    return ctx.handle_job_failure(*self, failure).await;
+                                }
+                                rpc::JobState::JobUnknown => {
+                                    return Err(ctx.retryable(
+                                        self,
+                                        "leader returned unknown job state",
+                                        anyhow!("unknown leader job state"),
+                                        10,
+                                    ));
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            warn!(message = "error while polling leader status", error = format!("{:?}", err), job_id = *ctx.config.id);
+                            tokio::time::sleep(Duration::from_secs(2)).await;
+                        }
+                    }
+                }
+                _ = log_interval.tick() => {
+                    log_event!(
+                        "job_running",
+                        {
+                            "service": "controller",
+                            "job_id": ctx.config.id,
+                            "scheduler": &config().controller.scheduler,
+                        },
+                        [
+                            "duration_ms" => ctx.last_transitioned_at.elapsed().as_millis() as f64,
+                        ]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -14,8 +14,6 @@ use std::time::{Duration, Instant};
 use tokio::time::MissedTickBehavior;
 use tracing::{error, warn};
 
-const LEADER_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
 #[derive(Debug)]
 pub struct LeaderRunning {
     pub started: Instant,
@@ -33,7 +31,7 @@ impl State for LeaderRunning {
         let mut log_interval = tokio::time::interval(Duration::from_secs(60));
         log_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        let mut poll_interval = tokio::time::interval(LEADER_POLL_INTERVAL);
+        let mut poll_interval = tokio::time::interval(*config().controller.leader_poll_interval);
         poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         leader_stop_if_desired_running!(self, ctx.config, ctx);

--- a/crates/arroyo-controller/src/states/leader_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_stopping.rs
@@ -1,0 +1,105 @@
+use super::{JobContext, State, Stopped, Transition};
+use crate::states::StateError;
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::JobStopMode;
+use std::time::Duration;
+use tracing::{error, info};
+const FINISH_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Copy, Clone, Debug)]
+pub enum LeaderStopBehavior {
+    StopJob(JobStopMode),
+    StopWorkers,
+}
+
+#[derive(Debug)]
+pub struct LeaderStopping {
+    pub stop_behavior: LeaderStopBehavior,
+}
+
+#[async_trait::async_trait]
+impl State for LeaderStopping {
+    fn name(&self) -> &'static str {
+        "Stopping"
+    }
+
+    async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
+        match (ctx.leader_manager.as_mut(), self.stop_behavior) {
+            (Some(leader_manager), LeaderStopBehavior::StopJob(mode)) => {
+                if let Err(e) = leader_manager.stop_leader(mode).await {
+                    return Err(ctx.retryable(
+                        self,
+                        "failed to send stop message to leader",
+                        e,
+                        10,
+                    ));
+                }
+
+                let timeout = match self.stop_behavior {
+                    LeaderStopBehavior::StopJob(JobStopMode::JobStopCheckpoint) => config()
+                        .pipeline
+                        .checkpoint
+                        .timeout
+                        .as_ref()
+                        .map(|t| **t)
+                        .unwrap_or(Duration::MAX),
+                    _ => FINISH_TIMEOUT,
+                };
+
+                info!(
+                    msg = "waiting for workers to terminate",
+                    job_id = *ctx.config.id
+                );
+                // TODO: we should watch the config queue and move immediately to force stop if requested
+                //  by the user
+                match tokio::time::timeout(
+                    timeout,
+                    leader_manager.wait_for_state(rpc::JobState::JobStopped),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => {
+                        error!(
+                            msg = "encountered error while waiting for job to stop gracefully; will try force-stopping",
+                            job_id = *ctx.config.id,
+                            error = e.to_string(),
+                        );
+
+                        return Ok(Transition::next(
+                            *self,
+                            LeaderStopping {
+                                stop_behavior: LeaderStopBehavior::StopWorkers,
+                            },
+                        ));
+                    }
+                    Err(_e) => {
+                        error!(
+                            msg = "timed out waiting for job to stop",
+                            job_id = *ctx.config.id,
+                        );
+
+                        return Ok(Transition::next(
+                            *self,
+                            LeaderStopping {
+                                stop_behavior: LeaderStopBehavior::StopWorkers,
+                            },
+                        ));
+                    }
+                }
+            }
+            (_, LeaderStopBehavior::StopWorkers) | (None, _) => {
+                if let Err(e) = ctx
+                    .scheduler
+                    .stop_workers(&ctx.config.id, Some(ctx.status.run_id), true)
+                    .await
+                {
+                    return Err(ctx.retryable(self, "failed while stopping workers", e, 20));
+                }
+            }
+        }
+
+        Ok(Transition::next(*self, Stopped {}))
+    }
+}

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -18,6 +18,12 @@ use self::checkpoint_stopping::CheckpointStopping;
 use self::compiling::Compiling;
 use self::failing::Failing;
 use self::finishing::Finishing;
+use self::leader_checkpoint_stopping::LeaderCheckpointStopping;
+use self::leader_finishing::LeaderFinishing;
+use self::leader_rescaling::LeaderRescaling;
+use self::leader_restarting::LeaderRestarting;
+use self::leader_running::LeaderRunning;
+use self::leader_stopping::LeaderStopping;
 use self::recovering::Recovering;
 use self::rescaling::Rescaling;
 use self::running::Running;
@@ -36,16 +42,22 @@ use arroyo_rpc::{errors, log_event};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use prost::Message;
 
-mod checkpoint_stopping;
-mod compiling;
-mod failing;
-mod finishing;
-mod recovering;
-mod rescaling;
-mod restarting;
-mod running;
-mod scheduling;
-mod stopping;
+pub(crate) mod checkpoint_stopping;
+pub(crate) mod compiling;
+pub(crate) mod failing;
+pub(crate) mod finishing;
+pub(crate) mod leader_checkpoint_stopping;
+pub(crate) mod leader_finishing;
+pub(crate) mod leader_rescaling;
+pub(crate) mod leader_restarting;
+pub(crate) mod leader_running;
+pub(crate) mod leader_stopping;
+pub(crate) mod recovering;
+pub(crate) mod rescaling;
+pub(crate) mod restarting;
+pub(crate) mod running;
+pub(crate) mod scheduling;
+pub(crate) mod stopping;
 
 pub enum Transition {
     Stop,
@@ -200,13 +212,32 @@ impl TransitionTo<Running> for Scheduling {
     }
 }
 
+impl TransitionTo<LeaderRunning> for Scheduling {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            if ctx.status.start_time.is_none() || ctx.status.finish_time.is_some() {
+                ctx.status.start_time = Some(OffsetDateTime::now_utc());
+                ctx.status.finish_time = None;
+            }
+        })
+    }
+}
+
 impl TransitionTo<CheckpointStopping> for Running {}
 impl TransitionTo<Stopping> for Running {}
+impl TransitionTo<Stopping> for LeaderRunning {}
 impl TransitionTo<Stopping> for Scheduling {}
 impl TransitionTo<Stopping> for Compiling {}
 impl TransitionTo<Stopping> for Rescaling {}
 impl TransitionTo<Finishing> for Running {}
 impl TransitionTo<Recovering> for Running {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+impl TransitionTo<Recovering> for LeaderRunning {
     fn update_status(&self) -> TransitionFn {
         Box::new(|ctx| {
             ctx.status.restarts += 1;
@@ -256,6 +287,100 @@ impl TransitionTo<Stopped> for Stopping {
         Box::new(done_transition)
     }
 }
+
+impl TransitionTo<LeaderCheckpointStopping> for LeaderRunning {}
+impl TransitionTo<LeaderStopping> for LeaderRunning {}
+impl TransitionTo<LeaderFinishing> for LeaderRunning {}
+impl TransitionTo<LeaderRestarting> for LeaderRunning {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restart_nonce = ctx.config.restart_nonce;
+        })
+    }
+}
+impl TransitionTo<LeaderRescaling> for LeaderRunning {}
+
+impl TransitionTo<Stopped> for LeaderStopping {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(done_transition)
+    }
+}
+
+impl TransitionTo<LeaderStopping> for LeaderStopping {}
+
+impl TransitionTo<Stopping> for LeaderStopping {}
+impl TransitionTo<Recovering> for LeaderStopping {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+
+impl TransitionTo<LeaderStopping> for LeaderCheckpointStopping {}
+impl TransitionTo<Stopping> for LeaderCheckpointStopping {}
+impl TransitionTo<Stopped> for LeaderCheckpointStopping {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(done_transition)
+    }
+}
+impl TransitionTo<Recovering> for LeaderCheckpointStopping {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+
+impl TransitionTo<Finished> for LeaderFinishing {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(done_transition)
+    }
+}
+impl TransitionTo<Recovering> for LeaderFinishing {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+impl TransitionTo<LeaderStopping> for LeaderFinishing {}
+impl TransitionTo<Stopping> for LeaderFinishing {}
+
+impl TransitionTo<LeaderCheckpointStopping> for LeaderRestarting {}
+impl TransitionTo<LeaderRestarting> for LeaderRestarting {}
+impl TransitionTo<Scheduling> for LeaderRestarting {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.run_id += 1;
+        })
+    }
+}
+
+impl TransitionTo<Recovering> for LeaderRestarting {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+impl TransitionTo<LeaderStopping> for LeaderRestarting {}
+
+impl TransitionTo<Scheduling> for LeaderRescaling {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.run_id += 1;
+        })
+    }
+}
+impl TransitionTo<Recovering> for LeaderRescaling {
+    fn update_status(&self) -> TransitionFn {
+        Box::new(|ctx| {
+            ctx.status.restarts += 1;
+        })
+    }
+}
+impl TransitionTo<LeaderStopping> for LeaderRescaling {}
 
 impl TransitionTo<Stopping> for CheckpointStopping {}
 impl TransitionTo<Stopped> for CheckpointStopping {
@@ -365,22 +490,67 @@ macro_rules! stop_if_desired_non_running {
     };
 }
 
+macro_rules! leader_stop_if_desired_running {
+    ($self:ident, $config:expr, $ctx:expr) => {
+        use crate::states::leader_checkpoint_stopping::LeaderCheckpointStopping;
+        use crate::states::leader_stopping::{LeaderStopBehavior, LeaderStopping};
+        use crate::types::public::StopMode;
+        use arroyo_rpc::grpc::rpc::JobStopMode;
+
+        match $config.stop_mode {
+            StopMode::force => {
+                return Ok(Transition::next(
+                    *$self,
+                    LeaderStopping {
+                        stop_behavior: LeaderStopBehavior::StopWorkers,
+                    },
+                ));
+            }
+            StopMode::checkpoint => {
+                return Ok(Transition::next(*$self, LeaderCheckpointStopping {}));
+            }
+            StopMode::graceful => {
+                return Ok(Transition::next(
+                    *$self,
+                    LeaderStopping {
+                        stop_behavior: LeaderStopBehavior::StopJob(JobStopMode::JobStopGraceful),
+                    },
+                ));
+            }
+            StopMode::immediate => {
+                return Ok(Transition::next(
+                    *$self,
+                    LeaderStopping {
+                        stop_behavior: LeaderStopBehavior::StopJob(JobStopMode::JobStopImmediate),
+                    },
+                ));
+            }
+            StopMode::none => {
+                // do nothing
+            }
+        }
+    };
+}
+
 use crate::job_controller::job_metrics::JobMetrics;
+use crate::job_controller::leader_manager::LeaderManager;
 use crate::states::restarting::Restarting;
+pub(crate) use leader_stop_if_desired_running;
 pub(crate) use stop_if_desired_non_running;
 pub(crate) use stop_if_desired_running;
 
 pub struct JobContext<'a> {
-    config: JobConfig,
-    status: &'a mut JobStatus,
-    program: &'a mut LogicalProgram,
-    db: DatabaseSource,
-    scheduler: Arc<dyn Scheduler>,
-    rx: &'a mut Receiver<JobMessage>,
-    retries_attempted: usize,
-    job_controller: Option<JobController>,
-    last_transitioned_at: Instant,
-    metrics: Arc<tokio::sync::RwLock<HashMap<Arc<String>, JobMetrics>>>,
+    pub config: JobConfig,
+    pub status: &'a mut JobStatus,
+    pub program: &'a mut LogicalProgram,
+    pub db: DatabaseSource,
+    pub scheduler: Arc<dyn Scheduler>,
+    pub rx: &'a mut Receiver<JobMessage>,
+    pub retries_attempted: usize,
+    pub job_controller: Option<JobController>,
+    pub leader_manager: Option<LeaderManager>,
+    pub last_transitioned_at: Instant,
+    pub metrics: Arc<tokio::sync::RwLock<HashMap<Arc<String>, JobMetrics>>>,
 }
 
 impl JobContext<'_> {
@@ -418,7 +588,7 @@ impl JobContext<'_> {
         error!(
             job_id = self.config.id.as_str(),
             task_id = event.task_id,
-            subtask_idx = event.subtask_idx,
+            operator_subtask = event.subtask_idx,
             operator_id = event.operator_id,
             error_domain = event.error_domain.as_str(),
             retry_hint = event.retry_hint.as_str(),
@@ -459,6 +629,76 @@ impl JobContext<'_> {
                 },
             )),
         }
+    }
+
+    pub async fn handle_job_failure<T: State + TransitionTo<Recovering>>(
+        &self,
+        state: T,
+        failure: arroyo_rpc::grpc::rpc::JobFailure,
+    ) -> Result<Transition, StateError> {
+        let error_domain = errors::ErrorDomain::from(failure.error_domain());
+        let retry_hint = errors::RetryHint::from(failure.retry_hint());
+        let operator_id = failure
+            .operator_id
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let subtask_index = failure.subtask_index.unwrap_or_default();
+        let reason = failure.message.clone();
+
+        error!(
+            job_id = self.config.id.as_str(),
+            task_id = format!("{:?}", failure.task_id),
+            operator_subtask = subtask_index,
+            operator_id,
+            error_domain = error_domain.as_str(),
+            retry_hint = retry_hint.as_str(),
+            message = "job failed",
+            reason,
+        );
+
+        if let (Some(operator_id), Some(subtask_index)) =
+            (failure.operator_id.as_ref(), failure.subtask_index)
+        {
+            let client = self.db.client().await.unwrap();
+            if let Err(db_err) = queries::controller_queries::execute_create_job_log_message(
+                &client,
+                &generate_id(IdTypes::JobLogMessage),
+                &self.config.id.as_str(),
+                operator_id,
+                &(subtask_index as i64),
+                &LogLevel::error,
+                &"job failed",
+                &failure.message,
+                &error_domain.as_str(),
+                &retry_hint.as_str(),
+            )
+            .await
+            {
+                warn!("Failed to log job failure to database: {:?}", db_err);
+            }
+        }
+
+        match retry_hint {
+            errors::RetryHint::NoRetry => Err(StateError::FatalError {
+                source: anyhow!("job failed: {}", failure.message),
+                message: failure.message,
+                domain: error_domain,
+            }),
+            errors::RetryHint::WithBackoff => Ok(Transition::next(
+                state,
+                Recovering {
+                    source: anyhow!("job failed: {}", failure.message),
+                    reason: failure.message,
+                    domain: error_domain,
+                },
+            )),
+        }
+    }
+
+    pub fn leader_manager(&mut self) -> &mut LeaderManager {
+        self.leader_manager
+            .as_mut()
+            .expect("requested leader_manager but was not initialized")
     }
 }
 
@@ -671,6 +911,7 @@ async fn run_to_completion(
         rx: &mut rx,
         retries_attempted: 0,
         job_controller: None,
+        leader_manager: None,
         last_transitioned_at: Instant::now(),
         metrics,
     };
@@ -771,7 +1012,7 @@ impl StateMachine {
             "Stopped" => Some(Box::new(Stopped {})),
             "Finished" => Some(Box::new(Finished {})),
             "Failed" => Some(Box::new(Failed {})),
-            "Compiling" | "Scheduling" | "Running" | "Recovering" | "Rescaling" => {
+            "Compiling" | "Scheduling" | "Running" | "Recovering" | "Rescaling" | "Restarting" => {
                 Some(Box::new(Compiling {}))
             }
             "Failing" => {
@@ -888,7 +1129,8 @@ impl StateMachine {
         shutdown_guard: &ShutdownGuard,
     ) {
         match (applied, status.state.as_str()) {
-            (_, "Running" | "Recovering" | "Rescaling") | (AppliedStatus::NotApplied, _) => {
+            (_, "Running" | "Recovering" | "Rescaling" | "Restarting")
+            | (AppliedStatus::NotApplied, _) => {
                 // done() means there isn't a task running, but these states
                 // need to be advanced.
                 if self.done() {

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -1,11 +1,15 @@
 use super::{
     JobContext, State, StateError, Transition, compiling::Compiling, fatal, state_backoff,
 };
-use anyhow::bail;
+use crate::JobMessage;
+use crate::job_controller::JobController;
+use crate::job_controller::leader_manager::LeaderManager;
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
-use arroyo_rpc::grpc::rpc::StopMode;
+use arroyo_rpc::grpc::rpc::{JobState, JobStopMode, StopMode};
+use arroyo_rpc::retry;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
 use tracing::{info, warn};
 
@@ -18,29 +22,27 @@ pub struct Recovering {
 
 impl Recovering {
     // tries, with increasing levels of force, to tear down the existing cluster
-    pub async fn cleanup<'a>(ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
-        let job_controller = ctx.job_controller.as_mut().unwrap();
-
+    pub async fn cleanup_job_controller(
+        job_controller: &mut JobController,
+        job_id: &str,
+        rx: &mut Receiver<JobMessage>,
+    ) {
         // first try to stop it gracefully
         if job_controller.finished() {
-            return Ok(());
+            return;
         }
 
         // stop the job
-        info!(message = "stopping job", job_id = *ctx.config.id);
+        info!(message = "stopping job", job_id);
         let start = Instant::now();
         match job_controller.stop_job(StopMode::Immediate).await {
             Ok(_) => {
-                if (timeout(
-                    Duration::from_secs(5),
-                    job_controller.wait_for_finish(ctx.rx),
-                )
-                .await)
+                if (timeout(Duration::from_secs(5), job_controller.wait_for_finish(rx)).await)
                     .is_ok()
                 {
                     info!(
                         message = "job stopped",
-                        job_id = *ctx.config.id,
+                        job_id,
                         duration = start.elapsed().as_secs_f32()
                     );
                 }
@@ -49,44 +51,122 @@ impl Recovering {
                 warn!(
                     message = "failed to stop job",
                     error = format!("{:?}", e),
-                    job_id = *ctx.config.id
+                    job_id,
                 );
             }
         }
+    }
 
-        // tell the processes to stop
-
-        for i in 0..10 {
-            if ctx
-                .scheduler
-                .workers_for_job(&ctx.config.id, Some(ctx.status.run_id))
-                .await?
-                .is_empty()
-            {
-                return Ok(());
+    pub async fn cleanup_leader(leader_manager: &mut LeaderManager, job_id: &str) {
+        let status = match leader_manager.poll_leader_status().await {
+            Ok(status) => status,
+            Err(e) => {
+                warn!(job_id, error =? e, "failed to get leader status while recovering");
+                return;
             }
+        };
 
-            info!(
-                message = "sending SIGKILL to workers",
-                job_id = *ctx.config.id
-            );
-
-            if let Err(e) = ctx
-                .scheduler
-                .stop_workers(&ctx.config.id, Some(ctx.status.run_id), true)
-                .await
-            {
+        let expected_state = match JobState::try_from(status.job_state) {
+            Ok(JobState::JobFailed) => {
+                return;
+            }
+            Ok(JobState::JobUnknown) | Err(_) => {
                 warn!(
-                    message = "error while stopping workers",
-                    error = format!("{:?}", e),
-                    job_id = *ctx.config.id
+                    job_id,
+                    "received unknown job state {} while cleaning job", status.job_state
                 );
+                return;
             }
+            Ok(JobState::JobInitializing) => {
+                warn!(job_id, "job is in initializing while cleaning");
+                return;
+            }
+            Ok(JobState::JobRunning) => {
+                // shutdown
+                info!(job_id, "job is still running in recovering, shutting down");
+                if retry!(
+                    leader_manager
+                        .stop_leader(JobStopMode::JobStopImmediate)
+                        .await,
+                    10,
+                    Duration::from_millis(200),
+                    Duration::from_secs(2),
+                    |e| warn!(job_id, err = ?e, "failed to stop job")
+                )
+                .is_err()
+                {
+                    return;
+                }
+                JobState::JobStopped
+            }
+            Ok(JobState::JobStopping) => {
+                // wait for job to be stopped
+                JobState::JobStopped
+            }
+            Ok(JobState::JobStopped) => {
+                return;
+            }
+            Ok(JobState::JobFinishing) => {
+                // wait for job to be finished
+                JobState::JobFinished
+            }
+            Ok(JobState::JobFinished) => {
+                return;
+            }
+            Ok(JobState::JobFailing) => {
+                // wait for job to be failed
+                JobState::JobFailed
+            }
+        };
 
-            tokio::time::sleep(Duration::from_millis(i * 50)).await;
+        if let Err(e) = timeout(
+            Duration::from_secs(60),
+            leader_manager.wait_for_state(expected_state),
+        )
+        .await
+        {
+            warn!(job_id, error = ?e, ?expected_state, "timed out waiting for state during cleanup");
+        }
+    }
+
+    async fn tear_down_workers<'a>(ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
+        if ctx
+            .scheduler
+            .workers_for_job(&ctx.config.id, Some(ctx.status.run_id))
+            .await?
+            .is_empty()
+        {
+            return Ok(());
         }
 
-        bail!("Failed to clean up cluster")
+        info!(message = "tearing down workers", job_id = *ctx.config.id);
+
+        ctx.scheduler
+            .stop_workers(&ctx.config.id, Some(ctx.status.run_id), true)
+            .await
+    }
+
+    pub async fn cleanup<'a>(ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
+        // attempt to shutdown the job cleanly
+        match (ctx.job_controller.as_mut(), ctx.leader_manager.as_mut()) {
+            (Some(jc), None) => Self::cleanup_job_controller(jc, &ctx.config.id, ctx.rx).await,
+            (None, Some(lm)) => Self::cleanup_leader(lm, &ctx.config.id).await,
+            (Some(_), Some(_)) => unreachable!("both job controller and leader manager are set!"),
+            (None, None) => {
+                // somehow we got here before scheduling set the job controller / leader manager
+            }
+        };
+
+        // then tear down the workers
+        retry!(
+            Self::tear_down_workers(ctx).await,
+            10,
+            Duration::from_millis(200),
+            Duration::from_secs(10),
+            |e| warn!(job_id = *ctx.config.id, error =? e, "failed to tear down cluster")
+        )?;
+
+        Ok(())
     }
 }
 
@@ -126,11 +206,9 @@ impl State for Recovering {
             "recovering pipeline"
         );
 
-        // tear down the existing cluster
-        if let Err(e) = Self::cleanup(ctx).await {
-            return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
+        match Self::cleanup(ctx).await {
+            Ok(()) => Ok(Transition::next(*self, Compiling)),
+            Err(e) => Err(ctx.retryable(self, "failed to tear down existing cluster", e, 3)),
         }
-
-        Ok(Transition::next(*self, Compiling))
     }
 }

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -7,23 +7,15 @@ use std::{
 use arroyo_rpc::grpc::rpc::{
     StartExecutionReq, TaskAssignment, worker_grpc_client::WorkerGrpcClient,
 };
-use arroyo_types::{MachineId, WorkerId};
+use arroyo_types::{JobId, MachineId, WorkerId};
 use tokio::{select, sync::Mutex, task::JoinHandle};
 use tonic::{Request, transport::Channel};
 use tracing::{debug, error, info, warn};
 
-use anyhow::anyhow;
-use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::config::config;
-use arroyo_rpc::grpc::api;
-use arroyo_rpc::grpc_channel_builder;
-use arroyo_state::{
-    BackingStore, StateBackend,
-    committing_state::CommittingState,
-    tables::{ErasedTable, global_keyed_map::GlobalKeyedTable},
-};
-
+use super::{JobContext, State, Transition, leader_running::LeaderRunning, running::Running};
+use crate::job_controller::checkpoint_store::DbCheckpointMetadataStore;
 use crate::job_controller::job_metrics::JobMetrics;
+use crate::job_controller::leader_manager::LeaderManager;
 use crate::{JobMessage, schedulers::SchedulerError};
 use crate::{
     job_controller::JobController, queries::controller_queries, states::stop_if_desired_non_running,
@@ -32,9 +24,17 @@ use crate::{
     schedulers::StartPipelineReq,
     states::{StateError, fatal},
 };
+use anyhow::anyhow;
+use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::config::{JobControllerMode, config};
+use arroyo_rpc::grpc::api;
+use arroyo_rpc::grpc_channel_builder;
 use arroyo_rpc::worker_types::RunningMessage;
-
-use super::{JobContext, State, Transition, running::Running};
+use arroyo_state::{
+    BackingStore, StateBackend,
+    committing_state::CommittingState,
+    tables::{ErasedTable, global_keyed_map::GlobalKeyedTable},
+};
 
 #[derive(Debug, Clone)]
 struct WorkerStatus {
@@ -281,13 +281,17 @@ impl State for Scheduling {
         let worker_connects = Arc::new(Mutex::new(HashMap::new()));
         let mut handles = vec![];
 
-        let config = &config().pipeline;
+        let pipeline_config = &config().pipeline;
 
         let start = Instant::now();
         loop {
-            let timeout = config
+            let timeout = pipeline_config
                 .worker_startup_time
-                .min(ctx.config.ttl.unwrap_or(*config.worker_startup_time))
+                .min(
+                    ctx.config
+                        .ttl
+                        .unwrap_or(*pipeline_config.worker_startup_time),
+                )
                 .checked_sub(start.elapsed())
                 .unwrap_or(Duration::ZERO);
 
@@ -308,7 +312,7 @@ impl State for Scheduling {
                 _ = tokio::time::sleep(timeout) => {
                     return Err(ctx.retryable(self,
                         "timed out while waiting for workers to start",
-                        anyhow!("timed out after {:?} while waiting for worker startup", *config.worker_startup_time), 3));
+                        anyhow!("timed out after {:?} while waiting for worker startup", *pipeline_config.worker_startup_time), 3));
                 }
             }
 
@@ -554,6 +558,43 @@ impl State for Scheduling {
         let worker_connects = Arc::try_unwrap(worker_connects).unwrap().into_inner();
         let program = api::ArrowProgram::from(ctx.program.clone());
 
+        // Use ignore_state_before_epoch as default so new checkpoints exceed the threshold
+        let default_epoch = ctx
+            .config
+            .ignore_state_before_epoch
+            .filter(|&t| t > 0)
+            .map(|t| {
+                let epoch = (t - 1) as u32;
+                info!(
+                    message = "starting from ignore_state_before_epoch threshold",
+                    job_id = *ctx.config.id,
+                    default_epoch = epoch,
+                );
+                epoch
+            })
+            .unwrap_or(0);
+
+        let start_epoch = checkpoint_info
+            .as_ref()
+            .map(|info| info.epoch)
+            .unwrap_or(default_epoch);
+        let min_epoch = checkpoint_info
+            .as_ref()
+            .map(|info| info.min_epoch)
+            .unwrap_or(default_epoch);
+
+        let (leader_id, leader_addr) = matches!(config().job_controller, JobControllerMode::Worker)
+            .then(|| {
+                workers
+                    .iter()
+                    .min_by_key(|w| w.0.0)
+                    .map(|(id, status)| (*id, status.rpc_address.clone()))
+                    .unwrap()
+            })
+            .unzip();
+
+        let checkpoint_interval_micros = ctx.config.checkpoint_interval.as_micros() as u64;
+
         let tasks: Vec<_> = worker_connects
             .into_iter()
             .map(|(id, mut c)| {
@@ -562,6 +603,7 @@ impl State for Scheduling {
                 let restore_epoch = checkpoint_info.as_ref().map(|info| info.epoch);
                 let program = program.clone();
                 let machine_id = workers.get(&id).as_ref().unwrap().machine_id.clone();
+                let leader_addr = leader_addr.clone();
 
                 tokio::spawn(async move {
                     info!(
@@ -574,8 +616,14 @@ impl State for Scheduling {
                     match c
                         .start_execution(Request::new(StartExecutionReq {
                             restore_epoch,
+                            start_epoch,
+                            min_epoch,
                             program: Some(program.clone()),
                             tasks: assignments.clone(),
+                            job_controller_addr: leader_addr,
+                            is_leader: leader_id.is_some_and(|l| l == id),
+                            wait_for_leader: leader_id.is_some(),
+                            checkpoint_interval_micros,
                         }))
                         .await
                     {
@@ -622,9 +670,9 @@ impl State for Scheduling {
         let start = Instant::now();
         let mut started_tasks = HashSet::new();
         while started_tasks.len() < ctx.program.task_count() {
-            let timeout = config
+            let timeout = pipeline_config
                 .task_startup_time
-                .min(ctx.config.ttl.unwrap_or(*config.task_startup_time))
+                .min(ctx.config.ttl.unwrap_or(*pipeline_config.task_startup_time))
                 .checked_sub(start.elapsed())
                 .unwrap_or(Duration::ZERO);
 
@@ -684,7 +732,7 @@ impl State for Scheduling {
                 _ = tokio::time::sleep(timeout) => {
                     return Err(ctx.retryable(self,
                         "timed out while waiting for tasks to start",
-                        anyhow!("timed out after {:?} while waiting for worker startup", *config.task_startup_time), 3));
+                        anyhow!("timed out after {:?} while waiting for worker startup", *pipeline_config.task_startup_time), 3));
                 }
             }
         }
@@ -700,47 +748,65 @@ impl State for Scheduling {
             .await
             .insert(ctx.config.id.clone(), metrics.clone());
 
-        // Use ignore_state_before_epoch as default so new checkpoints exceed the threshold
-        let default_epoch = ctx
-            .config
-            .ignore_state_before_epoch
-            .filter(|&t| t > 0)
-            .map(|t| {
-                let epoch = (t - 1) as u32;
-                info!(
-                    message = "starting from ignore_state_before_epoch threshold",
-                    job_id = *ctx.config.id,
-                    default_epoch = epoch,
+        match leader_addr {
+            None => {
+                let checkpoint_store = Arc::new(DbCheckpointMetadataStore {
+                    organization_id: ctx.config.organization_id.clone(),
+                    job_id: ctx.config.id.clone(),
+                    state_backend: StateBackend::name(),
+                    db: ctx.db.clone(),
+                });
+                let mut controller = JobController::new(
+                    checkpoint_store,
+                    ctx.config.clone(),
+                    program,
+                    start_epoch,
+                    min_epoch,
+                    worker_connects,
+                    committing_state,
+                    metrics,
                 );
-                epoch
-            })
-            .unwrap_or(0);
+                if needs_commit {
+                    info!("restored checkpoint was in committing phase, sending commits");
+                    controller
+                        .send_commit_messages()
+                        .await
+                        .expect("failed to send commit messages");
+                }
 
-        let mut controller = JobController::new(
-            ctx.db.clone(),
-            ctx.config.clone(),
-            program,
-            checkpoint_info
-                .as_ref()
-                .map(|info| info.epoch)
-                .unwrap_or(default_epoch),
-            checkpoint_info
-                .as_ref()
-                .map(|info| info.min_epoch)
-                .unwrap_or(default_epoch),
-            worker_connects,
-            committing_state,
-            metrics,
-        );
-        if needs_commit {
-            info!("restored checkpoint was in committing phase, sending commits");
-            controller
-                .send_commit_messages()
+                ctx.job_controller = Some(controller);
+                Ok(Transition::next(*self, Running {}))
+            }
+            Some(leader_addr) => {
+                ctx.job_controller = None;
+
+                let leader_manager = match LeaderManager::connect(
+                    JobId(ctx.config.id.clone()),
+                    ctx.status.run_id,
+                    leader_addr,
+                )
                 .await
-                .expect("failed to send commit messages");
-        }
+                {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return Err(ctx.retryable(
+                            self,
+                            "failed to connect to worker leader",
+                            e,
+                            10,
+                        ));
+                    }
+                };
 
-        ctx.job_controller = Some(controller);
-        Ok(Transition::next(*self, Running {}))
+                ctx.leader_manager = Some(leader_manager);
+
+                Ok(Transition::next(
+                    *self,
+                    LeaderRunning {
+                        started: Instant::now(),
+                    },
+                ))
+            }
+        }
     }
 }

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -32,6 +32,7 @@ http-port = 5115
 bind-address = "0.0.0.0"
 rpc-port = 5116
 scheduler = "process"
+leader-poll-interval = "500ms"
 
 [compiler]
 bind-address = "0.0.0.0"

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -1,5 +1,6 @@
 checkpoint-url = "/tmp/arroyo/checkpoints"
 default-checkpoint-interval = "10s"
+job-controller = "controller"
 
 [pipeline]
 source-batch-size = 512
@@ -18,6 +19,8 @@ store-deserialization-errors = true
 [pipeline.compaction]
 enabled = false
 checkpoints-to-compact = 4
+
+[pipeline.checkpoint]
 
 # Services
 

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -6,6 +6,7 @@ import "api.proto";
 
 // Controller
 
+
 message WorkerContext {
   string machine_id = 1;
   uint64 worker_id = 2;
@@ -50,11 +51,12 @@ enum TaskCheckpointEventType {
   FINISHED_COMMIT = 4;
 }
 
+
 message TaskCheckpointEventReq {
   WorkerContext worker_context = 1;
   uint64 time = 2;
   string operator_id = 8;
-  uint32 subtask_idx = 5;
+  uint32 subtask_index = 5;
   uint32 epoch = 6;
   TaskCheckpointEventType event_type = 7;
 }
@@ -64,7 +66,7 @@ message TaskCheckpointEventResp {
 
 message TaskCheckpointCompletedReq {
   WorkerContext worker_context = 1;
-  uint64 time = 2;
+  uint64  time = 2;
   string operator_id = 4;
   uint32 epoch = 5;
   SubtaskCheckpointMetadata metadata = 6;
@@ -107,7 +109,7 @@ message TaskError {
 
 message TaskFailedReq {
   WorkerContext worker_context = 1;
-  uint64 time = 2;
+  uint64  time = 2;
   TaskError error = 3;
 }
 
@@ -156,7 +158,7 @@ message SinkDataResp {
 
 message WorkerFinishedReq {
   WorkerContext worker_context = 1;
-  uint64 time = 2;
+  uint64  time = 2;
   uint64 slots = 3;
 }
 
@@ -190,6 +192,7 @@ enum WorkerPhase {
   INITIALIZING = 1;
   RUNNING = 2;
   FAILED = 3;
+  WAITING_ON_LEADER = 4;
 }
 
 message GetWorkerPhaseReq {
@@ -225,20 +228,81 @@ service ControllerGrpc {
   rpc RegisterNode(RegisterNodeReq) returns (RegisterNodeResp);
   rpc HeartbeatNode(HeartbeatNodeReq) returns (HeartbeatNodeResp);
   rpc RegisterWorker(RegisterWorkerReq) returns (RegisterWorkerResp);
-  rpc Heartbeat(HeartbeatReq) returns (HeartbeatResp);
   rpc TaskStarted(TaskStartedReq) returns (TaskStartedResp);
-  rpc TaskCheckpointEvent(TaskCheckpointEventReq) returns (TaskCheckpointEventResp);
-  rpc TaskCheckpointCompleted(TaskCheckpointCompletedReq) returns (TaskCheckpointCompletedResp);
-  rpc TaskFinished(TaskFinishedReq) returns (TaskFinishedResp);
-  rpc TaskFailed(TaskFailedReq) returns (TaskFailedResp);
   rpc SendSinkData(SinkDataReq) returns (SinkDataResp);
   // sent from the node to the controller when a worker process exits
   rpc WorkerFinished(WorkerFinishedReq) returns (WorkerFinishedResp);
   rpc WorkerInitializationComplete(WorkerInitializationCompleteReq) returns (WorkerInitializationCompleteResp);
 
   rpc SubscribeToOutput(GrpcOutputSubscription) returns (stream OutputData);
+}
+
+service JobControllerGrpc {
+  rpc TaskCheckpointEvent(TaskCheckpointEventReq) returns (TaskCheckpointEventResp);
+  rpc TaskCheckpointCompleted(TaskCheckpointCompletedReq) returns (TaskCheckpointCompletedResp);
   rpc NonfatalError(NonfatalErrorReq) returns (WorkerErrorRes);
   rpc JobMetrics(JobMetricsReq) returns (JobMetricsResp);
+  rpc Heartbeat(HeartbeatReq) returns (HeartbeatResp);
+  rpc TaskFinished(TaskFinishedReq) returns (TaskFinishedResp);
+  rpc TaskFailed(TaskFailedReq) returns (TaskFailedResp);
+}
+
+message JobStatusReq {
+  string job_id = 1;
+}
+
+message CheckpointStatus {
+  uint32 epoch = 1;
+  uint64 started_at = 2;
+  optional uint64 finished_at = 3;
+  uint64 size_bytes = 4;
+}
+
+enum JobState {
+  JOB_UNKNOWN = 0;
+  JOB_INITIALIZING = 1;
+  JOB_RUNNING = 2;
+  JOB_STOPPING = 3;
+  JOB_STOPPED = 4;
+  JOB_FINISHING = 5;
+  JOB_FINISHED = 6;
+  JOB_FAILING = 7;
+  JOB_FAILED = 8;
+}
+
+message JobFailure {
+  optional string operator_id = 1;
+  optional uint32 task_id = 2;
+  optional uint32 subtask_index = 3;
+  string message = 4;
+  ErrorDomain error_domain = 5;
+  RetryHint retry_hint = 6;
+}
+
+message JobStatus {
+  JobState job_state = 1;
+  uint64 updated_at = 2;
+  uint64 transitioned_at = 3;
+  optional CheckpointStatus last_checkpoint = 4;
+  optional JobFailure job_failure = 5;
+}
+
+message JobStatusResp {
+  string job_id = 1;
+  uint64 run_id = 2;
+  JobStatus job_status = 3;
+}
+
+message StopJobReq {
+  JobStopMode stop_mode = 1;
+}
+
+message StopJobResp {
+}
+
+service JobStatusGrpc {
+  rpc GetJobStatus(JobStatusReq) returns (JobStatusResp);
+  rpc StopJob(StopJobReq) returns (StopJobResp);
 }
 
 // Checkpoint metadata
@@ -364,7 +428,16 @@ message TaskAssignment {
 message StartExecutionReq {
   api.ArrowProgram program = 1;
   optional uint32 restore_epoch = 2;
+  uint32 start_epoch = 6;
+  uint32 min_epoch = 7;
   repeated TaskAssignment tasks = 3;
+  // if none, clients should use the controller address
+  optional string job_controller_addr = 4;
+  bool is_leader = 5;
+  // if set, the worker should wait for a job_controller_init message before starting
+  // (used in worker leader mode)
+  bool wait_for_leader = 8;
+  uint64 checkpoint_interval_micros = 9;
 }
 
 message StartExecutionResp {
@@ -415,6 +488,12 @@ enum StopMode {
   IMMEDIATE = 1;
 }
 
+enum JobStopMode {
+  JOB_STOP_GRACEFUL = 0;
+  JOB_STOP_IMMEDIATE = 1;
+  JOB_STOP_CHECKPOINT = 2;
+}
+
 message StopExecutionReq {
   StopMode stop_mode = 1;
 }
@@ -435,7 +514,16 @@ message MetricsResp {
   repeated MetricFamily metrics = 1;
 }
 
+// Sent from the Job Controller when running in a worker to all workers to start
+// execution
+message JobControllerInitReq {
+}
+
+message JobControllerInitResp {}
+
+
 service WorkerGrpc {
+  rpc GetWorkerPhase(GetWorkerPhaseReq) returns (GetWorkerPhaseResp);
   rpc StartExecution(StartExecutionReq) returns (StartExecutionResp);
   rpc Checkpoint(CheckpointReq) returns (CheckpointResp);
   rpc Commit(CommitReq) returns (CommitResp);
@@ -443,7 +531,7 @@ service WorkerGrpc {
   rpc StopExecution(StopExecutionReq) returns (StopExecutionResp);
   rpc JobFinished(JobFinishedReq) returns (JobFinishedResp);
   rpc GetMetrics(MetricsReq) returns (MetricsResp);
-  rpc GetWorkerPhase(GetWorkerPhaseReq) returns (GetWorkerPhaseResp);
+  rpc JobControllerInit(JobControllerInitReq) returns (JobControllerInitResp);
 }
 
 // Node

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -56,7 +56,7 @@ message TaskCheckpointEventReq {
   WorkerContext worker_context = 1;
   uint64 time = 2;
   string operator_id = 8;
-  uint32 subtask_index = 5;
+  uint32 subtask_idx = 5;
   uint32 epoch = 6;
   TaskCheckpointEventType event_type = 7;
 }

--- a/crates/arroyo-rpc/src/checkpoints.rs
+++ b/crates/arroyo-rpc/src/checkpoints.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckpointStatus {
+    InProgress,
+    Committing,
+    Ready,
+    Failed,
+    Compacting,
+    Compacted,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateCheckpointReq {
+    pub checkpoint_id: String,
+    pub epoch: u32,
+    pub min_epoch: u32,
+    pub start_time: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateCheckpointReq {
+    pub checkpoint_id: String,
+    pub operator_details: JsonValue,
+    pub finish_time: Option<SystemTime>,
+    pub status: CheckpointStatus,
+    pub event_spans: JsonValue,
+}
+
+#[derive(Debug, Clone)]
+pub struct FinishCheckpointReq {
+    pub checkpoint_id: String,
+    pub finish_time: SystemTime,
+    pub event_spans: JsonValue,
+}
+
+#[async_trait::async_trait]
+pub trait CheckpointMetadataStore: Send + Sync {
+    async fn create_checkpoint(&self, req: CreateCheckpointReq) -> Result<()>;
+
+    async fn update_checkpoint(&self, req: UpdateCheckpointReq) -> Result<()>;
+
+    async fn finish_checkpoint(&self, req: FinishCheckpointReq) -> Result<()>;
+
+    async fn mark_compacting(&self, job_id: &str, min_epoch: u32, new_min: u32) -> Result<()>;
+
+    async fn mark_checkpoints_compacted(&self, job_id: &str, epoch: u32) -> Result<()>;
+
+    async fn drop_old_checkpoint_rows(&self, job_id: &str, epoch: u32) -> Result<()>;
+
+    fn notify_checkpoint_complete(&self);
+}

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -370,6 +370,9 @@ pub struct ControllerConfig {
     /// TLS configuration for controller gRPC service
     #[serde(default)]
     pub tls: Option<TlsConfig>,
+
+    /// Poll interval for leader status
+    pub leader_poll_interval: HumanReadableDuration,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -260,6 +260,9 @@ pub struct Config {
     /// Directory to look for config files in
     pub config_dir: Option<PathBuf>,
 
+    /// Controls where the "job controller" lives, either on the controller or a worker-leader
+    pub job_controller: JobControllerMode,
+
     /// Run options
     #[serde(default)]
     pub run: RunConfig,
@@ -267,6 +270,14 @@ pub struct Config {
     /// Telemetry config
     #[serde(default)]
     pub disable_telemetry: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum JobControllerMode {
+    #[default]
+    Controller,
+    Worker,
 }
 
 impl Config {
@@ -530,6 +541,16 @@ pub struct PipelineConfig {
     pub chaining: ChainingConfig,
 
     pub compaction: CompactionConfig,
+
+    pub checkpoint: CheckpointConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct CheckpointConfig {
+    /// Checkpoint timeout
+    #[serde(default)]
+    pub timeout: Option<HumanReadableDuration>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api_types;
+pub mod checkpoints;
 pub mod formats;
 pub mod public_ids;
 pub mod schema_resolver;
@@ -1056,6 +1057,31 @@ pub async fn controller_client(
 ) -> Result<ControllerGrpcClient<Channel>> {
     let channel = connect_controller(our_name, our_tls).await?;
     Ok(ControllerGrpcClient::new(channel))
+}
+
+pub async fn job_controller_client(
+    our_name: &str,
+    our_tls: &Option<TlsConfig>,
+    addr: String,
+    is_worker_job_controller: bool,
+) -> Result<crate::grpc::rpc::job_controller_grpc_client::JobControllerGrpcClient<Channel>> {
+    let their_tls = if is_worker_job_controller {
+        &config().worker.tls
+    } else {
+        &config().controller.tls
+    };
+
+    let channel = connect_grpc(our_name, addr, our_tls, their_tls).await?;
+    Ok(crate::grpc::rpc::job_controller_grpc_client::JobControllerGrpcClient::new(channel))
+}
+
+pub async fn job_status_client(
+    our_name: &str,
+    our_tls: &Option<TlsConfig>,
+    addr: String,
+) -> Result<crate::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient<Channel>> {
+    let channel = connect_grpc(our_name, addr, our_tls, &config().controller.tls).await?;
+    Ok(crate::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient::new(channel))
 }
 
 pub fn local_address(bind_address: IpAddr) -> String {

--- a/crates/arroyo-rpc/src/worker_types.rs
+++ b/crates/arroyo-rpc/src/worker_types.rs
@@ -1,6 +1,6 @@
 use crate::errors;
 use crate::grpc::rpc;
-use crate::grpc::rpc::{TaskCheckpointCompletedReq, TaskCheckpointEventReq};
+use crate::grpc::rpc::{JobStopMode, TaskCheckpointCompletedReq, TaskCheckpointEventReq};
 use arroyo_types::{JobId, MachineId, WorkerId};
 use std::time::{Instant, SystemTime};
 
@@ -35,6 +35,19 @@ pub struct TaskFailedEvent {
     pub retry_hint: errors::RetryHint,
 }
 
+impl From<TaskFailedEvent> for rpc::JobFailure {
+    fn from(value: TaskFailedEvent) -> Self {
+        Self {
+            operator_id: Some(value.operator_id),
+            task_id: Some(value.task_id),
+            subtask_index: Some(value.subtask_idx),
+            message: value.reason,
+            error_domain: rpc::ErrorDomain::from(value.error_domain).into(),
+            retry_hint: rpc::RetryHint::from(value.retry_hint).into(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum RunningMessage {
     TaskCheckpointEvent(TaskCheckpointEventReq),
@@ -52,5 +65,8 @@ pub enum RunningMessage {
     },
     WorkerFinished {
         worker_id: WorkerId,
+    },
+    Stop {
+        stop_mode: JobStopMode,
     },
 }

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -17,13 +17,16 @@ use tokio::sync::mpsc::{Receiver, channel};
 
 use crate::udfs::get_udfs;
 use arroyo_rpc::config;
-use arroyo_rpc::grpc::rpc::{StopMode, TaskCheckpointCompletedReq, TaskCheckpointEventReq};
+use arroyo_rpc::grpc::rpc::{
+    StopMode, TaskCheckpointCompletedReq, TaskCheckpointEventReq, WorkerContext,
+};
 use arroyo_rpc::{CompactionResult, ControlMessage, ControlResp};
-use arroyo_state::checkpoint_state::CheckpointState;
+use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::{CheckpointBarrier, to_micros};
 use arroyo_udf_host::LocalUdf;
 use arroyo_worker::engine::Engine;
 use arroyo_worker::engine::{Program, RunningEngine};
+use arroyo_worker::job_controller::checkpoint_state::CheckpointState;
 use petgraph::{Direction, Graph};
 use serde_json::Value;
 use test_log::test as test_log;
@@ -147,10 +150,15 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
         match c {
             ControlResp::CheckpointEvent(c) => {
                 let req = TaskCheckpointEventReq {
-                    worker_context: None,
+                    worker_context: Some(WorkerContext {
+                        machine_id: "test".to_string(),
+                        worker_id: 1,
+                        job_id: (*ctx.job_id).clone(),
+                        run_id: 0,
+                    }),
                     time: to_micros(c.time),
                     operator_id: c.operator_id,
-                    subtask_idx: c.subtask_idx,
+                    subtask_index: c.subtask_idx,
                     epoch: c.checkpoint_epoch,
                     event_type: c.event_type as i32,
                 };
@@ -158,20 +166,33 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
             }
             ControlResp::CheckpointCompleted(c) => {
                 let req = TaskCheckpointCompletedReq {
-                    worker_context: None,
+                    worker_context: Some(WorkerContext {
+                        machine_id: "test".to_string(),
+                        worker_id: 1,
+                        job_id: (*ctx.job_id).clone(),
+                        run_id: 0,
+                    }),
                     time: c.subtask_metadata.finish_time,
                     operator_id: c.operator_id,
                     epoch: c.checkpoint_epoch,
                     needs_commit: false,
                     metadata: Some(c.subtask_metadata),
                 };
-                checkpoint_state.checkpoint_finished(req).await.unwrap();
+                if let Some(operator_metadata) = checkpoint_state.checkpoint_finished(req).unwrap()
+                {
+                    StateBackend::write_operator_checkpoint_metadata(operator_metadata)
+                        .await
+                        .unwrap();
+                }
             }
             _ => {}
         }
     }
 
-    checkpoint_state.write_metadata().await.unwrap();
+    let checkpoint_metadata = checkpoint_state.build_metadata();
+    StateBackend::write_checkpoint_metadata(checkpoint_metadata)
+        .await
+        .unwrap();
 
     info!("Smoke test checkpoint completed");
 }

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -158,7 +158,7 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
                     }),
                     time: to_micros(c.time),
                     operator_id: c.operator_id,
-                    subtask_index: c.subtask_idx,
+                    subtask_idx: c.subtask_idx,
                     epoch: c.checkpoint_epoch,
                     event_type: c.event_type as i32,
                 };

--- a/crates/arroyo-state/src/lib.rs
+++ b/crates/arroyo-state/src/lib.rs
@@ -20,7 +20,6 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-pub mod checkpoint_state;
 pub mod committing_state;
 mod metrics;
 pub mod parquet;

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -9,6 +9,7 @@ use crate::arrow::tumbling_aggregating_window::TumblingAggregateWindowConstructo
 use crate::arrow::watermark_generator::WatermarkGeneratorConstructor;
 use crate::arrow::window_fn::WindowFunctionConstructor;
 use crate::arrow::{KeyExecutionConstructor, ProjectionConstructor, ValueExecutionConstructor};
+use crate::job_controller::WorkerContext;
 use crate::network_manager::{NetworkManager, Quad, Senders};
 use arroyo_connectors::connectors;
 use arroyo_datastream::logical::{
@@ -26,7 +27,6 @@ use arroyo_rpc::grpc::{
     api,
     rpc::{CheckpointMetadata, TaskAssignment},
 };
-use arroyo_rpc::worker_types::WorkerContext;
 use arroyo_rpc::{ControlMessage, ControlResp};
 use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::{JobId, MachineId, TaskInfo, WorkerId, range_for_server};
@@ -371,7 +371,7 @@ pub struct StreamConfig {
 pub struct RunningEngine {
     program: Program,
     assignments: HashMap<(u32, usize), TaskAssignment>,
-    worker_context: WorkerContext,
+    worker_id: WorkerId,
 }
 
 impl RunningEngine {
@@ -385,7 +385,7 @@ impl RunningEngine {
                     .get(&(w.id(), w.subtask_idx()))
                     .unwrap()
                     .worker_id
-                    == self.worker_context.worker_id.0
+                    == self.worker_id.0
             })
             .map(|idx| graph.node_weight(idx).unwrap().as_queue().tx.clone())
             .collect()
@@ -401,7 +401,7 @@ impl RunningEngine {
                     .get(&(w.id(), w.subtask_idx()))
                     .unwrap()
                     .worker_id
-                    == self.worker_context.worker_id.0
+                    == self.worker_id.0
             })
             .map(|idx| graph.node_weight(idx).unwrap().as_queue().tx.clone())
             .collect()
@@ -419,7 +419,7 @@ impl RunningEngine {
                     .get(&(w.id(), w.subtask_idx()))
                     .unwrap()
                     .worker_id
-                    == self.worker_context.worker_id.0
+                    == self.worker_id.0
             })
             .for_each(|idx| {
                 let w = graph.node_weight(idx).unwrap();
@@ -512,7 +512,7 @@ impl Engine {
 
         let node_indexes: Vec<_> = self.program.graph.read().unwrap().node_indices().collect();
 
-        let _worker_id = self.worker_context.worker_id;
+        let worker_id = self.worker_context.worker_id;
 
         let mut senders = Senders::new();
 
@@ -547,7 +547,7 @@ impl Engine {
         RunningEngine {
             program: self.program,
             assignments: self.assignments,
-            worker_context: self.worker_context,
+            worker_id,
         }
     }
 

--- a/crates/arroyo-worker/src/job_controller/checkpoint_state.rs
+++ b/crates/arroyo-worker/src/job_controller/checkpoint_state.rs
@@ -215,7 +215,7 @@ impl CheckpointState {
     }
 
     pub fn checkpoint_event(&mut self, c: TaskCheckpointEventReq) -> anyhow::Result<()> {
-        debug!(message = "Checkpoint event", checkpoint_id = self.checkpoint_id, event_type = ?c.event_type(), subtask_index = c.subtask_index, operator_id = ?c.operator_id);
+        debug!(message = "Checkpoint event", checkpoint_id = self.checkpoint_id, event_type = ?c.event_type(), subtask_idx = c.subtask_idx, operator_id = ?c.operator_id);
 
         if grpc::rpc::TaskCheckpointEventType::FinishedCommit == c.event_type() {
             bail!(
@@ -236,9 +236,9 @@ impl CheckpointState {
                 tasks: HashMap::new(),
             })
             .tasks
-            .entry(c.subtask_index)
+            .entry(c.subtask_idx)
             .or_insert_with(|| api::TaskCheckpointDetail {
-                subtask_index: c.subtask_index,
+                subtask_index: c.subtask_idx,
                 start_time: c.time,
                 finish_time: None,
                 bytes: None,

--- a/crates/arroyo-worker/src/job_controller/checkpoint_state.rs
+++ b/crates/arroyo-worker/src/job_controller/checkpoint_state.rs
@@ -1,31 +1,21 @@
-use crate::{
-    BackingStore, StateBackend,
-    committing_state::CommittingState,
-    tables::{
-        ErasedTable, expiring_time_key_map::ExpiringTimeKeyTable,
-        global_keyed_map::GlobalKeyedTable,
-    },
-};
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail};
 use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::grpc::{
-    self,
-    api::{self, OperatorCheckpointDetail},
-    rpc,
-    rpc::{
-        CheckpointMetadata, OperatorCheckpointMetadata, OperatorMetadata,
-        SubtaskCheckpointMetadata, TableCheckpointMetadata, TableConfig, TableEnum,
-        TableSubtaskCheckpointMetadata, TaskCheckpointCompletedReq, TaskCheckpointEventReq,
-    },
+use arroyo_rpc::grpc::api::OperatorCheckpointDetail;
+use arroyo_rpc::grpc::rpc::{
+    CheckpointMetadata, OperatorCheckpointMetadata, OperatorMetadata, SubtaskCheckpointMetadata,
+    TableCheckpointMetadata, TableConfig, TableEnum, TableSubtaskCheckpointMetadata,
+    TaskCheckpointCompletedReq, TaskCheckpointEventReq,
 };
-use arroyo_rpc::{TaskEventSpans, get_event_spans, log_trace_event};
+use arroyo_rpc::grpc::{api, rpc};
+use arroyo_rpc::{TaskEventSpans, get_event_spans, grpc, log_trace_event};
+use arroyo_state::committing_state::CommittingState;
+use arroyo_state::tables::ErasedTable;
+use arroyo_state::tables::expiring_time_key_map::ExpiringTimeKeyTable;
+use arroyo_state::tables::global_keyed_map::GlobalKeyedTable;
 use arroyo_types::{from_micros, to_micros};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
-use std::{
-    collections::{HashMap, HashSet},
-    time::SystemTime,
-};
+use std::time::{Duration, SystemTime};
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone)]
@@ -225,7 +215,7 @@ impl CheckpointState {
     }
 
     pub fn checkpoint_event(&mut self, c: TaskCheckpointEventReq) -> anyhow::Result<()> {
-        debug!(message = "Checkpoint event", checkpoint_id = self.checkpoint_id, event_type = ?c.event_type(), subtask_idx = c.subtask_idx, operator_id = ?c.operator_id);
+        debug!(message = "Checkpoint event", checkpoint_id = self.checkpoint_id, event_type = ?c.event_type(), subtask_index = c.subtask_index, operator_id = ?c.operator_id);
 
         if grpc::rpc::TaskCheckpointEventType::FinishedCommit == c.event_type() {
             bail!(
@@ -246,9 +236,9 @@ impl CheckpointState {
                 tasks: HashMap::new(),
             })
             .tasks
-            .entry(c.subtask_idx)
+            .entry(c.subtask_index)
             .or_insert_with(|| api::TaskCheckpointDetail {
-                subtask_index: c.subtask_idx,
+                subtask_index: c.subtask_index,
                 start_time: c.time,
                 finish_time: None,
                 bytes: None,
@@ -278,7 +268,10 @@ impl CheckpointState {
         Ok(())
     }
 
-    pub async fn checkpoint_finished(&mut self, c: TaskCheckpointCompletedReq) -> Result<()> {
+    pub fn checkpoint_finished(
+        &mut self,
+        c: TaskCheckpointCompletedReq,
+    ) -> anyhow::Result<Option<OperatorCheckpointMetadata>> {
         // TODO: UI management
         let metadata = c
             .metadata
@@ -395,7 +388,7 @@ impl CheckpointState {
             }
 
             operator_detail.started_metadata_write = Some(to_micros(SystemTime::now()));
-            StateBackend::write_operator_checkpoint_metadata(OperatorCheckpointMetadata {
+            let metadata = OperatorCheckpointMetadata {
                 start_time: to_micros(operator_state.start_time.unwrap()),
                 finish_time: to_micros(operator_state.finish_time.unwrap()),
                 table_checkpoint_metadata,
@@ -408,13 +401,12 @@ impl CheckpointState {
                     max_watermark,
                     parallelism: operator_state.subtasks_checkpointed as u64,
                 }),
-            })
-            .await
-            .expect("Should be able to write operator checkpoint metadata");
+            };
 
             operator_detail.finish_time = Some(to_micros(SystemTime::now()));
+            return Ok(Some(metadata));
         }
-        Ok(())
+        Ok(None)
     }
 
     pub fn done(&self) -> bool {
@@ -429,7 +421,7 @@ impl CheckpointState {
         )
     }
 
-    pub async fn write_metadata(&mut self) -> Result<()> {
+    pub fn build_metadata(&mut self) -> CheckpointMetadata {
         let finish_time = SystemTime::now();
 
         for (op, details) in &self.operator_details {
@@ -471,7 +463,7 @@ impl CheckpointState {
             Default::default(),
         );
 
-        StateBackend::write_checkpoint_metadata(CheckpointMetadata {
+        CheckpointMetadata {
             job_id: self.job_id.to_string(),
             epoch: self.epoch,
             min_epoch: self.min_epoch,
@@ -482,8 +474,6 @@ impl CheckpointState {
                 .keys()
                 .map(|key| key.to_string())
                 .collect(),
-        })
-        .await?;
-        Ok(())
+        }
     }
 }

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -1,0 +1,509 @@
+use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use anyhow::bail;
+use arroyo_rpc::checkpoints::CheckpointMetadataStore;
+use arroyo_rpc::grpc::rpc::{
+    CommitReq, GetWorkerPhaseReq, JobControllerInitReq, JobFailure, JobStatus, JobStopMode,
+    StopExecutionReq, StopMode, TaskAssignment, WorkerPhase,
+};
+use arroyo_state::{BackingStore, StateBackend};
+use arroyo_types::WorkerId;
+use futures::future::try_join_all;
+
+use crate::job_controller::model::{
+    CheckpointingOrCommittingState, JobState, RunningJobModel, TaskState, TaskStatus, WorkerState,
+    WorkerStatus,
+};
+use crate::job_controller::{
+    JobControllerStatus, RunningMessage, TaskFailedEvent, WorkerContext, connect_to_worker,
+};
+use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::log_event;
+use arroyo_server_common::shutdown::ShutdownGuard;
+use tokio::time::interval;
+use tokio::{sync::mpsc::Receiver, task::JoinHandle};
+use tonic::Request;
+use tracing::{error, info};
+
+const CHECKPOINT_ROWS_TO_KEEP: u32 = 10;
+
+pub struct WorkerJobController {
+    worker_context: WorkerContext,
+    checkpoint_interval: Duration,
+    status: JobControllerStatus,
+    model: RunningJobModel,
+    cleanup_task: Option<JoinHandle<anyhow::Result<u32>>>,
+    rx: Receiver<RunningMessage>,
+    stopping: bool,
+    final_checkpoint_started: bool,
+}
+
+impl std::fmt::Debug for WorkerJobController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobController")
+            .field("model", &self.model)
+            .field("cleaning", &self.cleanup_task.is_some())
+            .finish()
+    }
+}
+
+pub enum ControllerProgress {
+    Continue,
+    Finishing,
+    Finished,
+    Stopped,
+    TaskFailed(TaskFailedEvent),
+}
+
+impl WorkerJobController {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn init(
+        worker_context: WorkerContext,
+        program: Arc<LogicalProgram>,
+        tasks: &[TaskAssignment],
+        epoch: u32,
+        min_epoch: u32,
+        rx: Receiver<RunningMessage>,
+        job_status: Arc<Mutex<JobStatus>>,
+        checkpoint_interval: Duration,
+    ) -> anyhow::Result<Self> {
+        let mut worker_connects = HashMap::new();
+        let mut workers = HashMap::new();
+
+        for t in tasks {
+            workers
+                .entry(WorkerId(t.worker_id))
+                .or_insert_with(|| t.worker_rpc.clone());
+        }
+
+        let futures = workers.into_iter().map(|(id, addr)| async move {
+            let connect = connect_to_worker(id, addr).await?;
+            anyhow::Ok((id, connect))
+        });
+
+        let mut workers = HashMap::new();
+
+        for (id, connect) in try_join_all(futures).await? {
+            worker_connects.insert(id, connect.clone());
+            workers.insert(
+                id,
+                WorkerStatus {
+                    id,
+                    connect,
+                    last_heartbeat: Instant::now(),
+                    state: WorkerState::Running,
+                },
+            );
+        }
+
+        let tasks = program
+            .graph
+            .node_weights()
+            .flat_map(|node| {
+                (0..node.parallelism).map(|idx| {
+                    (
+                        (node.node_id, idx as u32),
+                        TaskStatus {
+                            state: TaskState::Running,
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        let status = JobControllerStatus { job_status };
+        status.transition(rpc::JobState::JobRunning)?;
+
+        Ok(Self {
+            checkpoint_interval,
+            model: RunningJobModel {
+                job_id: worker_context.job_id.0.clone(),
+                state: JobState::Running,
+                checkpoint_state: None,
+                epoch,
+                min_epoch,
+                last_checkpoint: Instant::now(),
+                workers,
+                tasks,
+                operator_parallelism: program.tasks_per_node(),
+                program,
+                metric_update_task: None,
+                last_updated_metrics: Instant::now(),
+                checkpoint_spans: vec![],
+            },
+            status,
+            worker_context,
+            cleanup_task: None,
+            rx,
+            stopping: false,
+            final_checkpoint_started: false,
+        })
+    }
+
+    pub fn start(self, shutdown: &ShutdownGuard) {
+        shutdown.spawn_task("job_controller", async move { self.start_inner().await });
+    }
+
+    pub async fn start_inner(mut self) -> anyhow::Result<()> {
+        // initialize workers
+        let futures = self.model.workers.iter_mut().map(|(id, status)| {
+            let id = *id;
+            let mut connect = status.connect.clone();
+            async move {
+                loop {
+                    let phase = connect.get_worker_phase(Request::new(GetWorkerPhaseReq {} )).await?
+                        .into_inner();
+                    match phase.phase() {
+                        WorkerPhase::Idle | WorkerPhase::Initializing => {
+                            // continue
+                        }
+                        WorkerPhase::Running => {
+                            bail!("worker {:?} unexpectedly entered Running phase before being initialized by the job controller", id);
+                        }
+                        WorkerPhase::Failed => {
+                            bail!("worker {:?} was in Failed state during startup with error: {:?}", id, phase.error_message);
+                        }
+                        WorkerPhase::WaitingOnLeader => {
+                            break;
+                        }
+                    }
+
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+
+                connect.job_controller_init(JobControllerInitReq {}).await?;
+
+                anyhow::Result::Ok(())
+            }
+        });
+
+        try_join_all(futures).await?;
+
+        let mut interval = interval(Duration::from_millis(200));
+        loop {
+            tokio::select! {
+                msg = self.rx.recv() => {
+                    match msg {
+                        Some(RunningMessage::Stop { stop_mode }) => {
+                            self.handle_stop(stop_mode).await?;
+                        }
+                        Some(running) => {
+                            self.model.handle_message(running, &self.status).await?;
+                        }
+                        None => {
+                            return Ok(())
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    match self.progress().await {
+                        Ok(ControllerProgress::Continue) => {
+                            // do nothing
+                        },
+                        Ok(ControllerProgress::Finishing) => {
+                            self.status.transition(rpc::JobState::JobFinishing)?;
+                        },
+                        Ok(ControllerProgress::Finished) => {
+                            self.status.transition(rpc::JobState::JobFinished)?;
+                        }
+                        Ok(ControllerProgress::Stopped) => {
+                            self.status.transition(rpc::JobState::JobStopped)?;
+                            return Ok(());
+                        }
+                        Ok(ControllerProgress::TaskFailed(event)) => {
+                            log_event!("task_error", {
+                                "service": "controller",
+                                "job_id": *self.worker_context.job_id,
+                                "operator_id": event.operator_id,
+                                "subtask_index": event.subtask_idx,
+                                "error": event.reason,
+                                "domain": event.error_domain.as_str(),
+                            });
+
+                            self.status.to_failing(event.into())?;
+                        }
+                        Err(err) => {
+                            error!(message = "error while running", error = format!("{:?}", err), job_id = *self.worker_context.job_id);
+                            log_event!("running_error", {
+                                "service": "controller",
+                                "job_id": *self.worker_context.job_id,
+                                "error": format!("{:?}", err),
+                            });
+
+                            self.status.to_failing(JobFailure {
+                                operator_id: None,
+                                task_id: None,
+                                subtask_index: None,
+                                message: err.to_string(),
+                                error_domain: rpc::ErrorDomain::Internal.into(),
+                                retry_hint: rpc::RetryHint::WithBackoff.into(),
+                            })?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn handle_message(&mut self, msg: RunningMessage) -> anyhow::Result<()> {
+        self.model.handle_message(msg, &self.status).await
+    }
+
+    async fn handle_stop(&mut self, stop_mode: JobStopMode) -> anyhow::Result<()> {
+        info!(
+            message = "handling stop request",
+            job_id = *self.worker_context.job_id,
+            stop_mode = ?stop_mode,
+            already_stopping = self.stopping,
+        );
+
+        if self.stopping {
+            if stop_mode == JobStopMode::JobStopImmediate {
+                self.stop_job(StopMode::Immediate).await?;
+            }
+            return Ok(());
+        }
+
+        self.stopping = true;
+        self.status.transition(rpc::JobState::JobStopping)?;
+
+        match stop_mode {
+            JobStopMode::JobStopCheckpoint => {
+                if self.checkpoint(true).await? {
+                    self.final_checkpoint_started = true;
+                }
+            }
+            JobStopMode::JobStopGraceful => {
+                self.stop_job(StopMode::Graceful).await?;
+            }
+            JobStopMode::JobStopImmediate => {
+                self.stop_job(StopMode::Immediate).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn progress(&mut self) -> anyhow::Result<ControllerProgress> {
+        // have any of our workers failed?
+        if self.model.worker_timedout() {
+            bail!("worker failed");
+        }
+
+        // have any tasks failed?
+        if let Some(event) = self.model.task_failed() {
+            return Ok(ControllerProgress::TaskFailed(event));
+        }
+
+        // if we're stopping and all tasks have finished, we're done
+        if self.stopping && self.model.all_tasks_finished() {
+            return Ok(ControllerProgress::Stopped);
+        }
+
+        // have any of our tasks finished?
+        if !self.stopping && self.model.any_finished_sources() {
+            return Ok(ControllerProgress::Finishing);
+        }
+
+        if !self.stopping && self.model.all_tasks_finished() {
+            return Ok(ControllerProgress::Finished);
+        }
+
+        // check on cleanup
+        if self.cleanup_task.is_some() && self.cleanup_task.as_ref().unwrap().is_finished() {
+            let task = self.cleanup_task.take().unwrap();
+
+            match task.await {
+                Ok(Ok(min_epoch)) => {
+                    info!(
+                        message = "setting new min epoch",
+                        min_epoch,
+                        job_id = *self.worker_context.job_id
+                    );
+                    self.model.min_epoch = min_epoch;
+                }
+                Ok(Err(e)) => {
+                    error!(
+                        message = "cleanup failed",
+                        job_id = *self.worker_context.job_id,
+                        error = format!("{:?}", e)
+                    );
+
+                    // wait a bit before trying again
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(e) => {
+                    error!(
+                        message = "cleanup panicked",
+                        job_id = *self.worker_context.job_id,
+                        error = format!("{:?}", e)
+                    );
+
+                    // wait a bit before trying again
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+
+        if !self.stopping
+            && let Some(new_epoch) = self.model.cleanup_needed()
+            && self.cleanup_task.is_none()
+            && self.model.checkpoint_state.is_none()
+        {
+            self.cleanup_task = Some(self.start_cleanup(new_epoch));
+        }
+
+        if self.stopping && !self.final_checkpoint_started && self.model.checkpoint_state.is_none()
+        {
+            info!(
+                message = "retrying deferred final checkpoint",
+                job_id = *self.worker_context.job_id
+            );
+            self.model.start_checkpoint(&self.status, true).await?;
+            self.final_checkpoint_started = true;
+        }
+
+        // check on checkpointing
+        if self.model.checkpoint_state.is_some() {
+            self.model.finish_checkpoint_if_done(&self.status).await?;
+        } else if !self.stopping
+            && self.model.last_checkpoint.elapsed() > self.checkpoint_interval
+            && self.cleanup_task.is_none()
+        {
+            // or do we need to start checkpointing?
+            self.checkpoint(false).await?;
+        }
+
+        Ok(ControllerProgress::Continue)
+    }
+
+    pub async fn stop_job(&mut self, stop_mode: StopMode) -> anyhow::Result<()> {
+        for c in self.model.workers.values_mut() {
+            c.connect
+                .stop_execution(StopExecutionReq {
+                    stop_mode: stop_mode as i32,
+                })
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn checkpoint(&mut self, then_stop: bool) -> anyhow::Result<bool> {
+        if self.model.checkpoint_state.is_none() {
+            self.model.start_checkpoint(&self.status, then_stop).await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub fn finished(&self) -> bool {
+        self.model.all_tasks_finished()
+    }
+
+    pub async fn checkpoint_finished(&mut self) -> anyhow::Result<bool> {
+        if self.model.checkpoint_state.is_some() {
+            self.model.finish_checkpoint_if_done(&self.status).await?;
+        }
+        Ok(self.model.checkpoint_state.is_none())
+    }
+
+    pub async fn send_commit_messages(&mut self) -> anyhow::Result<()> {
+        let Some(CheckpointingOrCommittingState::Committing(committing)) =
+            &self.model.checkpoint_state
+        else {
+            bail!("should be committing")
+        };
+        for worker in self.model.workers.values_mut() {
+            worker
+                .connect
+                .commit(CommitReq {
+                    epoch: self.model.epoch,
+                    committing_data: committing.committing_data(),
+                })
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn wait_for_finish(
+        &mut self,
+        rx: &mut Receiver<RunningMessage>,
+    ) -> anyhow::Result<()> {
+        loop {
+            if self.model.all_tasks_finished() {
+                return Ok(());
+            }
+
+            match rx
+                .recv()
+                .await
+                .ok_or_else(|| anyhow::anyhow!("channel closed while receiving"))?
+            {
+                RunningMessage::Stop { stop_mode } => {
+                    if stop_mode == JobStopMode::JobStopImmediate {
+                        info!(
+                            message = "stopping job immediately",
+                            job_id = *self.worker_context.job_id
+                        );
+                        self.stop_job(StopMode::Immediate).await?;
+                    }
+                }
+                msg => {
+                    self.model.handle_message(msg, &self.status).await?;
+                }
+            }
+        }
+    }
+
+    pub fn operator_parallelism(&self, node_id: u32) -> Option<usize> {
+        self.model.operator_parallelism.get(&node_id).cloned()
+    }
+
+    fn start_cleanup(&mut self, new_min: u32) -> JoinHandle<anyhow::Result<u32>> {
+        let min_epoch = self.model.min_epoch.max(1);
+        let job_id = self.worker_context.job_id.clone();
+        let store = self.status.clone();
+
+        info!(
+            message = "Starting cleaning",
+            job_id = *job_id,
+            min_epoch,
+            new_min
+        );
+        let start = Instant::now();
+        let cur_epoch = self.model.epoch;
+
+        tokio::spawn(async move {
+            let checkpoint = StateBackend::load_checkpoint_metadata(&job_id, cur_epoch).await?;
+
+            store.mark_compacting(&job_id, min_epoch, new_min).await?;
+
+            StateBackend::cleanup_checkpoint(checkpoint, min_epoch, new_min).await?;
+
+            store.mark_checkpoints_compacted(&job_id, new_min).await?;
+
+            if let Some(epoch_to_filter_before) = min_epoch.checked_sub(CHECKPOINT_ROWS_TO_KEEP) {
+                store
+                    .drop_old_checkpoint_rows(&job_id, epoch_to_filter_before)
+                    .await?;
+            }
+
+            info!(
+                message = "Finished cleaning",
+                job_id = *job_id,
+                min_epoch,
+                new_min,
+                duration = start.elapsed().as_secs_f32()
+            );
+
+            Ok(new_min)
+        })
+    }
+}

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -1,0 +1,266 @@
+use anyhow::{anyhow, bail};
+use arroyo_rpc::checkpoints::{
+    CheckpointMetadataStore, CreateCheckpointReq, FinishCheckpointReq, UpdateCheckpointReq,
+};
+use arroyo_rpc::config::config;
+use arroyo_rpc::errors::{ErrorDomain, RetryHint};
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
+use arroyo_rpc::grpc::rpc::{
+    JobFailure, JobStatus, SubtaskCheckpointMetadata, TaskCheckpointEventType,
+};
+use arroyo_rpc::grpc_channel_builder;
+use arroyo_types::WorkerId;
+use arroyo_types::to_micros;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+use tonic::transport::Channel;
+use tracing::{error, info};
+
+// Re-export shared types from arroyo-rpc
+pub use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent, WorkerContext};
+
+pub const CHECKPOINTS_TO_KEEP: u32 = 4;
+pub const COMPACT_EVERY: u32 = 2;
+
+pub mod checkpoint_state;
+pub mod controller;
+pub mod model;
+
+#[derive(Debug, Clone)]
+pub struct WorkerRegistration {
+    #[allow(dead_code)]
+    pub context: WorkerContext,
+    pub rpc_address: String,
+    pub data_address: String,
+    pub slots: u64,
+    pub resources_slots: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkerInitResult {
+    #[allow(dead_code)]
+    pub context: WorkerContext,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub time: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+pub enum JobControllerEvent {
+    TaskStarted {
+        time: SystemTime,
+        operator_idx: u32,
+        subtask_index: u64,
+    },
+    TaskFinished {
+        time: SystemTime,
+        operator_idx: u32,
+        subtask_index: u64,
+    },
+    TaskFailed {
+        time: SystemTime,
+        operator_id: String,
+        subtask_index: u64,
+        message: String,
+        details: String,
+        error_domain: ErrorDomain,
+        retry_hint: RetryHint,
+    },
+    CheckpointEvent {
+        time: SystemTime,
+        operator_id: String,
+        subtask_index: u32,
+        epoch: u32,
+        event_type: TaskCheckpointEventType,
+    },
+    CheckpointCompleted {
+        time: SystemTime,
+        operator_id: String,
+        epoch: u32,
+        metadata: SubtaskCheckpointMetadata,
+        needs_commit: bool,
+    },
+    NonfatalError {
+        time: SystemTime,
+        operator_id: String,
+        subtask_index: u64,
+        message: String,
+        details: String,
+        error_domain: ErrorDomain,
+        retry_hint: RetryHint,
+    },
+}
+
+pub(crate) async fn connect_to_worker(
+    id: WorkerId,
+    addr: String,
+) -> anyhow::Result<WorkerGrpcClient<Channel>> {
+    info!(
+        message = "connecting to worker from job leader",
+        worker_id =? id,
+        addr,
+    );
+
+    for i in 0..3 {
+        match grpc_channel_builder(
+            "controller",
+            addr.clone(),
+            &config().worker.tls,
+            &config().worker.tls,
+        )
+        .await?
+        .timeout(Duration::from_secs(15))
+        .connect()
+        .await
+        {
+            Ok(channel) => return Ok(WorkerGrpcClient::new(channel)),
+            Err(e) => {
+                error!(
+                    message = "Failed to connect to worker",
+                    worker_id =? id,
+                    error = format!("{:?}", e),
+                    addr,
+                    retry = i
+                );
+                tokio::time::sleep(Duration::from_millis((i + 1) * 100)).await;
+            }
+        }
+    }
+    bail!("failed to connect to worker {:?} at {}", id, addr)
+}
+
+#[derive(Clone)]
+pub struct JobControllerStatus {
+    pub job_status: Arc<Mutex<JobStatus>>,
+}
+
+impl JobControllerStatus {
+    pub fn transition(&self, next: rpc::JobState) -> anyhow::Result<()> {
+        let mut status = self.job_status.lock().unwrap();
+        let cur = rpc::JobState::try_from(status.job_state)?;
+        match (cur, next) {
+            (rpc::JobState::JobUnknown, _) | (_, rpc::JobState::JobUnknown) => {
+                bail!("invalid job status transition involving JOB_UNKNOWN");
+            }
+            (rpc::JobState::JobInitializing, rpc::JobState::JobRunning)
+            | (rpc::JobState::JobInitializing, rpc::JobState::JobStopping)
+            | (rpc::JobState::JobInitializing, rpc::JobState::JobFailing)
+            | (rpc::JobState::JobRunning, rpc::JobState::JobStopping)
+            | (rpc::JobState::JobRunning, rpc::JobState::JobFinishing)
+            | (rpc::JobState::JobRunning, rpc::JobState::JobFailing)
+            | (rpc::JobState::JobStopping, rpc::JobState::JobStopped)
+            | (rpc::JobState::JobStopping, rpc::JobState::JobFailing)
+            | (rpc::JobState::JobFinishing, rpc::JobState::JobFinished)
+            | (rpc::JobState::JobFinishing, rpc::JobState::JobFailing)
+            | (rpc::JobState::JobFailing, rpc::JobState::JobFailed) => {
+                status.job_state = next.into();
+                status.transitioned_at = to_micros(SystemTime::now());
+            }
+            (cur, next) if cur == next => {
+                // no-op
+            }
+            _ => {
+                bail!("invalid job status transition from {:?} to {:?}", cur, next);
+            }
+        }
+
+        status.updated_at = to_micros(SystemTime::now());
+
+        Ok(())
+    }
+
+    pub fn to_failing(&self, failure: JobFailure) -> anyhow::Result<()> {
+        {
+            let mut status = self.job_status.lock().unwrap();
+            status.job_failure = Some(failure);
+        }
+        self.transition(rpc::JobState::JobFailing)
+    }
+}
+
+fn checkpoint_size_bytes(operator_details: &Value) -> u64 {
+    operator_details
+        .as_object()
+        .into_iter()
+        .flat_map(|operators| operators.values())
+        .filter_map(|operator| operator.get("tasks"))
+        .filter_map(Value::as_object)
+        .flat_map(|tasks| tasks.values())
+        .filter_map(|task| task.get("bytes"))
+        .filter_map(Value::as_u64)
+        .sum()
+}
+
+fn update_last_checkpoint(
+    job_status: &Arc<Mutex<JobStatus>>,
+    f: impl FnOnce(&mut rpc::CheckpointStatus),
+) -> anyhow::Result<()> {
+    let mut status = job_status
+        .lock()
+        .map_err(|e| anyhow!("job status mutex poisoned: {e}"))?;
+
+    status.updated_at = to_micros(SystemTime::now());
+
+    let checkpoint = status
+        .last_checkpoint
+        .as_mut()
+        .ok_or_else(|| anyhow!("job status missing last checkpoint"))?;
+
+    f(checkpoint);
+    Ok(())
+}
+
+#[async_trait]
+impl CheckpointMetadataStore for JobControllerStatus {
+    async fn create_checkpoint(&self, req: CreateCheckpointReq) -> anyhow::Result<()> {
+        let mut status = self
+            .job_status
+            .lock()
+            .map_err(|e| anyhow!("job status mutex poisoned: {e}"))?;
+        status.last_checkpoint = Some(rpc::CheckpointStatus {
+            epoch: req.epoch,
+            started_at: to_micros(req.start_time),
+            finished_at: None,
+            size_bytes: 0,
+        });
+        Ok(())
+    }
+
+    async fn update_checkpoint(&self, req: UpdateCheckpointReq) -> anyhow::Result<()> {
+        let size_bytes = checkpoint_size_bytes(&req.operator_details);
+        update_last_checkpoint(&self.job_status, |checkpoint| {
+            checkpoint.size_bytes = size_bytes;
+            checkpoint.finished_at = req.finish_time.map(to_micros);
+        })
+    }
+
+    async fn finish_checkpoint(&self, req: FinishCheckpointReq) -> anyhow::Result<()> {
+        update_last_checkpoint(&self.job_status, |checkpoint| {
+            checkpoint.finished_at = Some(to_micros(req.finish_time));
+        })
+    }
+
+    async fn mark_compacting(
+        &self,
+        _job_id: &str,
+        _min_epoch: u32,
+        _new_min: u32,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn mark_checkpoints_compacted(&self, _job_id: &str, _epoch: u32) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn drop_old_checkpoint_rows(&self, _job_id: &str, _epoch: u32) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn notify_checkpoint_complete(&self) {
+        // no-op
+    }
+}

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -106,7 +106,12 @@ impl RunningJobModel {
         checkpoint_id: &str,
         store: &dyn CheckpointMetadataStore,
     ) -> anyhow::Result<()> {
-        info!("finishing committing");
+        info!(
+            message = "Finishing committing",
+            epoch = self.epoch,
+            job_id = *self.job_id,
+        );
+
         store
             .finish_checkpoint(FinishCheckpointReq {
                 checkpoint_id: checkpoint_id.to_string(),
@@ -142,7 +147,7 @@ impl RunningJobModel {
                                 if matches!(c.event_type(), TaskCheckpointEventType::FinishedCommit)
                                 {
                                     committing_state
-                                        .subtask_committed(c.operator_id.clone(), c.subtask_index);
+                                        .subtask_committed(c.operator_id.clone(), c.subtask_idx);
                                     self.compact_state().await?;
                                 } else {
                                     warn!("unexpected checkpoint event type {:?}", c.event_type())

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -1,0 +1,586 @@
+use crate::job_controller::checkpoint_state::CheckpointState;
+use crate::job_controller::{CHECKPOINTS_TO_KEEP, COMPACT_EVERY, RunningMessage, TaskFailedEvent};
+use anyhow::bail;
+use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::api_types::checkpoints::{JobCheckpointEventType, JobCheckpointSpan};
+use arroyo_rpc::checkpoints::{
+    CheckpointMetadataStore, CheckpointStatus, CreateCheckpointReq, FinishCheckpointReq,
+    UpdateCheckpointReq,
+};
+use arroyo_rpc::config::config;
+use arroyo_rpc::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
+use arroyo_rpc::grpc::rpc::{
+    CheckpointReq, CommitReq, JobFinishedReq, LoadCompactedDataReq, TaskCheckpointEventType,
+};
+use arroyo_rpc::public_ids::{IdTypes, generate_id};
+use arroyo_state::committing_state::CommittingState;
+use arroyo_state::parquet::ParquetBackend;
+use arroyo_state::{BackingStore, StateBackend};
+use arroyo_types::{WorkerId, to_micros};
+use futures::future::try_join_all;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
+use tokio::task::JoinHandle;
+use tonic::Request;
+use tonic::transport::Channel;
+use tracing::{debug, error, info, warn};
+
+pub struct RunningJobModel {
+    pub job_id: Arc<String>,
+    pub state: JobState,
+    pub program: Arc<LogicalProgram>,
+    pub checkpoint_state: Option<CheckpointingOrCommittingState>,
+    pub epoch: u32,
+    pub min_epoch: u32,
+    pub last_checkpoint: Instant,
+    pub workers: HashMap<WorkerId, WorkerStatus>,
+    pub tasks: HashMap<(u32, u32), TaskStatus>,
+    pub operator_parallelism: HashMap<u32, usize>,
+    pub metric_update_task: Option<JoinHandle<()>>,
+    pub last_updated_metrics: Instant,
+
+    // checkpoint-wide events
+    pub checkpoint_spans: Vec<JobCheckpointSpan>,
+}
+
+impl std::fmt::Debug for RunningJobModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RunningJobModel")
+            .field("job_id", &self.job_id)
+            .field("state", &self.state)
+            .field("checkpointing", &self.checkpoint_state.is_some())
+            .field("epoch", &self.epoch)
+            .field("min_epoch", &self.min_epoch)
+            .field("last_checkpoint", &self.last_checkpoint)
+            .finish()
+    }
+}
+
+impl RunningJobModel {
+    async fn update_db(&self, store: &dyn CheckpointMetadataStore) -> anyhow::Result<()> {
+        if let Some(CheckpointingOrCommittingState::Checkpointing(checkpoint_state)) =
+            &self.checkpoint_state
+        {
+            store
+                .update_checkpoint(UpdateCheckpointReq {
+                    checkpoint_id: checkpoint_state.checkpoint_id().to_string(),
+                    operator_details: serde_json::to_value(&checkpoint_state.operator_details)
+                        .unwrap(),
+                    finish_time: None,
+                    status: CheckpointStatus::InProgress,
+                    event_spans: serde_json::to_value(&self.checkpoint_spans).unwrap(),
+                })
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn update_checkpoint_in_db(
+        &self,
+        checkpoint_state: &CheckpointState,
+        store: &dyn CheckpointMetadataStore,
+        status: CheckpointStatus,
+    ) -> anyhow::Result<()> {
+        let finish_time = if status == CheckpointStatus::Ready {
+            Some(SystemTime::now())
+        } else {
+            None
+        };
+        store
+            .update_checkpoint(UpdateCheckpointReq {
+                checkpoint_id: checkpoint_state.checkpoint_id().to_string(),
+                operator_details: serde_json::to_value(&checkpoint_state.operator_details).unwrap(),
+                finish_time,
+                status,
+                event_spans: serde_json::to_value(&self.checkpoint_spans).unwrap(),
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn finish_committing(
+        &self,
+        checkpoint_id: &str,
+        store: &dyn CheckpointMetadataStore,
+    ) -> anyhow::Result<()> {
+        info!("finishing committing");
+        store
+            .finish_checkpoint(FinishCheckpointReq {
+                checkpoint_id: checkpoint_id.to_string(),
+                finish_time: SystemTime::now(),
+                event_spans: serde_json::to_value(&self.checkpoint_spans).unwrap(),
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn handle_message(
+        &mut self,
+        msg: RunningMessage,
+        store: &dyn CheckpointMetadataStore,
+    ) -> anyhow::Result<()> {
+        match msg {
+            RunningMessage::TaskCheckpointEvent(c) => {
+                if let Some(checkpoint_state) = &mut self.checkpoint_state {
+                    if c.epoch != self.epoch {
+                        warn!(
+                            message = "Received checkpoint event for wrong epoch",
+                            epoch = c.epoch,
+                            expected = self.epoch,
+                            job_id = *self.job_id,
+                        );
+                    } else {
+                        match checkpoint_state {
+                            CheckpointingOrCommittingState::Checkpointing(checkpoint_state) => {
+                                checkpoint_state.checkpoint_event(c)?;
+                            }
+                            CheckpointingOrCommittingState::Committing(committing_state) => {
+                                if matches!(c.event_type(), TaskCheckpointEventType::FinishedCommit)
+                                {
+                                    committing_state
+                                        .subtask_committed(c.operator_id.clone(), c.subtask_index);
+                                    self.compact_state().await?;
+                                } else {
+                                    warn!("unexpected checkpoint event type {:?}", c.event_type())
+                                }
+                            }
+                        };
+                        self.update_db(store).await?;
+                    }
+                } else {
+                    debug!(
+                        message = "Received checkpoint event but not checkpointing",
+                        job_id = *self.job_id,
+                        event = format!("{:?}", c)
+                    )
+                }
+            }
+            RunningMessage::TaskCheckpointFinished(c) => {
+                if let Some(checkpoint_state) = &mut self.checkpoint_state {
+                    if c.epoch != self.epoch {
+                        warn!(
+                            message = "Received checkpoint finished for wrong epoch",
+                            epoch = c.epoch,
+                            expected = self.epoch,
+                            job_id = *self.job_id,
+                        );
+                    } else {
+                        let CheckpointingOrCommittingState::Checkpointing(checkpoint_state) =
+                            checkpoint_state
+                        else {
+                            bail!("Received checkpoint finished but not checkpointing");
+                        };
+                        if let Some(operator_metadata) = checkpoint_state.checkpoint_finished(c)? {
+                            StateBackend::write_operator_checkpoint_metadata(operator_metadata)
+                                .await?;
+                        }
+
+                        if checkpoint_state.done()
+                            && let Some(e) = self
+                                .checkpoint_spans
+                                .iter_mut()
+                                .find(|e| e.event == JobCheckpointEventType::CheckpointingOperators)
+                        {
+                            e.finish()
+                        }
+
+                        self.update_db(store).await?;
+                    }
+                } else {
+                    warn!(
+                        message = "Received checkpoint finished but not checkpointing",
+                        job_id = *self.job_id
+                    )
+                }
+            }
+            RunningMessage::TaskFinished {
+                worker_id: _,
+                time: _,
+                task_id,
+                subtask_idx,
+            } => {
+                let key = (task_id, subtask_idx);
+                if let Some(status) = self.tasks.get_mut(&key) {
+                    status.state = TaskState::Finished;
+                } else {
+                    warn!(
+                        message = "Received task finished for unknown task",
+                        job_id = *self.job_id,
+                        task_id = key.0,
+                        subtask_idx
+                    );
+                }
+            }
+            RunningMessage::TaskFailed(event) => {
+                let key = (event.task_id, event.subtask_idx);
+                if let Some(status) = self.tasks.get_mut(&key) {
+                    status.state = TaskState::Failed(event);
+                } else {
+                    warn!(
+                        message = "Received task failed message for unknown task",
+                        job_id = *self.job_id,
+                        task_id = key.0,
+                        subtask_idx = key.1,
+                        reason = event.reason,
+                    );
+                }
+            }
+            RunningMessage::WorkerHeartbeat { worker_id, time } => {
+                if let Some(worker) = self.workers.get_mut(&worker_id) {
+                    worker.last_heartbeat = time;
+                } else {
+                    warn!(
+                        message = "Received heartbeat for unknown worker",
+                        job_id = *self.job_id,
+                        worker_id = worker_id.0
+                    );
+                }
+            }
+            RunningMessage::WorkerFinished { worker_id } => {
+                if let Some(worker) = self.workers.get_mut(&worker_id) {
+                    worker.state = WorkerState::Stopped;
+                } else {
+                    warn!(
+                        message = "Received finish message for unknown worker",
+                        job_id = *self.job_id,
+                        worker_id = worker_id.0
+                    );
+                }
+            }
+            RunningMessage::Stop { .. } => {
+                // should have been already handled by the job controller
+            }
+        }
+
+        if self.state == JobState::Running
+            && self.all_tasks_finished()
+            && self.checkpoint_state.is_none()
+        {
+            for w in &mut self.workers.values_mut() {
+                if let Err(e) = w.connect.job_finished(JobFinishedReq {}).await {
+                    warn!(
+                        message = "Failed to connect to worker to send job finish",
+                        job_id = *self.job_id,
+                        worker_id = w.id.0,
+                        error = format!("{:?}", e),
+                    )
+                }
+            }
+            self.state = JobState::Stopped;
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_checkpoint(
+        &mut self,
+        store: &dyn CheckpointMetadataStore,
+        then_stop: bool,
+    ) -> anyhow::Result<()> {
+        self.epoch += 1;
+
+        info!(
+            message = "Starting checkpointing",
+            job_id = *self.job_id,
+            epoch = self.epoch,
+            then_stop
+        );
+
+        self.checkpoint_spans.clear();
+        self.start_or_get_span(JobCheckpointEventType::Checkpointing);
+        self.start_or_get_span(JobCheckpointEventType::CheckpointingOperators);
+
+        let checkpoints = self.workers.values_mut().map(|worker| {
+            worker.connect.checkpoint(Request::new(CheckpointReq {
+                epoch: self.epoch,
+                timestamp: to_micros(SystemTime::now()),
+                min_epoch: self.min_epoch,
+                then_stop,
+                is_commit: false,
+            }))
+        });
+
+        try_join_all(checkpoints).await?;
+
+        let checkpoint_id = generate_id(IdTypes::Checkpoint);
+
+        store
+            .create_checkpoint(CreateCheckpointReq {
+                checkpoint_id: checkpoint_id.clone(),
+                epoch: self.epoch,
+                min_epoch: self.min_epoch,
+                start_time: SystemTime::now(),
+            })
+            .await?;
+
+        let state = CheckpointState::new(
+            self.job_id.clone(),
+            checkpoint_id,
+            self.epoch,
+            self.min_epoch,
+            self.program.clone(),
+        );
+
+        self.checkpoint_state = Some(CheckpointingOrCommittingState::Checkpointing(state));
+
+        Ok(())
+    }
+
+    async fn compact_state(&mut self) -> anyhow::Result<()> {
+        if !config().pipeline.compaction.enabled {
+            debug!("Compaction is disabled, skipping compaction");
+            return Ok(());
+        }
+
+        self.start_or_get_span(JobCheckpointEventType::Compacting);
+        info!(
+            message = "Compacting state",
+            job_id = *self.job_id,
+            epoch = self.epoch,
+        );
+
+        let mut worker_clients: Vec<WorkerGrpcClient<Channel>> =
+            self.workers.values().map(|w| w.connect.clone()).collect();
+        for node in self.program.graph.node_weights() {
+            for (op, _) in node.operator_chain.iter() {
+                let compacted_tables = ParquetBackend::compact_operator(
+                    // compact the operator's state and notify the workers to load the new files
+                    self.job_id.clone(),
+                    &op.operator_id,
+                    self.epoch,
+                )
+                .await?;
+
+                if compacted_tables.is_empty() {
+                    continue;
+                }
+
+                // TODO: these should be put on separate tokio tasks.
+                for worker_client in &mut worker_clients {
+                    worker_client
+                        .load_compacted_data(LoadCompactedDataReq {
+                            operator_id: op.operator_id.clone(),
+                            compacted_metadata: compacted_tables.clone(),
+                        })
+                        .await?;
+                }
+            }
+        }
+        self.start_or_get_span(JobCheckpointEventType::Compacting)
+            .finish();
+
+        info!(
+            message = "Finished compaction",
+            job_id = *self.job_id,
+            epoch = self.epoch,
+        );
+        Ok(())
+    }
+
+    pub async fn finish_checkpoint_if_done(
+        &mut self,
+        store: &dyn CheckpointMetadataStore,
+    ) -> anyhow::Result<()> {
+        if self.checkpoint_state.as_ref().unwrap().done() {
+            let state = self.checkpoint_state.take().unwrap();
+            match state {
+                CheckpointingOrCommittingState::Checkpointing(mut checkpointing) => {
+                    let metadata_span =
+                        self.start_or_get_span(JobCheckpointEventType::WritingMetadata);
+                    let checkpoint_metadata = checkpointing.build_metadata();
+                    StateBackend::write_checkpoint_metadata(checkpoint_metadata).await?;
+                    metadata_span.finish();
+
+                    let committing_state = checkpointing.committing_state();
+                    let duration = checkpointing
+                        .start_time()
+                        .elapsed()
+                        .unwrap_or(Duration::ZERO)
+                        .as_secs_f32();
+                    // shortcut if committing is unnecessary
+                    if committing_state.done() {
+                        self.start_or_get_span(JobCheckpointEventType::Checkpointing)
+                            .finish();
+                        self.update_checkpoint_in_db(
+                            &checkpointing,
+                            store,
+                            CheckpointStatus::Ready,
+                        )
+                        .await?;
+                        self.last_checkpoint = Instant::now();
+                        self.checkpoint_state = None;
+                        self.compact_state().await?;
+
+                        info!(
+                            message = "Finished checkpointing",
+                            job_id = *self.job_id,
+                            epoch = self.epoch,
+                            duration
+                        );
+                        store.notify_checkpoint_complete();
+                    } else {
+                        self.update_checkpoint_in_db(
+                            &checkpointing,
+                            store,
+                            CheckpointStatus::Committing,
+                        )
+                        .await?;
+
+                        let committing_data = committing_state.committing_data();
+                        self.checkpoint_state =
+                            Some(CheckpointingOrCommittingState::Committing(committing_state));
+                        info!(
+                            message = "Committing checkpoint",
+                            job_id = *self.job_id,
+                            epoch = self.epoch,
+                        );
+
+                        self.start_or_get_span(JobCheckpointEventType::Committing);
+
+                        for worker in self.workers.values_mut() {
+                            worker
+                                .connect
+                                .commit(Request::new(CommitReq {
+                                    epoch: self.epoch,
+                                    committing_data: committing_data.clone(),
+                                }))
+                                .await?;
+                        }
+                    }
+                }
+                CheckpointingOrCommittingState::Committing(committing) => {
+                    self.start_or_get_span(JobCheckpointEventType::Committing)
+                        .finish();
+                    self.start_or_get_span(JobCheckpointEventType::Checkpointing)
+                        .finish();
+                    self.finish_committing(committing.checkpoint_id(), store)
+                        .await?;
+                    self.last_checkpoint = Instant::now();
+                    self.checkpoint_state = None;
+                    info!(
+                        message = "Finished committing checkpointing",
+                        job_id = *self.job_id,
+                        epoch = self.epoch,
+                    );
+                    store.notify_checkpoint_complete();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn cleanup_needed(&self) -> Option<u32> {
+        if self.epoch - self.min_epoch > CHECKPOINTS_TO_KEEP
+            && self.epoch.is_multiple_of(COMPACT_EVERY)
+        {
+            Some(self.epoch - CHECKPOINTS_TO_KEEP)
+        } else {
+            None
+        }
+    }
+
+    pub fn worker_timedout(&self) -> bool {
+        for (worker, status) in &self.workers {
+            if status.heartbeat_timeout() {
+                error!(
+                    message = "worker failed to heartbeat",
+                    job_id = *self.job_id,
+                    worker_id = worker.0
+                );
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn task_failed(&self) -> Option<TaskFailedEvent> {
+        for status in self.tasks.values() {
+            if let TaskState::Failed(reason) = &status.state {
+                return Some(reason.clone());
+            }
+        }
+
+        None
+    }
+
+    pub fn any_finished_sources(&self) -> bool {
+        let source_tasks = self.program.sources();
+
+        self.tasks.iter().any(|((operator, _), t)| {
+            source_tasks.contains(operator) && t.state == TaskState::Finished
+        })
+    }
+
+    pub fn all_tasks_finished(&self) -> bool {
+        self.tasks
+            .iter()
+            .all(|(_, t)| t.state == TaskState::Finished)
+    }
+
+    pub fn start_or_get_span(&mut self, event: JobCheckpointEventType) -> &mut JobCheckpointSpan {
+        if let Some(idx) = self.checkpoint_spans.iter().position(|e| e.event == event) {
+            return &mut self.checkpoint_spans[idx];
+        }
+
+        self.checkpoint_spans.push(JobCheckpointSpan::now(event));
+        self.checkpoint_spans.last_mut().unwrap()
+    }
+}
+
+pub enum CheckpointingOrCommittingState {
+    Checkpointing(CheckpointState),
+    Committing(CommittingState),
+}
+
+impl CheckpointingOrCommittingState {
+    pub fn done(&self) -> bool {
+        match self {
+            CheckpointingOrCommittingState::Checkpointing(checkpointing) => checkpointing.done(),
+            CheckpointingOrCommittingState::Committing(committing) => committing.done(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorkerState {
+    Running,
+    Stopped,
+}
+
+#[allow(unused)]
+pub struct WorkerStatus {
+    pub id: WorkerId,
+    pub connect: WorkerGrpcClient<Channel>,
+    pub last_heartbeat: Instant,
+    pub state: WorkerState,
+}
+
+impl WorkerStatus {
+    fn heartbeat_timeout(&self) -> bool {
+        self.last_heartbeat.elapsed() > *config().pipeline.worker_heartbeat_timeout
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TaskState {
+    Running,
+    Finished,
+    Failed(TaskFailedEvent),
+}
+
+#[derive(Debug)]
+pub struct TaskStatus {
+    pub state: TaskState,
+}
+
+// Stores a model of the current state of a running job to use in the state machine
+#[derive(Debug, PartialEq, Eq)]
+pub enum JobState {
+    Running,
+    Stopped,
+}

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -427,7 +427,7 @@ impl WorkerState {
                                     worker_context: Some(self.worker_context.as_proto()),
                                     time: to_micros(c.time),
                                     operator_id: c.operator_id,
-                                    subtask_index: c.subtask_idx,
+                                    subtask_idx: c.subtask_idx,
                                     epoch: c.checkpoint_epoch,
                                     event_type: c.event_type as i32,
                                 }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -2,29 +2,35 @@
 #![allow(clippy::type_complexity)]
 
 use crate::engine::{Engine, Program, SubtaskNode};
+use crate::job_controller::{RunningMessage, TaskFailedEvent, WorkerContext};
 use crate::network_manager::NetworkManager;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 use arroyo_rpc::grpc::rpc::worker_grpc_server::{WorkerGrpc, WorkerGrpcServer};
 use arroyo_rpc::grpc::rpc::{
     CheckpointReq, CheckpointResp, CommitReq, CommitResp, GetWorkerPhaseReq, GetWorkerPhaseResp,
-    HeartbeatReq, JobFinishedReq, JobFinishedResp, LoadCompactedDataReq, LoadCompactedDataRes,
-    MetricFamily, MetricsReq, MetricsResp, NonfatalErrorReq, RegisterWorkerReq, StartExecutionReq,
-    StartExecutionResp, StopExecutionReq, StopExecutionResp, TaskCheckpointCompletedReq,
-    TaskCheckpointEventReq, TaskFailedReq, TaskFinishedReq, TaskStartedReq,
+    HeartbeatReq, HeartbeatResp, JobControllerInitReq, JobControllerInitResp, JobFinishedReq,
+    JobFinishedResp, JobMetricsReq, JobMetricsResp, JobStatus, JobStatusReq, JobStatusResp,
+    JobStopMode, LoadCompactedDataReq, LoadCompactedDataRes, MetricFamily, MetricsReq, MetricsResp,
+    NonfatalErrorReq, RegisterWorkerReq, StartExecutionReq, StartExecutionResp, StopExecutionReq,
+    StopExecutionResp, StopJobReq, StopJobResp, TaskAssignment, TaskCheckpointCompletedReq,
+    TaskCheckpointCompletedResp, TaskCheckpointEventReq, TaskCheckpointEventResp, TaskFailedReq,
+    TaskFailedResp, TaskFinishedReq, TaskFinishedResp, TaskStartedReq, WorkerErrorRes,
     WorkerInitializationCompleteReq, WorkerPhase, WorkerResources,
 };
 use arroyo_types::{
-    CheckpointBarrier, JOB_ID_ENV, JobId, MachineId, RUN_ID_ENV, WorkerId, from_millis, to_micros,
+    CheckpointBarrier, JOB_ID_ENV, JobId, MachineId, RUN_ID_ENV, WorkerId, from_micros,
+    from_millis, to_micros,
 };
 use rand::random;
 
-use arroyo_rpc::worker_types::WorkerContext;
+use async_trait::async_trait;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
+use std::mem;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::net::TcpListener;
 use tokio::select;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
@@ -32,13 +38,20 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info, warn};
 
+use crate::job_controller::controller::WorkerJobController;
 use crate::utils::to_d2;
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_planner::physical::new_registry;
 use arroyo_rpc::config::config;
-use arroyo_rpc::controller_client;
 use arroyo_rpc::grpc::rpc;
-use arroyo_rpc::{CompactionResult, ControlMessage, ControlResp, local_address, retry};
+use arroyo_rpc::grpc::rpc::job_controller_grpc_server::{
+    JobControllerGrpc, JobControllerGrpcServer,
+};
+use arroyo_rpc::grpc::rpc::job_status_grpc_server::{JobStatusGrpc, JobStatusGrpcServer};
+use arroyo_rpc::{
+    CompactionResult, ControlMessage, ControlResp, controller_client, job_controller_client,
+    local_address, retry,
+};
 use arroyo_server_common::shutdown::{CancellationToken, ShutdownGuard};
 use arroyo_server_common::wrap_start;
 pub use ordered_float::OrderedFloat;
@@ -49,6 +62,7 @@ use uuid::Uuid;
 pub mod arrow;
 
 pub mod engine;
+pub mod job_controller;
 mod network_manager;
 pub mod utils;
 
@@ -96,11 +110,32 @@ enum WorkerExecutionPhase {
     Initializing {
         started_at: SystemTime,
     },
+    WaitingOnLeader {
+        control_rx: Receiver<ControlResp>,
+        job_controller_addr: String,
+        engine_state: EngineState,
+    },
     Running(EngineState),
     Failed {
         started_at: SystemTime,
         error_message: String,
     },
+}
+
+impl Display for WorkerExecutionPhase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                WorkerExecutionPhase::Idle => "idle",
+                WorkerExecutionPhase::Initializing { .. } => "initializing",
+                WorkerExecutionPhase::WaitingOnLeader { .. } => "waiting_on_leader",
+                WorkerExecutionPhase::Running(_) => "running",
+                WorkerExecutionPhase::Failed { .. } => "failed",
+            }
+        )
+    }
 }
 
 struct EngineState {
@@ -150,301 +185,32 @@ impl LocalRunner {
     }
 }
 
-pub struct WorkerServer {
+#[derive(Clone)]
+pub struct WorkerState {
     worker_context: WorkerContext,
     phase: Arc<Mutex<WorkerExecutionPhase>>,
     network: Arc<Mutex<Option<NetworkManager>>>,
-    shutdown_guard: ShutdownGuard,
+    // used to send messages to the local job controller -- only on the leader node
+    job_controller_tx: Arc<OnceLock<Sender<RunningMessage>>>,
+    job_status: Arc<Mutex<JobStatus>>,
 }
 
-impl WorkerServer {
-    pub fn from_config(shutdown_guard: ShutdownGuard) -> Result<Self> {
-        let id = WorkerId(config().worker.id.unwrap_or_else(random));
-        let machine_id = MachineId(Arc::new(
-            config()
-                .worker
-                .machine_id
-                .clone()
-                .unwrap_or_else(|| Uuid::new_v4().to_string()),
-        ));
-        let job_id = JobId(Arc::new(
-            std::env::var(JOB_ID_ENV).unwrap_or_else(|_| panic!("{JOB_ID_ENV} is not set")),
-        ));
-
-        let run_id = std::env::var(RUN_ID_ENV)
-            .unwrap_or_else(|_| panic!("{RUN_ID_ENV} is not set"))
-            .parse()
-            .unwrap_or_else(|_| panic!("{RUN_ID_ENV} must be an unsigned int"));
-
-        Ok(WorkerServer::new(
-            machine_id,
-            id,
-            job_id,
-            run_id,
-            shutdown_guard,
-        ))
-    }
-
-    pub fn new(
-        machine_id: MachineId,
-        worker_id: WorkerId,
-        job_id: JobId,
-        run_id: u64,
-        shutdown_guard: ShutdownGuard,
-    ) -> Self {
-        Self {
-            worker_context: WorkerContext {
-                machine_id,
-                worker_id,
-                job_id,
-                run_id,
-            },
-            phase: Arc::new(Mutex::new(WorkerExecutionPhase::Idle)),
-            network: Arc::new(Mutex::new(None)),
-            shutdown_guard,
-        }
-    }
-
-    pub fn id(&self) -> WorkerId {
-        self.worker_context.worker_id
-    }
-
-    pub fn job_id(&self) -> &str {
-        &self.worker_context.job_id
-    }
-
-    pub async fn start_async(self) -> Result<()> {
-        let config = config();
-        let listener = TcpListener::bind(SocketAddr::new(
-            config.worker.bind_address,
-            config.worker.rpc_port,
-        ))
-        .await?;
-        let local_addr = listener.local_addr()?;
-
-        let mut client = retry!(
-            controller_client("worker", &config.worker.tls).await,
-            2,
-            Duration::from_millis(100),
-            Duration::from_secs(2),
-            |e| warn!("Failed to connect to controller: {e}, retrying...")
-        )?;
-
-        let mut network = NetworkManager::new(0).await?;
-        let data_port = network
-            .open_listener(self.shutdown_guard.child("network-manager"))
-            .await;
-
-        *self.network.lock().unwrap() = Some(network);
-
-        let hostname = local_address(config.worker.bind_address);
-        let rpc_address = format!("http://{}:{}", hostname, local_addr.port());
-
-        let data_address = format!("{hostname}:{data_port}");
+impl WorkerState {
+    async fn initialize(self, shutdown_guard: ShutdownGuard, req: StartExecutionReq) {
         let worker_context = self.worker_context.clone();
 
-        self.shutdown_guard
-            .child("grpc")
-            .into_spawn_task(wrap_start(
-                "worker",
-                local_addr,
-                if let Some(tls) = config.get_tls_config(&config.worker.tls) {
-                    info!(
-                        "Started worker-rpc with TLS for {:?} on {}",
-                        self.worker_context.worker_id, local_addr
-                    );
-                    arroyo_server_common::grpc_server_with_tls(tls)
-                        .await?
-                        .add_service(WorkerGrpcServer::new(self))
-                        .serve_with_incoming(TcpListenerStream::new(listener))
-                } else {
-                    info!(
-                        "Started worker-rpc for {:?} on {}",
-                        self.worker_context.worker_id, local_addr
-                    );
-                    arroyo_server_common::grpc_server()
-                        .add_service(WorkerGrpcServer::new(self))
-                        .serve_with_incoming(TcpListenerStream::new(listener))
-                },
-            ));
+        let phase = self.phase.clone();
 
-        // ideally, get a signal when the server is started...
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        let error_message = if let Err(e) = self.initialize_inner(shutdown_guard, req).await {
+            let mut phase_guard = phase.lock().unwrap();
+            *phase_guard = WorkerExecutionPhase::Failed {
+                started_at: SystemTime::now(),
+                error_message: e.to_string(),
+            };
 
-        client
-            .register_worker(Request::new(RegisterWorkerReq {
-                worker_context: Some(worker_context.as_proto()),
-                time: to_micros(SystemTime::now()),
-                rpc_address,
-                data_address,
-                resources: Some(WorkerResources {
-                    slots: std::thread::available_parallelism().unwrap().get() as u64,
-                }),
-                slots: config.worker.task_slots as u64,
-            }))
-            .await
-            .unwrap();
-
-        Ok(())
-    }
-
-    #[tokio::main]
-    pub async fn start(self) -> Result<()> {
-        self.start_async().await
-    }
-
-    async fn run_control_loop(
-        cancel_token: CancellationToken,
-        control_rx: Receiver<ControlResp>,
-        worker_context: WorkerContext,
-    ) -> Result<()> {
-        let mut controller = controller_client("worker", &config().worker.tls)
-            .await
-            .expect("Unable to connect to controller");
-
-        let mut tick = tokio::time::interval(Duration::from_secs(5));
-        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        let mut control_rx = control_rx;
-
-        loop {
-            select! {
-                msg = control_rx.recv() => {
-                    let err = match msg {
-                        Some(ControlResp::CheckpointEvent(c)) => {
-                            controller.task_checkpoint_event(Request::new(
-                                TaskCheckpointEventReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: to_micros(c.time),
-                                    operator_id: c.operator_id,
-                                    subtask_idx: c.subtask_idx,
-                                    epoch: c.checkpoint_epoch,
-                                    event_type: c.event_type as i32,
-                                }
-                            )).await.err()
-                        }
-                        Some(ControlResp::CheckpointCompleted(c)) => {
-                            controller.task_checkpoint_completed(Request::new(
-                                TaskCheckpointCompletedReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: c.subtask_metadata.finish_time,
-                                    operator_id: c.operator_id,
-                                    epoch: c.checkpoint_epoch,
-                                    needs_commit: false,
-                                    metadata: Some(c.subtask_metadata),
-                                }
-                            )).await.err()
-                        }
-                        Some(ControlResp::TaskFinished { task_id, subtask_idx }) => {
-                            info!(message = "Task finished", task_id, subtask_idx);
-                            controller.task_finished(Request::new(
-                                TaskFinishedReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: to_micros(SystemTime::now()),
-                                    task_id,
-                                    subtask_idx,
-                                }
-                            )).await.err()
-                        }
-                        Some(ControlResp::TaskFailed { task_id, subtask_idx, error }) => {
-                            controller.task_failed(Request::new(
-                                TaskFailedReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: to_micros(SystemTime::now()),
-                                    error: Some(rpc::TaskError {
-                                        task_id,
-                                        subtask_idx,
-                                        error: error.message,
-                                        error_domain: rpc::ErrorDomain::from(error.domain) as i32,
-                                        retry_hint: rpc::RetryHint::from(error.retry_hint) as i32,
-                                        operator_id: error.operator_id.unwrap_or_default(),
-                                        details: error.details.unwrap_or_default(),
-                                    }),
-                                }
-                            )).await.err()
-                        }
-                        Some(ControlResp::Error { task_id, operator_id, subtask_idx, message, details}) => {
-                            controller.nonfatal_error(Request::new(
-                                NonfatalErrorReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: to_micros(SystemTime::now()),
-                                    error: Some(rpc::TaskError {
-                                        task_id,
-                                        operator_id,
-                                        subtask_idx,
-                                        error: message,
-                                        error_domain: rpc::ErrorDomain::External as i32,
-                                        retry_hint: rpc::RetryHint::NoRetry as i32,
-                                        details,
-                                    }),
-                                }
-                            )).await.err()
-                        }
-                        Some(ControlResp::TaskStarted {task_id, subtask_idx, start_time}) => {
-                            controller.task_started(Request::new(
-                                TaskStartedReq {
-                                    worker_context: Some(worker_context.as_proto()),
-                                    time: to_micros(start_time),
-                                    task_id,
-                                    subtask_idx,
-                                }
-                            )).await.err()
-                        }
-                        None => {
-                            // TODO: remove the control queue from the select at this point
-                            tokio::time::sleep(Duration::from_millis(50)).await;
-                            None
-                        }
-                    };
-                    if let Some(err) = err {
-                        error!("encountered control message failure {}", err);
-                        cancel_token.cancel();
-                    }
-                }
-                _ = tick.tick() => {
-                    let result = controller.heartbeat(Request::new(HeartbeatReq {
-                        worker_context: Some(worker_context.as_proto()),
-                        time: to_micros(SystemTime::now()),
-                    })).await;
-                    if let Err(err) = result {
-                        error!("heartbeat failed {:?}", err);
-                        break;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    async fn initialize(
-        phase: Arc<Mutex<WorkerExecutionPhase>>,
-        network: Arc<Mutex<Option<NetworkManager>>>,
-        shutdown_guard: ShutdownGuard,
-        worker_context: WorkerContext,
-        req: StartExecutionReq,
-    ) {
-        let error_message = match Self::initialize_inner(
-            Arc::clone(&network),
-            shutdown_guard,
-            &worker_context,
-            req,
-        )
-        .await
-        {
-            Ok(engine_state) => {
-                let mut phase_guard = phase.lock().unwrap();
-                *phase_guard = WorkerExecutionPhase::Running(engine_state);
-
-                None
-            }
-            Err(e) => {
-                let mut phase_guard = phase.lock().unwrap();
-                *phase_guard = WorkerExecutionPhase::Failed {
-                    started_at: SystemTime::now(),
-                    error_message: e.to_string(),
-                };
-
-                Some(e.to_string())
-            }
+            Some(e.to_string())
+        } else {
+            None
         };
 
         if let Ok(mut client) = controller_client("worker", &config().worker.tls).await
@@ -464,16 +230,54 @@ impl WorkerServer {
         }
     }
 
-    async fn initialize_inner(
-        network: Arc<Mutex<Option<NetworkManager>>>,
-        shutdown_guard: ShutdownGuard,
-        worker_context: &WorkerContext,
-        req: StartExecutionReq,
-    ) -> Result<EngineState> {
-        let mut registry = new_registry();
+    async fn initialize_job_controller(
+        &self,
+        program: Arc<LogicalProgram>,
+        tasks: &[TaskAssignment],
+        epoch: u32,
+        min_epoch: u32,
+        shutdown: &ShutdownGuard,
+        checkpoint_interval: Duration,
+    ) -> anyhow::Result<()> {
+        // runs only on the leader
 
-        let logical = LogicalProgram::try_from(req.program.expect("Program is None"))
-            .map_err(|e| anyhow::anyhow!("Failed to create LogicalProgram: {}", e))?;
+        let (tx, rx) = channel(128);
+
+        self.job_controller_tx.set(tx).map_err(|_| {
+            anyhow!("tried to initialize job controller but it was already initialized!")
+        })?;
+
+        debug!(
+            "[{:?}] initialized job controller",
+            self.worker_context.worker_id
+        );
+
+        WorkerJobController::init(
+            self.worker_context.clone(),
+            program,
+            tasks,
+            epoch,
+            min_epoch,
+            rx,
+            self.job_status.clone(),
+            checkpoint_interval,
+        )
+        .await?
+        .start(shutdown);
+
+        Ok(())
+    }
+
+    async fn initialize_inner(
+        self,
+        shutdown_guard: ShutdownGuard,
+        req: StartExecutionReq,
+    ) -> Result<()> {
+        let mut registry = new_registry();
+        let logical = Arc::new(
+            LogicalProgram::try_from(req.program.expect("Program is None"))
+                .map_err(|e| Status::internal(format!("Failed to create LogicalProgram: {}", e)))?,
+        );
 
         debug!(
             "Starting execution for graph\n{}",
@@ -503,9 +307,23 @@ impl WorkerServer {
 
         let (control_tx, control_rx) = channel(128);
 
+        if req.is_leader {
+            // TODO: the leader needs to load checkpoint metadata and figure out epochs/min epochs
+            //  itself from object storage
+            self.initialize_job_controller(
+                logical.clone(),
+                &req.tasks,
+                req.start_epoch,
+                req.min_epoch,
+                &shutdown_guard,
+                Duration::from_micros(req.checkpoint_interval_micros),
+            )
+            .await?;
+        }
+
         let engine = {
             let network_manager = {
-                network
+                self.network
                     .lock()
                     .unwrap()
                     .take()
@@ -513,7 +331,7 @@ impl WorkerServer {
             };
 
             let program = Program::from_logical(
-                &worker_context.job_id,
+                &self.worker_context.job_id,
                 &logical.graph,
                 &req.tasks,
                 registry,
@@ -522,17 +340,14 @@ impl WorkerServer {
             )
             .await;
 
-            let engine = Engine::new(program, worker_context.clone(), network_manager, req.tasks);
+            let engine = Engine::new(
+                program,
+                self.worker_context.clone(),
+                network_manager,
+                req.tasks,
+            );
             engine.start().await
         };
-
-        let cancel_token = shutdown_guard.token();
-        let wc = worker_context.clone();
-        shutdown_guard
-            .child("control-thread")
-            .into_spawn_task(
-                async move { Self::run_control_loop(cancel_token, control_rx, wc).await },
-            );
 
         let sources = engine.source_controls();
         let sinks = engine.sink_controls();
@@ -547,36 +362,382 @@ impl WorkerServer {
             shutdown_guard: shutdown_guard.child("engine-state"),
         };
 
-        info!(
-            "[{:?}] Initialization completed successfully",
-            worker_context.worker_id
-        );
-        Ok(engine_state)
+        let mut phase_guard = self.phase.lock().unwrap();
+
+        let job_controller_addr = req
+            .job_controller_addr
+            .clone()
+            .unwrap_or_else(|| config().controller_endpoint());
+
+        if req.wait_for_leader {
+            info!("waiting for leader");
+            *phase_guard = WorkerExecutionPhase::WaitingOnLeader {
+                control_rx,
+                engine_state,
+                job_controller_addr,
+            };
+            drop(phase_guard);
+        } else {
+            info!("Worker moving to running phase");
+            *phase_guard = WorkerExecutionPhase::Running(engine_state);
+            drop(phase_guard);
+
+            let cancel_token = shutdown_guard.token();
+            shutdown_guard
+                .child("control-thread")
+                .into_spawn_task(async move {
+                    self.run_control_loop(cancel_token, control_rx, job_controller_addr, false)
+                        .await
+                });
+        }
+
+        info!("Initialization completed successfully");
+        Ok(())
+    }
+
+    async fn run_control_loop(
+        self,
+        cancel_token: CancellationToken,
+        control_rx: Receiver<ControlResp>,
+        job_controller_addr: String,
+        is_worker_job_controller: bool,
+    ) -> Result<()> {
+        // TODO: We need this just for sending TaskStarted notifications to the actual controller for
+        //  scheduling; it would be nicer if we didn't need to retain it for the entire job lifecycle
+        let mut controller = controller_client("worker", &config().worker.tls).await?;
+        let mut job_controller = job_controller_client(
+            "worker",
+            &config().worker.tls,
+            job_controller_addr,
+            is_worker_job_controller,
+        )
+        .await?;
+
+        let mut tick = tokio::time::interval(Duration::from_secs(5));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut control_rx = control_rx;
+
+        loop {
+            select! {
+                msg = control_rx.recv() => {
+                    let err = match msg {
+                        Some(ControlResp::CheckpointEvent(c)) => {
+                            job_controller.task_checkpoint_event(Request::new(
+                                TaskCheckpointEventReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: to_micros(c.time),
+                                    operator_id: c.operator_id,
+                                    subtask_index: c.subtask_idx,
+                                    epoch: c.checkpoint_epoch,
+                                    event_type: c.event_type as i32,
+                                }
+                            )).await.err()
+                        }
+                        Some(ControlResp::CheckpointCompleted(c)) => {
+                            job_controller.task_checkpoint_completed(Request::new(
+                                TaskCheckpointCompletedReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: c.subtask_metadata.finish_time,
+                                    operator_id: c.operator_id,
+                                    epoch: c.checkpoint_epoch,
+                                    needs_commit: false,
+                                    metadata: Some(c.subtask_metadata),
+                                }
+                            )).await.err()
+                        }
+                        Some(ControlResp::TaskFinished { task_id, subtask_idx }) => {
+                            info!(message = "Task finished", task_id, subtask_idx);
+                            job_controller.task_finished(Request::new(
+                                TaskFinishedReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: to_micros(SystemTime::now()),
+                                    task_id,
+                                    subtask_idx,
+                                }
+                            )).await.err()
+                        }
+                        Some(ControlResp::TaskFailed { task_id, subtask_idx, error }) => {
+                            job_controller.task_failed(Request::new(
+                                TaskFailedReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: to_micros(SystemTime::now()),
+                                    error: Some(rpc::TaskError {
+                                        task_id,
+                                        subtask_idx,
+                                        error: error.message,
+                                        error_domain: rpc::ErrorDomain::from(error.domain) as i32,
+                                        retry_hint: rpc::RetryHint::from(error.retry_hint) as i32,
+                                        operator_id: error.operator_id.unwrap_or_default(),
+                                        details: error.details.unwrap_or_default(),
+                                    }),
+                                }
+                            )).await.err()
+                        }
+                        Some(ControlResp::Error { task_id, operator_id, subtask_idx, message, details}) => {
+                            job_controller.nonfatal_error(Request::new(
+                                NonfatalErrorReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: to_micros(SystemTime::now()),
+                                    error: Some(rpc::TaskError {
+                                        task_id,
+                                        operator_id,
+                                        subtask_idx,
+                                        error: message,
+                                        error_domain: rpc::ErrorDomain::External as i32,
+                                        retry_hint: rpc::RetryHint::NoRetry as i32,
+                                        details,
+                                    }),
+                                }
+                            )).await.err()
+                        }
+                        Some(ControlResp::TaskStarted {task_id, subtask_idx, start_time}) => {
+                            controller.task_started(Request::new(
+                                TaskStartedReq {
+                                    worker_context: Some(self.worker_context.as_proto()),
+                                    time: to_micros(start_time),
+                                    task_id,
+                                    subtask_idx,
+                                }
+                            )).await.err()
+                        }
+                        None => {
+                            // TODO: remove the control queue from the select at this point
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                            None
+                        }
+                    };
+                    if let Some(err) = err {
+                        error!("encountered control message failure {}", err);
+                        cancel_token.cancel();
+                    }
+                }
+                _ = tick.tick() => {
+                    if matches!(*self.phase.lock().unwrap(), WorkerExecutionPhase::Running { .. }) {
+                        let result = job_controller.heartbeat(Request::new(HeartbeatReq {
+                            worker_context: Some(self.worker_context.as_proto()),
+                            time: to_micros(SystemTime::now()),
+                        })).await;
+                        if let Err(err) = result {
+                            error!("heartbeat failed {:?}", err);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct WorkerServer {
+    state: WorkerState,
+    shutdown_guard: ShutdownGuard,
+}
+
+impl WorkerServer {
+    pub fn from_config(shutdown_guard: ShutdownGuard) -> Result<Self> {
+        let worker_id = WorkerId(config().worker.id.unwrap_or_else(random));
+        let job_id =
+            std::env::var(JOB_ID_ENV).unwrap_or_else(|_| panic!("{JOB_ID_ENV} is not set"));
+
+        let machine_id = MachineId(Arc::new(
+            config()
+                .worker
+                .machine_id
+                .clone()
+                .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        ));
+
+        let run_id = std::env::var(RUN_ID_ENV)
+            .unwrap_or_else(|_| panic!("{RUN_ID_ENV} is not set"))
+            .parse()
+            .unwrap_or_else(|_| panic!("{RUN_ID_ENV} must be an unsigned int"));
+
+        Ok(WorkerServer::new(
+            machine_id,
+            worker_id,
+            JobId(job_id.into()),
+            run_id,
+            shutdown_guard,
+        ))
+    }
+
+    pub fn new(
+        machine_id: MachineId,
+        worker_id: WorkerId,
+        job_id: JobId,
+        run_id: u64,
+        shutdown_guard: ShutdownGuard,
+    ) -> Self {
+        Self {
+            state: WorkerState {
+                phase: Arc::new(Mutex::new(WorkerExecutionPhase::Idle)),
+                network: Arc::new(Mutex::new(None)),
+                job_controller_tx: Arc::new(OnceLock::new()),
+                worker_context: WorkerContext {
+                    worker_id,
+                    machine_id,
+                    job_id,
+                    run_id,
+                },
+                job_status: Arc::new(Mutex::new(JobStatus {
+                    job_state: rpc::JobState::JobInitializing.into(),
+                    updated_at: to_micros(SystemTime::now()),
+                    transitioned_at: to_micros(SystemTime::now()),
+                    last_checkpoint: None,
+                    job_failure: None,
+                })),
+            },
+            shutdown_guard,
+        }
+    }
+
+    pub fn id(&self) -> WorkerId {
+        self.state.worker_context.worker_id
+    }
+
+    pub fn job_id(&self) -> &str {
+        &self.state.worker_context.job_id
+    }
+
+    pub async fn start_async(self) -> Result<()> {
+        let config = config();
+        let listener = TcpListener::bind(SocketAddr::new(
+            config.worker.bind_address,
+            config.worker.rpc_port,
+        ))
+        .await?;
+        let local_addr = listener.local_addr()?;
+
+        let mut client = retry!(
+            controller_client("worker", &config.worker.tls).await,
+            2,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+            |e| warn!("Failed to connect to controller: {e}, retrying...")
+        )?;
+
+        let mut network = NetworkManager::new(0).await?;
+        let data_port = network
+            .open_listener(self.shutdown_guard.child("network-manager"))
+            .await;
+
+        *self.state.network.lock().unwrap() = Some(network);
+
+        let context = self.state.worker_context.clone();
+
+        let hostname = local_address(config.worker.bind_address);
+        let rpc_address = format!("http://{}:{}", hostname, local_addr.port());
+
+        let data_address = format!("{hostname}:{data_port}");
+
+        let leader = LeaderServer {
+            state: self.state.clone(),
+        };
+
+        self.shutdown_guard
+            .child("grpc")
+            .into_spawn_task(wrap_start(
+                "worker",
+                local_addr,
+                if let Some(tls) = config.get_tls_config(&config.worker.tls) {
+                    info!("Started worker-rpc with TLS on {}", local_addr);
+                    arroyo_server_common::grpc_server_with_tls(tls)
+                        .await?
+                        .add_service(WorkerGrpcServer::new(self))
+                        .add_service(JobControllerGrpcServer::new(leader.clone()))
+                        .add_service(JobStatusGrpcServer::new(leader))
+                        .serve_with_incoming(TcpListenerStream::new(listener))
+                } else {
+                    info!("Started worker-rpc on {}", local_addr);
+                    arroyo_server_common::grpc_server()
+                        .add_service(WorkerGrpcServer::new(self))
+                        .add_service(JobControllerGrpcServer::new(leader.clone()))
+                        .add_service(JobStatusGrpcServer::new(leader))
+                        .serve_with_incoming(TcpListenerStream::new(listener))
+                },
+            ));
+
+        // ideally, get a signal when the server is started...
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        client
+            .register_worker(Request::new(RegisterWorkerReq {
+                time: to_micros(SystemTime::now()),
+                worker_context: Some(context.as_proto()),
+                rpc_address,
+                data_address,
+                resources: Some(WorkerResources {
+                    slots: std::thread::available_parallelism().unwrap().get() as u64,
+                }),
+                slots: config.worker.task_slots as u64,
+            }))
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::main]
+    pub async fn start(self) -> Result<()> {
+        self.start_async().await
     }
 }
 
 #[tonic::async_trait]
 impl WorkerGrpc for WorkerServer {
+    async fn get_worker_phase(
+        &self,
+        _req: Request<GetWorkerPhaseReq>,
+    ) -> Result<Response<GetWorkerPhaseResp>, Status> {
+        let phase = self.state.phase.lock().unwrap();
+
+        let (phase_enum, phase_started_at, error_message) = match &*phase {
+            WorkerExecutionPhase::Idle => (WorkerPhase::Idle as i32, None, None),
+            WorkerExecutionPhase::Initializing { started_at } => (
+                WorkerPhase::Initializing as i32,
+                Some(to_micros(*started_at)),
+                None,
+            ),
+            WorkerExecutionPhase::Running(_) => (WorkerPhase::Running as i32, None, None),
+            WorkerExecutionPhase::Failed {
+                started_at,
+                error_message,
+            } => (
+                WorkerPhase::Failed as i32,
+                Some(to_micros(*started_at)),
+                Some(error_message.clone()),
+            ),
+            WorkerExecutionPhase::WaitingOnLeader { .. } => {
+                (WorkerPhase::WaitingOnLeader as i32, None, None)
+            }
+        };
+
+        Ok(Response::new(GetWorkerPhaseResp {
+            phase: phase_enum,
+            phase_started_at,
+            error_message,
+        }))
+    }
+
     async fn start_execution(
         &self,
         request: Request<StartExecutionReq>,
     ) -> Result<Response<StartExecutionResp>, Status> {
-        let mut phase = self.phase.lock().unwrap();
+        let mut phase = self.state.phase.lock().unwrap();
 
         match &*phase {
             WorkerExecutionPhase::Idle => {
-                let started_at = SystemTime::now();
-                *phase = WorkerExecutionPhase::Initializing { started_at };
+                *phase = WorkerExecutionPhase::Initializing {
+                    started_at: SystemTime::now(),
+                };
 
                 // Spawn async initialization
-                let phase = Arc::clone(&self.phase);
-                let network = Arc::clone(&self.network);
-                let shutdown_guard = self.shutdown_guard.clone_temporary();
-                let worker_context = self.worker_context.clone();
+                let state = self.state.clone();
                 let req = request.into_inner();
+                let shutdown_guard = self.shutdown_guard.clone_temporary();
 
                 self.shutdown_guard.spawn_temporary(async move {
-                    Self::initialize(phase, network, shutdown_guard, worker_context, req).await;
+                    state.initialize(shutdown_guard, req).await;
                     Ok(())
                 });
 
@@ -584,6 +745,9 @@ impl WorkerGrpc for WorkerServer {
             }
             WorkerExecutionPhase::Initializing { .. } => {
                 Err(Status::unavailable("Worker is initializing"))
+            }
+            WorkerExecutionPhase::WaitingOnLeader { .. } => {
+                Err(Status::failed_precondition("Worker is waiting for leader"))
             }
             WorkerExecutionPhase::Running(_) => {
                 Err(Status::failed_precondition("Worker is already running"))
@@ -601,7 +765,7 @@ impl WorkerGrpc for WorkerServer {
         let req = request.into_inner();
 
         let (sinks, sources) = {
-            let phase = self.phase.lock().unwrap();
+            let phase = self.state.phase.lock().unwrap();
             match &*phase {
                 WorkerExecutionPhase::Running(engine_state) => {
                     (engine_state.sinks.clone(), engine_state.sources.clone())
@@ -644,7 +808,7 @@ impl WorkerGrpc for WorkerServer {
         debug!("received commit request {:?}", req);
 
         let sender_commit_map_pairs = {
-            let phase = self.phase.lock().unwrap();
+            let phase = self.state.phase.lock().unwrap();
             let engine_state = match &*phase {
                 WorkerExecutionPhase::Running(engine_state) => engine_state,
                 _ => {
@@ -690,7 +854,7 @@ impl WorkerGrpc for WorkerServer {
         let req = request.into_inner();
 
         let nodes = {
-            let phase = self.phase.lock().unwrap();
+            let phase = self.state.phase.lock().unwrap();
             let engine_state = match &*phase {
                 WorkerExecutionPhase::Running(engine_state) => engine_state,
                 _ => {
@@ -730,7 +894,7 @@ impl WorkerGrpc for WorkerServer {
         request: Request<StopExecutionReq>,
     ) -> Result<Response<StopExecutionResp>, Status> {
         let sources = {
-            let phase = self.phase.lock().unwrap();
+            let phase = self.state.phase.lock().unwrap();
             let engine_state = match &*phase {
                 WorkerExecutionPhase::Running(engine_state) => engine_state,
                 _ => {
@@ -757,7 +921,7 @@ impl WorkerGrpc for WorkerServer {
         &self,
         _request: Request<JobFinishedReq>,
     ) -> Result<Response<JobFinishedResp>, Status> {
-        let mut phase = self.phase.lock().unwrap();
+        let mut phase = self.state.phase.lock().unwrap();
         if let WorkerExecutionPhase::Running(engine_state) = &*phase {
             engine_state.shutdown_guard.cancel();
         }
@@ -800,34 +964,247 @@ impl WorkerGrpc for WorkerServer {
         Ok(Response::new(MetricsResp { metrics }))
     }
 
-    async fn get_worker_phase(
+    async fn job_controller_init(
         &self,
-        _req: Request<GetWorkerPhaseReq>,
-    ) -> Result<Response<GetWorkerPhaseResp>, Status> {
-        let phase = self.phase.lock().unwrap();
+        _: Request<JobControllerInitReq>,
+    ) -> std::result::Result<Response<JobControllerInitResp>, Status> {
+        let mut phase = self.state.phase.lock().unwrap();
+        let mut tmp_phase = WorkerExecutionPhase::Idle;
+        mem::swap(&mut *phase, &mut tmp_phase);
 
-        let (phase_enum, phase_started_at, error_message) = match &*phase {
-            WorkerExecutionPhase::Idle => (WorkerPhase::Idle as i32, None, None),
-            WorkerExecutionPhase::Initializing { started_at } => (
-                WorkerPhase::Initializing as i32,
-                Some(to_micros(*started_at)),
-                None,
-            ),
-            WorkerExecutionPhase::Running(_) => (WorkerPhase::Running as i32, None, None),
-            WorkerExecutionPhase::Failed {
-                started_at,
-                error_message,
-            } => (
-                WorkerPhase::Failed as i32,
-                Some(to_micros(*started_at)),
-                Some(error_message.clone()),
-            ),
+        let (job_controller_addr, control_rx) = match tmp_phase {
+            WorkerExecutionPhase::Running(e) => {
+                debug!("job_controller_init called on worker but already in running phase");
+                *phase = WorkerExecutionPhase::Running(e);
+                return Ok(Response::new(JobControllerInitResp {}));
+            }
+            WorkerExecutionPhase::WaitingOnLeader {
+                control_rx,
+                engine_state,
+                job_controller_addr,
+            } => {
+                *phase = WorkerExecutionPhase::Running(engine_state);
+                (job_controller_addr, control_rx)
+            }
+            p => {
+                let msg = format!("job_controller_init called on worker in {p} phase");
+                *phase = p;
+                return Err(Status::failed_precondition(msg));
+            }
         };
 
-        Ok(Response::new(GetWorkerPhaseResp {
-            phase: phase_enum,
-            phase_started_at,
-            error_message,
+        info!("Worker moving to running phase");
+        let cancel_token = self.shutdown_guard.token();
+        let state = self.state.clone();
+        self.shutdown_guard
+            .child("control-thread")
+            .into_spawn_task(async move {
+                state
+                    .run_control_loop(cancel_token, control_rx, job_controller_addr, true)
+                    .await
+            });
+
+        Ok(Response::new(JobControllerInitResp {}))
+    }
+}
+
+#[derive(Clone)]
+pub struct LeaderServer {
+    state: WorkerState,
+}
+
+impl LeaderServer {
+    async fn send_job_message(&self, msg: RunningMessage) -> Result<(), Status> {
+        self.state
+            .job_controller_tx
+            .get()
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "[{:?}] tried to handle job message on non-leader node!",
+                    self.state.worker_context.worker_id
+                ))
+            })?
+            .send(msg)
+            .await
+            .map_err(|_| Status::internal("could not process request, internal queue is closed"))
+    }
+}
+
+#[async_trait]
+impl JobControllerGrpc for LeaderServer {
+    async fn task_checkpoint_event(
+        &self,
+        request: Request<TaskCheckpointEventReq>,
+    ) -> Result<Response<TaskCheckpointEventResp>, Status> {
+        let req = request.into_inner();
+
+        debug!(req =? req, "received task checkpoint event");
+
+        self.send_job_message(RunningMessage::TaskCheckpointEvent(req))
+            .await?;
+
+        Ok(Response::new(TaskCheckpointEventResp {}))
+    }
+
+    async fn task_checkpoint_completed(
+        &self,
+        request: Request<TaskCheckpointCompletedReq>,
+    ) -> Result<Response<TaskCheckpointCompletedResp>, Status> {
+        let req = request.into_inner();
+
+        debug!("received task checkpoint completed {:?}", req);
+
+        self.send_job_message(RunningMessage::TaskCheckpointFinished(req))
+            .await?;
+
+        Ok(Response::new(TaskCheckpointCompletedResp {}))
+    }
+
+    async fn task_finished(
+        &self,
+        request: Request<TaskFinishedReq>,
+    ) -> Result<Response<TaskFinishedResp>, Status> {
+        let req = request.into_inner();
+
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
+
+        self.send_job_message(RunningMessage::TaskFinished {
+            worker_id: WorkerId(ctx.worker_id),
+            time: from_micros(req.time),
+            task_id: req.task_id,
+            subtask_idx: req.subtask_idx,
+        })
+        .await?;
+
+        Ok(Response::new(TaskFinishedResp {}))
+    }
+
+    async fn task_failed(
+        &self,
+        request: Request<TaskFailedReq>,
+    ) -> Result<Response<TaskFailedResp>, Status> {
+        let req = request.into_inner();
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("TaskFailedReq missing worker_context"))?;
+        let err = req
+            .error
+            .ok_or_else(|| Status::invalid_argument("TaskFailedReq missing error"))?;
+
+        self.send_job_message(RunningMessage::TaskFailed(TaskFailedEvent {
+            worker_id: WorkerId(ctx.worker_id),
+            task_id: err.task_id,
+            subtask_idx: err.subtask_idx,
+            error_domain: err.error_domain().into(),
+            retry_hint: err.retry_hint().into(),
+            operator_id: err.operator_id,
+            reason: err.error,
+            details: err.details,
         }))
+        .await?;
+
+        Ok(Response::new(TaskFailedResp {}))
+    }
+
+    async fn heartbeat(
+        &self,
+        request: Request<HeartbeatReq>,
+    ) -> Result<Response<HeartbeatResp>, Status> {
+        let req = request.into_inner();
+
+        debug!(
+            "[{:?}] Received heartbeat {:?}",
+            self.state.worker_context.worker_id, req
+        );
+
+        self.send_job_message(RunningMessage::WorkerHeartbeat {
+            worker_id: WorkerId(req.worker_context.as_ref().unwrap().worker_id),
+            time: Instant::now(),
+        })
+        .await?;
+
+        Ok(Response::new(HeartbeatResp {}))
+    }
+
+    async fn nonfatal_error(
+        &self,
+        request: Request<NonfatalErrorReq>,
+    ) -> Result<Response<WorkerErrorRes>, Status> {
+        let req = request.into_inner();
+        let ctx = req
+            .worker_context
+            .ok_or_else(|| Status::invalid_argument("NonfatalErrorReq missing worker_context"))?;
+        let err = req
+            .error
+            .ok_or_else(|| Status::invalid_argument("NonfatalErrorReq missing error"))?;
+
+        error!(
+            job_id = ctx.job_id,
+            operator_id = err.operator_id,
+            message = "non-fatal operator error",
+            error_message = err.error,
+            error_details = err.details
+        );
+
+        Ok(Response::new(WorkerErrorRes {}))
+    }
+
+    async fn job_metrics(
+        &self,
+        _request: Request<JobMetricsReq>,
+    ) -> Result<Response<JobMetricsResp>, Status> {
+        todo!("metric support")
+    }
+}
+
+#[async_trait]
+impl JobStatusGrpc for LeaderServer {
+    async fn get_job_status(
+        &self,
+        request: Request<JobStatusReq>,
+    ) -> std::result::Result<Response<JobStatusResp>, Status> {
+        if self.state.job_controller_tx.get().is_none() {
+            return Err(Status::failed_precondition(
+                "requested job status from non-leader node",
+            ));
+        }
+
+        let job_id = (*self.state.worker_context.job_id.0).clone();
+        let req = request.into_inner();
+        if job_id != req.job_id {
+            return Err(Status::failed_precondition(format!(
+                "requested job status for invalid job {} - expected {}",
+                req.job_id, job_id
+            )));
+        }
+
+        Ok(Response::new(JobStatusResp {
+            job_id,
+            run_id: self.state.worker_context.run_id,
+            job_status: Some((*self.state.job_status.lock().unwrap()).clone()),
+        }))
+    }
+
+    async fn stop_job(
+        &self,
+        request: Request<StopJobReq>,
+    ) -> std::result::Result<Response<StopJobResp>, Status> {
+        let req = request.into_inner();
+        let stop_mode = JobStopMode::try_from(req.stop_mode).map_err(|_| {
+            Status::invalid_argument(format!("invalid stop mode: {}", req.stop_mode))
+        })?;
+
+        info!(
+            message = "received stop job request",
+            worker_id = ?self.state.worker_context.worker_id,
+            stop_mode = ?stop_mode,
+        );
+
+        self.send_job_message(RunningMessage::Stop { stop_mode })
+            .await?;
+
+        Ok(Response::new(StopJobResp {}))
     }
 }


### PR DESCRIPTION
This PR is part one of the work to introduce the job controller, a worker-hosted component that manages all aspects of ongoing job running such that the data plane no longer has a dependency on the control plane.

The implementation was designed such that the existing job controller approach (running in the controller) should continue to work without significant risk from these changes; in other words, the new worker job controller is meant to be purely additive, such that it should be safe to merge these changes while they are still WIP.

There is a lot of functionality that is not yet implemented, including:

* Metrics
* Preview outputs (still go directly to the controller)
* Checkpoint metadata in the UI
* Tracking of last checkpoint for restoration
* Fencing at commit for split-brain

However, the basics should work at this point.