### PR TITLE
Retry transient 409s instead of treating them as user errors

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/mod.rs
@@ -167,6 +167,10 @@ fn map_storage_error(storage_error: StorageError) -> DataflowError {
 fn map_object_store_error(obj_err: &object_store::Error) -> DataflowError {
     use object_store::Error;
     match obj_err {
+        // 409s with "error code: 1018" are spurious upstream errors; let the task recover.
+        Error::AlreadyExists { source, .. } if source.to_string().contains("error code: 1018") => {
+            connector_err!(External, WithBackoff, "{}", obj_err)
+        }
         // User errors: authentication, authorization, bad paths, misconfiguration
         Error::NotFound { .. }
         | Error::InvalidPath { .. }

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -154,6 +154,8 @@ fn should_retry(e: &object_store::Error) -> bool {
             // some operations (like CompleteMultipartUpload)
             !source.to_string().contains("status 404 Not Found")
         }
+        // 409s with "error code: 1018" are spurious upstream errors, not real conflicts.
+        Error::AlreadyExists { source, .. } => source.to_string().contains("error code: 1018"),
         _ => false,
     }
 }


### PR DESCRIPTION
S3-compatible stores returning 409 with body `error code: 1018` should be treated as transient errors. `object_store` maps these to `AlreadyExists`, which is treated as non-retryable, causing permanent pipeline failures on a transient error.

Treat 409s carrying `error code: 1018` as transient in the retry handler and in the filesystem sink's error classification. Other 409s are unchanged, so legitimate conditional-write conflicts still surface as real errors (now and in the future).