### PR TITLE
Only install pgcrypto if needed

### DIFF
--- a/crates/arroyo/src/main.rs
+++ b/crates/arroyo/src/main.rs
@@ -382,11 +382,24 @@ async fn migrate(wait: Option<u32>) -> anyhow::Result<()> {
     // make compatible with lower version PG (i.g. 12.16) which not support function
     // gen_random_uuid by default.
     client
-        .batch_execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
+        .batch_execute(
+            r#"
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_proc
+                    WHERE proname = 'gen_random_uuid'
+                ) THEN
+                    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+                END IF;
+            END $$;
+        "#,
+        )
         .await
         .map_err(|e| {
             anyhow!(
-                "Failed to create extension pgcrypto on {:?}: {:?}",
+                "Failed to verify or install UUID support on {:?}: {:?}",
                 config().database.postgres,
                 e
             )


### PR DESCRIPTION
The `gen_random_uuid` function that Arroyo uses was added to Core in Postgres 13. Installing pgcrypto is no longer needed for versions 13+.

**Testing**
I ran `cargo run --bin arroyo -- migrate` on different PG versions.

PG v12:
* `pgcrypto` gets installed.

PG v14:
* `pgcrypto` is no longer being installed (though we have access to the `gen_random_uuid` function).