### PR TITLE
Filter stale worker addresses during cleanup via scheduler-authoritative data

### DIFF
--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -1,9 +1,7 @@
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::{
-    collections::HashMap,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use crate::types::public::StopMode as SqlStopMode;
 use anyhow::bail;
@@ -65,7 +63,7 @@ impl JobController {
         program: Arc<LogicalProgram>,
         epoch: u32,
         min_epoch: u32,
-        worker_connects: HashMap<WorkerId, WorkerClient>,
+        worker_connects: HashMap<WorkerId, (WorkerClient, String)>,
         commit_state: Option<CommittingState>,
         metrics: JobMetrics,
     ) -> Self {
@@ -86,11 +84,12 @@ impl JobController {
                     ),
                 workers: worker_connects
                     .into_iter()
-                    .map(|(id, connect)| {
+                    .map(|(id, (connect, rpc_address))| {
                         (
                             id,
                             WorkerStatus {
                                 id,
+                                rpc_address,
                                 connect,
                                 last_heartbeat: Instant::now(),
                                 state: WorkerState::Running,
@@ -125,6 +124,14 @@ impl JobController {
 
     pub fn update_config(&mut self, config: JobConfig) {
         self.config = config;
+    }
+
+    pub fn retain_workers_by_address(&mut self, live_addresses: &HashSet<String>) {
+        self.model.retain_workers_by_address(live_addresses);
+    }
+
+    pub fn worker_count(&self) -> usize {
+        self.model.workers.len()
     }
 
     pub async fn handle_message(&mut self, msg: RunningMessage) -> anyhow::Result<()> {
@@ -351,7 +358,7 @@ impl JobController {
 
     pub async fn wait_for_finish(&mut self, rx: &mut Receiver<JobMessage>) -> anyhow::Result<()> {
         loop {
-            if self.model.all_tasks_finished() {
+            if self.model.workers.is_empty() || self.model.all_tasks_finished() {
                 return Ok(());
             }
 

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -42,6 +42,12 @@ lazy_static! {
     .unwrap();
 }
 
+/// A worker's current address as reported by the scheduler's backing infrastructure.
+#[derive(Debug, Clone)]
+pub struct WorkerAddress {
+    pub rpc_address: String,
+}
+
 #[async_trait::async_trait]
 pub trait Scheduler: Send + Sync {
     async fn start_workers(
@@ -63,6 +69,17 @@ pub trait Scheduler: Send + Sync {
         job_id: &str,
         run_id: Option<u64>,
     ) -> anyhow::Result<Vec<WorkerId>>;
+
+    /// Returns authoritative worker addresses from the scheduler's infrastructure.
+    /// Override for schedulers that recycle addresses across worker lifetimes.
+    /// Returns `None` by default; callers fall back to the in-memory channel cache.
+    async fn worker_addresses_for_job(
+        &self,
+        _job_id: &str,
+        _run_id: Option<u64>,
+    ) -> anyhow::Result<Option<Vec<WorkerAddress>>> {
+        Ok(None)
+    }
 }
 
 pub struct ProcessWorker {

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -38,7 +38,9 @@ use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
-use arroyo_rpc::{errors, log_event};
+use std::collections::HashSet;
+
+use arroyo_rpc::{errors, log_event, retry};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use prost::Message;
 
@@ -258,6 +260,7 @@ impl TransitionTo<Scheduling> for Rescaling {
     fn update_status(&self) -> TransitionFn {
         Box::new(|ctx| {
             ctx.status.run_id += 1;
+            clear_worker_handles(ctx);
         })
     }
 }
@@ -279,7 +282,7 @@ impl TransitionTo<Failed> for Failing {}
 
 fn done_transition(ctx: &mut JobContext) {
     ctx.status.finish_time = Some(OffsetDateTime::now_utc());
-    ctx.job_controller = None;
+    clear_worker_handles(ctx);
 }
 
 impl TransitionTo<Stopped> for Stopping {
@@ -353,6 +356,7 @@ impl TransitionTo<Scheduling> for LeaderRestarting {
     fn update_status(&self) -> TransitionFn {
         Box::new(|ctx| {
             ctx.status.run_id += 1;
+            clear_worker_handles(ctx);
         })
     }
 }
@@ -370,6 +374,7 @@ impl TransitionTo<Scheduling> for LeaderRescaling {
     fn update_status(&self) -> TransitionFn {
         Box::new(|ctx| {
             ctx.status.run_id += 1;
+            clear_worker_handles(ctx);
         })
     }
 }
@@ -407,6 +412,7 @@ impl TransitionTo<Scheduling> for Restarting {
     fn update_status(&self) -> TransitionFn {
         Box::new(|ctx| {
             ctx.status.run_id += 1;
+            clear_worker_handles(ctx);
         })
     }
 }
@@ -889,6 +895,49 @@ pub(crate) async fn state_backoff(retries_attempted: usize) {
 
     debug!("waiting {}ms to retry", backoff.as_millis());
     tokio::time::sleep(backoff).await;
+}
+
+fn clear_worker_handles(ctx: &mut JobContext) {
+    ctx.job_controller = None;
+    ctx.leader_manager = None;
+}
+
+/// Filters the in-memory worker map against addresses the scheduler considers
+/// current. Entries whose address is no longer live are removed so that
+/// subsequent gRPC fanouts skip stale targets.
+pub(crate) async fn refresh_workers_from_scheduler(
+    scheduler: &Arc<dyn Scheduler>,
+    job_controller: &mut JobController,
+    job_id: &str,
+    run_id: u64,
+) {
+    let result = retry!(
+        scheduler
+            .worker_addresses_for_job(job_id, Some(run_id))
+            .await,
+        1,
+        Duration::from_millis(200),
+        Duration::from_secs(2),
+        |e| warn!(job_id, error = ?e, "failed to query scheduler for worker addresses, retrying")
+    );
+
+    match result {
+        Ok(Some(addrs)) => {
+            let live: HashSet<String> = addrs.into_iter().map(|a| a.rpc_address).collect();
+            let before = job_controller.worker_count();
+            job_controller.retain_workers_by_address(&live);
+            let removed = before - job_controller.worker_count();
+            if removed > 0 {
+                info!(job_id, removed, "removed stale workers from cleanup set");
+            }
+        }
+        Ok(None) => {
+            // Scheduler does not track addresses; proceed with existing map.
+        }
+        Err(e) => {
+            warn!(job_id, error = ?e, "scheduler address query failed, proceeding with existing worker set");
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+
 use super::{
-    JobContext, State, StateError, Transition, compiling::Compiling, fatal, state_backoff,
+    JobContext, State, StateError, Transition, clear_worker_handles, compiling::Compiling, fatal,
+    refresh_workers_from_scheduler, state_backoff,
 };
 use crate::JobMessage;
 use crate::job_controller::JobController;
 use crate::job_controller::leader_manager::LeaderManager;
+use crate::schedulers::Scheduler;
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode, StopMode};
@@ -23,16 +27,22 @@ pub struct Recovering {
 impl Recovering {
     // tries, with increasing levels of force, to tear down the existing cluster
     pub async fn cleanup_job_controller(
+        scheduler: &Arc<dyn Scheduler>,
         job_controller: &mut JobController,
         job_id: &str,
+        run_id: u64,
         rx: &mut Receiver<JobMessage>,
     ) {
-        // first try to stop it gracefully
         if job_controller.finished() {
             return;
         }
 
-        // stop the job
+        refresh_workers_from_scheduler(scheduler, job_controller, job_id, run_id).await;
+
+        if job_controller.worker_count() == 0 {
+            return;
+        }
+
         info!(message = "stopping job", job_id);
         let start = Instant::now();
         match job_controller.stop_job(StopMode::Immediate).await {
@@ -149,11 +159,21 @@ impl Recovering {
     pub async fn cleanup<'a>(ctx: &mut JobContext<'a>) -> anyhow::Result<()> {
         // attempt to shutdown the job cleanly
         match (ctx.job_controller.as_mut(), ctx.leader_manager.as_mut()) {
-            (Some(jc), None) => Self::cleanup_job_controller(jc, &ctx.config.id, ctx.rx).await,
+            (Some(jc), None) => {
+                Self::cleanup_job_controller(
+                    &ctx.scheduler,
+                    jc,
+                    &ctx.config.id,
+                    ctx.status.run_id,
+                    ctx.rx,
+                )
+                .await
+            }
             (None, Some(lm)) => Self::cleanup_leader(lm, &ctx.config.id).await,
             (Some(_), Some(_)) => unreachable!("both job controller and leader manager are set!"),
             (None, None) => {
-                // somehow we got here before scheduling set the job controller / leader manager
+                // No active handles; workers were already torn down or never started.
+                info!(job_id = *ctx.config.id, "no active handles during cleanup");
             }
         };
 
@@ -165,6 +185,8 @@ impl Recovering {
             Duration::from_secs(10),
             |e| warn!(job_id = *ctx.config.id, error =? e, "failed to tear down cluster")
         )?;
+
+        clear_worker_handles(ctx);
 
         Ok(())
     }

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -269,6 +269,9 @@ impl State for Scheduling {
             )
         }
 
+        // Ensure no stale handles survive into a new scheduling cycle.
+        super::clear_worker_handles(ctx);
+
         ctx.program
             .update_parallelism(&ctx.config.parallelism_overrides);
 
@@ -739,6 +742,24 @@ impl State for Scheduling {
         ctx.status.tasks = Some(ctx.program.task_count() as i32);
 
         let needs_commit = committing_state.is_some();
+
+        let worker_connects: HashMap<WorkerId, (WorkerClient, String)> = worker_connects
+            .into_iter()
+            .filter_map(|(id, client)| {
+                let addr = match workers.remove(&id) {
+                    Some(w) => w.rpc_address,
+                    None => {
+                        warn!(
+                            job_id = *ctx.config.id,
+                            worker_id = id.0,
+                            "worker channel has no matching registration, skipping"
+                        );
+                        return None;
+                    }
+                };
+                Some((id, (client, addr)))
+            })
+            .collect();
 
         let program = Arc::new(ctx.program.clone());
         let metrics = JobMetrics::new(program.clone());

--- a/crates/arroyo-controller/src/states/stopping.rs
+++ b/crates/arroyo-controller/src/states/stopping.rs
@@ -5,7 +5,7 @@ use arroyo_rpc::grpc::rpc::StopMode;
 use tokio::time::timeout;
 use tracing::{error, info};
 
-use super::{JobContext, State, Stopped, Transition};
+use super::{JobContext, State, Stopped, Transition, refresh_workers_from_scheduler};
 
 const FINISH_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -29,6 +29,20 @@ impl State for Stopping {
     async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
         match (ctx.job_controller.as_mut(), self.stop_mode) {
             (Some(job_controller), StopBehavior::StopJob(stop_mode)) => {
+                refresh_workers_from_scheduler(
+                    &ctx.scheduler,
+                    job_controller,
+                    &ctx.config.id,
+                    ctx.status.run_id,
+                )
+                .await;
+
+                if job_controller.worker_count() == 0 {
+                    // All workers gone; skip gRPC stop, fall through to scheduler termination.
+                    self.stop_mode = StopBehavior::StopWorkers;
+                    return Self::next(self, ctx).await;
+                }
+
                 if let Err(e) = job_controller.stop_job(stop_mode).await {
                     return Err(ctx.retryable(self, "failed while stopping job", e, 10));
                 }

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -82,18 +82,19 @@ impl WorkerJobController {
         }
 
         let futures = workers.into_iter().map(|(id, addr)| async move {
-            let connect = connect_to_worker(id, addr).await?;
-            anyhow::Ok((id, connect))
+            let connect = connect_to_worker(id, addr.clone()).await?;
+            anyhow::Ok((id, connect, addr))
         });
 
         let mut workers = HashMap::new();
 
-        for (id, connect) in try_join_all(futures).await? {
+        for (id, connect, rpc_address) in try_join_all(futures).await? {
             worker_connects.insert(id, connect.clone());
             workers.insert(
                 id,
                 WorkerStatus {
                     id,
+                    rpc_address,
                     connect,
                     last_heartbeat: Instant::now(),
                     state: WorkerState::Running,

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -18,7 +18,7 @@ use arroyo_state::parquet::ParquetBackend;
 use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::{WorkerId, to_micros};
 use futures::future::try_join_all;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::task::JoinHandle;
@@ -526,6 +526,12 @@ impl RunningJobModel {
             .all(|(_, t)| t.state == TaskState::Finished)
     }
 
+    /// Remove workers whose addresses are not in the given set.
+    pub fn retain_workers_by_address(&mut self, live_addresses: &HashSet<String>) {
+        self.workers
+            .retain(|_, w| live_addresses.contains(&w.rpc_address));
+    }
+
     pub fn start_or_get_span(&mut self, event: JobCheckpointEventType) -> &mut JobCheckpointSpan {
         if let Some(idx) = self.checkpoint_spans.iter().position(|e| e.event == event) {
             return &mut self.checkpoint_spans[idx];
@@ -559,6 +565,7 @@ pub enum WorkerState {
 #[allow(unused)]
 pub struct WorkerStatus {
     pub id: WorkerId,
+    pub rpc_address: String,
     pub connect: WorkerClient,
     pub last_heartbeat: Instant,
     pub state: WorkerState,


### PR DESCRIPTION
#### Context
Follow-up to #1045. Cleanup paths (Recovering, Failing, Stopping) can iterate stale gRPC channels targeting addresses recycled to other workers. While #1045 prevents misrouted messages at the receiver, this change prevents them at the sender by filtering the in-memory worker map against the scheduler's authoritative view before sending.

#### Changes
- Add rpc_address tracking to WorkerStatus so cached channels can be matched against live addresses.
- Add worker_addresses_for_job to the Scheduler trait (default None; opt-in for schedulers with address recycling).
- Before cleanup graceful stops, filter the worker map against the scheduler's response; skip entries whose addresses are no longer live.
- Clear stale handles explicitly at every state transition where workers are known to be gone.
- Short-circuit wait_for_finish when the worker map is empty.

Follows: #1045 (receiver-side worker identity validation).