### PR TITLE
Increase retry counts for scheduler errors to better tolerate transient infrastructure outages

### DIFF
--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -91,7 +91,7 @@ impl State for LeaderRestarting {
                 );
 
                 if let Err(e) = Recovering::cleanup(ctx).await {
-                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
+                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 20));
                 }
 
                 Ok(Transition::next(*self, Scheduling {}))

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -208,7 +208,7 @@ impl State for Recovering {
 
         match Self::cleanup(ctx).await {
             Ok(()) => Ok(Transition::next(*self, Compiling)),
-            Err(e) => Err(ctx.retryable(self, "failed to tear down existing cluster", e, 3)),
+            Err(e) => Err(ctx.retryable(self, "failed to tear down existing cluster", e, 20)),
         }
     }
 }

--- a/crates/arroyo-controller/src/states/restarting.rs
+++ b/crates/arroyo-controller/src/states/restarting.rs
@@ -73,7 +73,7 @@ impl State for Restarting {
             }
             RestartMode::force => {
                 if let Err(e) = Recovering::cleanup(ctx).await {
-                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 10));
+                    return Err(ctx.retryable(self, "failed to tear down existing cluster", e, 20));
                 }
 
                 Ok(Transition::next(*self, Scheduling {}))

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -238,7 +238,7 @@ impl Scheduling {
                         self,
                         "encountered error during scheduling",
                         anyhow::anyhow!("scheduling error: {}", s),
-                        10,
+                        20,
                     ));
                 }
             }


### PR DESCRIPTION
Raise retry counts in the controller state machine for transient scheduler errors so the effective retry window covers a longer duration (~15 minutes) of infrastructure blips instead of 3-4 mins. No behavior change for fatal or non-retryable errors.