### PR TITLE
Validate target worker_id on WorkerGrpc RPCs

### DIFF
--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -8,10 +8,8 @@ use std::{
 use crate::types::public::StopMode as SqlStopMode;
 use anyhow::bail;
 use arroyo_rpc::checkpoints::CheckpointMetadataStore;
-use arroyo_rpc::grpc::rpc::{
-    CommitReq, LabelPair, MetricsReq, StopExecutionReq, StopMode,
-    worker_grpc_client::WorkerGrpcClient,
-};
+use arroyo_rpc::grpc::rpc::{CommitReq, LabelPair, MetricsReq, StopExecutionReq, StopMode};
+use arroyo_rpc::identity::WorkerClient;
 use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::WorkerId;
 use rand::{Rng, rng};
@@ -27,7 +25,6 @@ use arroyo_worker::job_controller::model::{
     WorkerStatus,
 };
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
-use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 pub mod checkpoint_store;
@@ -68,7 +65,7 @@ impl JobController {
         program: Arc<LogicalProgram>,
         epoch: u32,
         min_epoch: u32,
-        worker_connects: HashMap<WorkerId, WorkerGrpcClient<Channel>>,
+        worker_connects: HashMap<WorkerId, WorkerClient>,
         commit_state: Option<CommittingState>,
         metrics: JobMetrics,
     ) -> Self {

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -4,12 +4,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use arroyo_rpc::grpc::rpc::{
-    StartExecutionReq, TaskAssignment, worker_grpc_client::WorkerGrpcClient,
-};
+use arroyo_rpc::grpc::rpc::{StartExecutionReq, TaskAssignment};
+use arroyo_rpc::identity::{WorkerClient, worker_client};
 use arroyo_types::{JobId, MachineId, WorkerId};
 use tokio::{select, sync::Mutex, task::JoinHandle};
-use tonic::{Request, transport::Channel};
+use tonic::Request;
 use tracing::{debug, error, info, warn};
 
 use super::{JobContext, State, Transition, leader_running::LeaderRunning, running::Running};
@@ -97,7 +96,7 @@ fn compute_assignments(
 async fn handle_worker_connect<'a>(
     msg: JobMessage,
     workers: &mut HashMap<WorkerId, WorkerStatus>,
-    worker_connects: Arc<Mutex<HashMap<WorkerId, WorkerGrpcClient<Channel>>>>,
+    worker_connects: Arc<Mutex<HashMap<WorkerId, WorkerClient>>>,
     handles: &mut Vec<JoinHandle<()>>,
     ctx: &mut JobContext<'a>,
 ) -> Result<(), StateError> {
@@ -162,7 +161,7 @@ async fn handle_worker_connect<'a>(
                         Ok(channel) => {
                             {
                                 let mut connects = connects.lock().await;
-                                connects.insert(worker_id, WorkerGrpcClient::new(channel));
+                                connects.insert(worker_id, worker_client(channel, *worker_id));
                             }
                             return;
                         }

--- a/crates/arroyo-rpc/src/identity.rs
+++ b/crates/arroyo-rpc/src/identity.rs
@@ -1,0 +1,141 @@
+//! Identity validation for worker-targeted gRPC requests.
+//!
+//! Every request addressed to a worker carries `x-target-worker-id` in
+//! metadata; the receiving server rejects mismatches with `PermissionDenied`.
+//! This guards against stale channels delivering to the wrong worker when
+//! network endpoints are recycled across worker lifetimes. Worker IDs are
+//! 64-bit random values in production, so they are effectively globally
+//! unique across jobs, runs, and clusters.
+
+use tonic::metadata::{Ascii, MetadataValue};
+use tonic::service::Interceptor;
+use tonic::service::interceptor::InterceptedService;
+use tonic::transport::Channel;
+use tonic::{Request, Status};
+use tracing::warn;
+
+use crate::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
+
+/// Target worker_id header, ASCII decimal.
+pub const WORKER_ID_HEADER: &str = "x-target-worker-id";
+
+/// Worker client with identity interceptor attached.
+pub type WorkerClient = WorkerGrpcClient<InterceptedService<Channel, InjectWorkerId>>;
+
+/// Construct a worker client that injects `target` as `x-target-worker-id`.
+pub fn worker_client(channel: Channel, target: u64) -> WorkerClient {
+    WorkerGrpcClient::with_interceptor(channel, InjectWorkerId::new(target))
+}
+
+/// Client interceptor: injects target worker_id into request metadata.
+#[derive(Clone, Debug)]
+pub struct InjectWorkerId(MetadataValue<Ascii>);
+
+impl InjectWorkerId {
+    pub fn new(target: u64) -> Self {
+        Self(
+            target
+                .to_string()
+                .parse()
+                .expect("u64 decimal is valid ASCII"),
+        )
+    }
+}
+
+impl Interceptor for InjectWorkerId {
+    fn call(&mut self, mut req: Request<()>) -> Result<Request<()>, Status> {
+        // MetadataValue clone is a Bytes refcount bump, not an allocation.
+        req.metadata_mut().insert(WORKER_ID_HEADER, self.0.clone());
+        Ok(req)
+    }
+}
+
+/// Server interceptor: rejects requests whose `x-target-worker-id` header
+/// does not match the server's own worker_id.
+#[derive(Clone, Debug)]
+pub struct VerifyWorkerId(pub u64);
+
+impl Interceptor for VerifyWorkerId {
+    fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
+        let Some(header) = req.metadata().get(WORKER_ID_HEADER) else {
+            return Ok(req);
+        };
+
+        let received: u64 = header
+            .to_str()
+            .map_err(|_| Status::permission_denied("x-target-worker-id mismatch"))?
+            .parse()
+            .map_err(|_| Status::permission_denied("x-target-worker-id mismatch"))?;
+
+        if received != self.0 {
+            warn!(
+                expected = self.0,
+                received, "rejecting request with mismatched target worker_id"
+            );
+            return Err(Status::permission_denied("x-target-worker-id mismatch"));
+        }
+
+        Ok(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Code;
+
+    #[test]
+    fn inject_writes_decimal_metadata() {
+        for id in [0, 42, 1234567890, u64::MAX] {
+            let req = InjectWorkerId::new(id).call(Request::new(())).unwrap();
+            let parsed: u64 = req
+                .metadata()
+                .get(WORKER_ID_HEADER)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(parsed, id);
+        }
+    }
+
+    #[test]
+    fn verify_behavior() {
+        // (expected_own_id, incoming_header, should_pass)
+        // Missing header is allowed; only present-but-mismatched headers are rejected.
+        let cases: &[(u64, Option<&str>, bool)] = &[
+            (0, Some("0"), true),
+            (42, Some("42"), true),
+            (42, None, true),
+            (42, Some("43"), false),
+            (42, Some("not-a-number"), false),
+            (42, Some("-1"), false),
+        ];
+
+        for &(expected, header, should_pass) in cases {
+            let mut req = Request::new(());
+            if let Some(h) = header {
+                req.metadata_mut()
+                    .insert(WORKER_ID_HEADER, h.parse().unwrap());
+            }
+            let result = VerifyWorkerId(expected).call(req);
+            assert_eq!(
+                result.is_ok(),
+                should_pass,
+                "case: expected={expected}, header={header:?}"
+            );
+            if let Err(s) = result {
+                assert_eq!(s.code(), Code::PermissionDenied);
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_through_both_interceptors() {
+        let req = InjectWorkerId::new(1234567890)
+            .call(Request::new(()))
+            .unwrap();
+        VerifyWorkerId(1234567890).call(req).unwrap();
+    }
+}

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -63,6 +63,7 @@ use url::{Host, Url};
 pub mod config;
 pub mod df;
 pub mod errors;
+pub mod identity;
 
 pub mod grpc {
     pub mod rpc {

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -5,18 +5,17 @@ use arroyo_rpc::checkpoints::{
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::{ErrorDomain, RetryHint};
 use arroyo_rpc::grpc::rpc;
-use arroyo_rpc::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
 use arroyo_rpc::grpc::rpc::{
     JobFailure, JobStatus, SubtaskCheckpointMetadata, TaskCheckpointEventType,
 };
 use arroyo_rpc::grpc_channel_builder;
+use arroyo_rpc::identity::{WorkerClient, worker_client};
 use arroyo_types::WorkerId;
 use arroyo_types::to_micros;
 use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
-use tonic::transport::Channel;
 use tracing::{error, info};
 
 // Re-export shared types from arroyo-rpc
@@ -94,10 +93,7 @@ pub enum JobControllerEvent {
     },
 }
 
-pub(crate) async fn connect_to_worker(
-    id: WorkerId,
-    addr: String,
-) -> anyhow::Result<WorkerGrpcClient<Channel>> {
+pub(crate) async fn connect_to_worker(id: WorkerId, addr: String) -> anyhow::Result<WorkerClient> {
     info!(
         message = "connecting to worker from job leader",
         worker_id =? id,
@@ -116,7 +112,7 @@ pub(crate) async fn connect_to_worker(
         .connect()
         .await
         {
-            Ok(channel) => return Ok(WorkerGrpcClient::new(channel)),
+            Ok(channel) => return Ok(worker_client(channel, *id)),
             Err(e) => {
                 error!(
                     message = "Failed to connect to worker",

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -8,10 +8,10 @@ use arroyo_rpc::checkpoints::{
     UpdateCheckpointReq,
 };
 use arroyo_rpc::config::config;
-use arroyo_rpc::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
 use arroyo_rpc::grpc::rpc::{
     CheckpointReq, CommitReq, JobFinishedReq, LoadCompactedDataReq, TaskCheckpointEventType,
 };
+use arroyo_rpc::identity::WorkerClient;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_state::committing_state::CommittingState;
 use arroyo_state::parquet::ParquetBackend;
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::task::JoinHandle;
 use tonic::Request;
-use tonic::transport::Channel;
 use tracing::{debug, error, info, warn};
 
 pub struct RunningJobModel {
@@ -348,7 +347,7 @@ impl RunningJobModel {
             epoch = self.epoch,
         );
 
-        let mut worker_clients: Vec<WorkerGrpcClient<Channel>> =
+        let mut worker_clients: Vec<WorkerClient> =
             self.workers.values().map(|w| w.connect.clone()).collect();
         for node in self.program.graph.node_weights() {
             for (op, _) in node.operator_chain.iter() {
@@ -560,7 +559,7 @@ pub enum WorkerState {
 #[allow(unused)]
 pub struct WorkerStatus {
     pub id: WorkerId,
-    pub connect: WorkerGrpcClient<Channel>,
+    pub connect: WorkerClient,
     pub last_heartbeat: Instant,
     pub state: WorkerState,
 }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -18,6 +18,7 @@ use arroyo_rpc::grpc::rpc::{
     TaskFailedResp, TaskFinishedReq, TaskFinishedResp, TaskStartedReq, WorkerErrorRes,
     WorkerInitializationCompleteReq, WorkerPhase, WorkerResources,
 };
+use arroyo_rpc::identity::VerifyWorkerId;
 use arroyo_types::{
     CheckpointBarrier, JOB_ID_ENV, JobId, MachineId, RUN_ID_ENV, WorkerId, from_micros,
     from_millis, to_micros,
@@ -644,14 +645,20 @@ impl WorkerServer {
                     info!("Started worker-rpc with TLS on {}", local_addr);
                     arroyo_server_common::grpc_server_with_tls(tls)
                         .await?
-                        .add_service(WorkerGrpcServer::new(self))
+                        .add_service(WorkerGrpcServer::with_interceptor(
+                            self,
+                            VerifyWorkerId(*context.worker_id),
+                        ))
                         .add_service(JobControllerGrpcServer::new(leader.clone()))
                         .add_service(JobStatusGrpcServer::new(leader))
                         .serve_with_incoming(TcpListenerStream::new(listener))
                 } else {
                     info!("Started worker-rpc on {}", local_addr);
                     arroyo_server_common::grpc_server()
-                        .add_service(WorkerGrpcServer::new(self))
+                        .add_service(WorkerGrpcServer::with_interceptor(
+                            self,
+                            VerifyWorkerId(*context.worker_id),
+                        ))
                         .add_service(JobControllerGrpcServer::new(leader.clone()))
                         .add_service(JobStatusGrpcServer::new(leader))
                         .serve_with_incoming(TcpListenerStream::new(listener))


### PR DESCRIPTION
#### Changes
- Each worker-addressed gRPC request now carries a target worker identity. Receiving worker rejects mismatches with PERMISSION_DENIED. This prevents stale gRPC channels from delivering control messages to the wrong worker when network endpoints are recycled across worker lifetimes.
- Uses a tonic Interceptor, so coverage is uniform across all WorkerGrpc RPCs and cannot be bypassed by adding new endpoints.
- Client construction goes through a single factory. Type system enforces interceptor attachment wherever clients are stored.

#### Tests
- Unit tests for identity injection, verification, and round-trip behavior.