### PR TITLE
Add optional state_url and tags to pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,6 @@ dependencies = [
  "datafusion",
  "futures",
  "lazy_static",
- "moka",
  "object_store",
  "once_cell",
  "parquet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "datafusion",
  "futures",
  "lazy_static",
+ "moka",
  "object_store",
  "once_cell",
  "parquet",

--- a/crates/arroyo-api/migrations/V28__add_pipeline_tags_and_state_url.sql
+++ b/crates/arroyo-api/migrations/V28__add_pipeline_tags_and_state_url.sql
@@ -1,6 +1,7 @@
--- Optional R2/S3 URL where this pipeline's checkpoints live. NULL falls
+-- Optional URL where this pipeline's checkpoints live. NULL falls
 -- back to the controller's global checkpoint_url config. Existing rows
 -- on upgrade automatically get NULL — no default needed.
+-- See [Storage](https://doc.arroyo.dev/deployment/#storage) for a complete reference.
 ALTER TABLE pipelines ADD COLUMN state_url TEXT;
--- Optional JSON object of the form: { "key" : "value", ... }
-ALTER TABLE pipelines ADD COLUMN tags JSONB;
+-- JSON object of the form: { "key" : "value", ... }. Defaults to an empty map.
+ALTER TABLE pipelines ADD COLUMN tags JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/crates/arroyo-api/migrations/V28__add_pipeline_tags_and_state_url.sql
+++ b/crates/arroyo-api/migrations/V28__add_pipeline_tags_and_state_url.sql
@@ -1,0 +1,6 @@
+-- Optional R2/S3 URL where this pipeline's checkpoints live. NULL falls
+-- back to the controller's global checkpoint_url config. Existing rows
+-- on upgrade automatically get NULL — no default needed.
+ALTER TABLE pipelines ADD COLUMN state_url TEXT;
+-- Optional JSON object of the form: { "key" : "value", ... }
+ALTER TABLE pipelines ADD COLUMN tags JSONB;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -123,7 +123,7 @@ WHERE organization_id = :organization_id AND pub_id = :pub_id;
 
 --: DbPipeline (state?, ttl_micros?)
 
---! create_pipeline(textual_repr?, state_url?, tags?)
+--! create_pipeline(textual_repr?, state_url?)
 INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_repr, udfs, program, proto_version, state_url, tags)
 VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -123,9 +123,9 @@ WHERE organization_id = :organization_id AND pub_id = :pub_id;
 
 --: DbPipeline (state?, ttl_micros?)
 
---! create_pipeline(textual_repr?)
-INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_repr, udfs, program, proto_version)
-VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version);
+--! create_pipeline(textual_repr?, state_url?, tags?)
+INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_repr, udfs, program, proto_version, state_url, tags)
+VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 
 --! get_pipelines : DbPipeline
 SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros
@@ -296,7 +296,7 @@ LIMIT cast(:limit as integer);
 --! create_udf (dylib_url?)
 INSERT INTO udfs (pub_id, organization_id, created_by, prefix, name, language, definition, description, dylib_url)
 VALUES (:pub_id, :organization_id, :created_by, :prefix, :name,  :language, :definition, :description, :dylib_url);
-    
+
 --! get_udf: DbUdf
 SELECT pub_id, prefix, name, language, definition, created_at, updated_at, description, dylib_url
 FROM udfs

--- a/crates/arroyo-api/sqlite_migrations/V6__add_pipeline_tags_and_state_url.sql
+++ b/crates/arroyo-api/sqlite_migrations/V6__add_pipeline_tags_and_state_url.sql
@@ -1,2 +1,2 @@
 ALTER TABLE pipelines ADD COLUMN state_url TEXT;
-ALTER TABLE pipelines ADD COLUMN tags TEXT;
+ALTER TABLE pipelines ADD COLUMN tags TEXT NOT NULL DEFAULT '{}';

--- a/crates/arroyo-api/sqlite_migrations/V6__add_pipeline_tags_and_state_url.sql
+++ b/crates/arroyo-api/sqlite_migrations/V6__add_pipeline_tags_and_state_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pipelines ADD COLUMN state_url TEXT;
+ALTER TABLE pipelines ADD COLUMN tags TEXT;

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -34,8 +34,8 @@ use crate::metrics::__path_get_operator_metric_groups;
 use crate::pipelines::__path_get_pipelines;
 use crate::pipelines::{
     __path_create_pipeline, __path_create_preview_pipeline, __path_delete_pipeline,
-    __path_get_pipeline, __path_get_pipeline_jobs, __path_patch_pipeline, __path_restart_pipeline,
-    __path_validate_query,
+    __path_get_pipeline, __path_get_pipeline_jobs, __path_patch_pipeline, __path_put_pipeline,
+    __path_restart_pipeline, __path_validate_query,
 };
 use crate::rest::__path_ping;
 use crate::rest_utils::{ErrorResp, service_unavailable};
@@ -250,6 +250,7 @@ impl IntoResponse for HttpError {
         validate_udf,
         create_pipeline,
         create_preview_pipeline,
+        put_pipeline,
         patch_pipeline,
         restart_pipeline,
         get_pipeline,
@@ -280,7 +281,6 @@ impl IntoResponse for HttpError {
     components(schemas(
         ErrorResp,
         PipelinePost,
-        PipelineTags,
         PreviewPost,
         PipelinePatch,
         PipelineRestart,

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -280,6 +280,7 @@ impl IntoResponse for HttpError {
     components(schemas(
         ErrorResp,
         PipelinePost,
+        PipelineTags,
         PreviewPost,
         PipelinePatch,
         PipelineRestart,

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, SystemTime};
 use crate::{compiler_service, connection_profiles, jobs, types};
 use arroyo_datastream::default_sink;
 use arroyo_rpc::api_types::pipelines::{
-    FailureReason, Job, Pipeline, PipelinePatch, PipelinePost, PipelineRestart, PreviewPost,
-    QueryValidationResult, StopType, ValidateQueryPost,
+    FailureReason, Job, Pipeline, PipelinePatch, PipelinePost, PipelineRestart, PipelineTags,
+    PreviewPost, QueryValidationResult, StopType, ValidateQueryPost,
 };
 use arroyo_rpc::api_types::udfs::{GlobalUdf, Udf, UdfLanguage};
 use arroyo_rpc::api_types::{JobCollection, PaginationQueryParams, PipelineCollection};
@@ -301,6 +301,10 @@ pub(crate) async fn create_pipeline_int(
     enable_sinks: bool,
     auth: AuthData,
     db: &DatabaseSource,
+    mut compiled: CompiledSql,
+    pub_id: Option<String>,
+    state_url: Option<String>,
+    tags: Option<PipelineTags>,
 ) -> Result<String, ErrorResp> {
     if parallelism > auth.org_metadata.max_parallelism as u64 {
         return Err(bad_request(format!(
@@ -310,10 +314,7 @@ pub(crate) async fn create_pipeline_int(
         )));
     }
 
-    let pub_id = generate_id(IdTypes::Pipeline);
-
-    let mut compiled =
-        compile_sql(query.clone(), &udfs, parallelism as usize, &auth, false, db).await?;
+    let pub_id = pub_id.unwrap_or_else(|| generate_id(IdTypes::Pipeline));
 
     if compiled.program.graph.node_count() > auth.org_metadata.max_operators as usize {
         return Err(bad_request(
@@ -394,6 +395,12 @@ pub(crate) async fn create_pipeline_int(
         return Err(required_field("name"));
     }
 
+    let tags_json = tags
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|e| log_and_map(anyhow!("pipeline tags serialization failed: {e}")))?;
+
     api_queries::execute_create_pipeline(
         &db.client().await?,
         &pub_id,
@@ -405,6 +412,8 @@ pub(crate) async fn create_pipeline_int(
         &serde_json::to_value(&udfs).unwrap(),
         &program_bytes,
         &2,
+        &state_url,
+        &tags_json,
     )
     .await?;
 
@@ -595,16 +604,32 @@ pub async fn create_pipeline(
         .map(Duration::from_micros)
         .unwrap_or(*config().default_checkpoint_interval);
 
+    let udfs = pipeline_post.udfs.unwrap_or_default();
+
+    let compiled = compile_sql(
+        pipeline_post.query.clone(),
+        &udfs,
+        pipeline_post.parallelism as usize,
+        &auth_data,
+        false,
+        &state.database,
+    )
+    .await?;
+
     let pipeline_id = create_pipeline_int(
         pipeline_post.name,
         pipeline_post.query,
-        pipeline_post.udfs.unwrap_or_default(),
+        udfs,
         pipeline_post.parallelism,
         checkpoint_interval,
-        false,
-        true,
+        /* is_preview */ false,
+        /* enable_sinks */ true,
         auth_data.clone(),
         &state.database,
+        compiled,
+        pipeline_post.pub_id,
+        pipeline_post.state_url,
+        pipeline_post.tags,
     )
     .await?;
 
@@ -634,16 +659,32 @@ pub async fn create_preview_pipeline(
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
+    let udfs = req.udfs.unwrap_or_default();
+
+    let compiled = compile_sql(
+        req.query.clone(),
+        &udfs,
+        1,
+        &auth_data,
+        false,
+        &state.database,
+    )
+    .await?;
+
     let pipeline_id = create_pipeline_int(
         format!("preview_{}", to_millis(SystemTime::now())),
         req.query,
-        req.udfs.unwrap_or_default(),
+        udfs,
         1,
         Duration::MAX,
-        true,
+        /* is_preview */ true,
         req.enable_sinks,
         auth_data.clone(),
         &state.database,
+        compiled,
+        None,
+        None,
+        None,
     )
     .await?;
 

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, SystemTime};
 use crate::{compiler_service, connection_profiles, jobs, types};
 use arroyo_datastream::default_sink;
 use arroyo_rpc::api_types::pipelines::{
-    FailureReason, Job, Pipeline, PipelinePatch, PipelinePost, PipelineRestart, PipelineTags,
-    PreviewPost, QueryValidationResult, StopType, ValidateQueryPost,
+    FailureReason, Job, Pipeline, PipelinePatch, PipelinePost, PipelineRestart, PreviewPost,
+    QueryValidationResult, StopType, ValidateQueryPost,
 };
 use arroyo_rpc::api_types::udfs::{GlobalUdf, Udf, UdfLanguage};
 use arroyo_rpc::api_types::{JobCollection, PaginationQueryParams, PipelineCollection};
@@ -304,7 +304,7 @@ pub(crate) async fn create_pipeline_int(
     mut compiled: CompiledSql,
     pub_id: Option<String>,
     state_url: Option<String>,
-    tags: Option<PipelineTags>,
+    tags: HashMap<String, String>,
 ) -> Result<String, ErrorResp> {
     if parallelism > auth.org_metadata.max_parallelism as u64 {
         return Err(bad_request(format!(
@@ -395,10 +395,7 @@ pub(crate) async fn create_pipeline_int(
         return Err(required_field("name"));
     }
 
-    let tags_json = tags
-        .as_ref()
-        .map(serde_json::to_value)
-        .transpose()
+    let tags_json = serde_json::to_value(tags)
         .map_err(|e| log_and_map(anyhow!("pipeline tags serialization failed: {e}")))?;
 
     api_queries::execute_create_pipeline(
@@ -580,7 +577,9 @@ pub async fn validate_query(
 
 /// Create a new pipeline
 ///
-/// The API will create a single job for the pipeline.
+/// The API will create a single job for the pipeline. The server generates
+/// a fresh id for the pipeline; if the caller wants to supply its own
+/// stable id, use `PUT /pipelines/{id}` instead.
 #[utoipa::path(
     post,
     path = "/v1/pipelines",
@@ -596,9 +595,47 @@ pub async fn create_pipeline(
     bearer_auth: BearerAuth,
     WithRejection(Json(pipeline_post), _): WithRejection<Json<PipelinePost>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
+    create_pipeline_inner(state, bearer_auth, None, pipeline_post).await
+}
+
+/// Create a new pipeline at a caller-supplied id
+///
+/// The API will create a single job for the pipeline, using the
+/// supplied `id`. Useful when an upstream system wants to address
+/// the pipeline by an id it already manages.
+///
+/// The endpoint is currently create-only: PUTing twice with the same id
+/// returns a 400 (duplicate-violation) rather than upserting.
+#[utoipa::path(
+    put,
+    path = "/v1/pipelines/{id}",
+    tag = "pipelines",
+    params(
+        ("id" = String, Path, description = "Caller-supplied pipeline id")
+    ),
+    request_body = PipelinePost,
+    responses(
+        (status = 200, description = "Created pipeline and job", body = Pipeline),
+        (status = 400, description = "Bad request", body = ErrorResp),
+    ),
+)]
+pub async fn put_pipeline(
+    State(state): State<AppState>,
+    bearer_auth: BearerAuth,
+    Path(id): Path<String>,
+    WithRejection(Json(pipeline_post), _): WithRejection<Json<PipelinePost>, ApiError>,
+) -> Result<Json<Pipeline>, ErrorResp> {
+    create_pipeline_inner(state, bearer_auth, Some(id), pipeline_post).await
+}
+
+async fn create_pipeline_inner(
+    state: AppState,
+    bearer_auth: BearerAuth,
+    pub_id: Option<String>,
+    pipeline_post: PipelinePost,
+) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
-    //let transaction = db.transaction().await?;
     let checkpoint_interval = pipeline_post
         .checkpoint_interval_micros
         .map(Duration::from_micros)
@@ -627,13 +664,11 @@ pub async fn create_pipeline(
         auth_data.clone(),
         &state.database,
         compiled,
-        pipeline_post.pub_id,
+        pub_id,
         pipeline_post.state_url,
-        pipeline_post.tags,
+        pipeline_post.tags.unwrap_or_default(),
     )
     .await?;
-
-    // transaction.commit().await?;
 
     let pipeline =
         query_pipeline_by_pub_id(&pipeline_id, &state.database.client().await?, &auth_data).await?;
@@ -684,7 +719,7 @@ pub async fn create_preview_pipeline(
         compiled,
         None,
         None,
-        None,
+        HashMap::default(),
     )
     .await?;
 

--- a/crates/arroyo-api/src/rest.rs
+++ b/crates/arroyo-api/src/rest.rs
@@ -1,7 +1,7 @@
 use axum::response::{Html, IntoResponse, Response};
 use axum::{
     Json, Router,
-    routing::{delete, get, patch, post},
+    routing::{delete, get, patch, post, put},
 };
 
 use http::{HeaderMap, HeaderName, StatusCode, Uri, header};
@@ -27,7 +27,7 @@ use crate::jobs::{
 use crate::metrics::get_operator_metric_groups;
 use crate::pipelines::{
     create_pipeline, create_preview_pipeline, delete_pipeline, get_pipeline, get_pipeline_jobs,
-    get_pipelines, patch_pipeline, restart_pipeline, validate_query,
+    get_pipelines, patch_pipeline, put_pipeline, restart_pipeline, validate_query,
 };
 use crate::rest_utils::not_found;
 use crate::udfs::{create_udf, delete_udf, get_udfs, validate_udf};
@@ -174,6 +174,7 @@ pub fn create_rest_app(database: DatabaseSource) -> Router {
         .route("/pipelines", get(get_pipelines))
         .route("/jobs", get(get_jobs))
         .route("/pipelines/validate_query", post(validate_query))
+        .route("/pipelines/:id", put(put_pipeline))
         .route("/pipelines/:id", patch(patch_pipeline))
         .route("/pipelines/:id", get(get_pipeline))
         .route("/pipelines/:id/restart", post(restart_pipeline))

--- a/crates/arroyo-api/src/rest_utils.rs
+++ b/crates/arroyo-api/src/rest_utils.rs
@@ -52,7 +52,9 @@ pub fn map_delete_err(name: &str, user: &str, error: DbError) -> ErrorResp {
 impl From<DbError> for ErrorResp {
     fn from(value: DbError) -> Self {
         match value {
-            DbError::DuplicateViolation => bad_request("A record already exists with that name"),
+            DbError::DuplicateViolation => {
+                bad_request("A record already exists with that name or id")
+            }
             DbError::ForeignKeyViolation => {
                 bad_request("Cannot delete; other records depend on this one")
             }

--- a/crates/arroyo-connectors/src/kafka/source/test.rs
+++ b/crates/arroyo-connectors/src/kafka/source/test.rs
@@ -2,7 +2,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 
 use arroyo_state::tables::ErasedTable;
 use arroyo_state::tables::global_keyed_map::GlobalKeyedTable;
-use arroyo_state::{BackingStore, StateBackend};
+use arroyo_state::{BackingStore, StateBackend, StorageProviderFor};
 use rand::random;
 
 use crate::kafka::SourceOffset;
@@ -314,31 +314,37 @@ async fn test_kafka() {
     .unwrap()
     .unwrap();
 
-    StateBackend::write_operator_checkpoint_metadata(OperatorCheckpointMetadata {
-        start_time: 0,
-        finish_time: 0,
-        table_checkpoint_metadata: single_item_hash_map("k", table_metadata),
-        table_configs: subtask_metadata.table_configs,
-        operator_metadata: Some(OperatorMetadata {
-            job_id: task_info.job_id.clone(),
-            operator_id: task_info.operator_id.clone(),
-            epoch: 1,
-            min_watermark: Some(0),
-            max_watermark: Some(0),
-            parallelism: 1,
-        }),
-    })
+    StateBackend::write_operator_checkpoint_metadata(
+        &StorageProviderFor::Worker,
+        OperatorCheckpointMetadata {
+            start_time: 0,
+            finish_time: 0,
+            table_checkpoint_metadata: single_item_hash_map("k", table_metadata),
+            table_configs: subtask_metadata.table_configs,
+            operator_metadata: Some(OperatorMetadata {
+                job_id: task_info.job_id.clone(),
+                operator_id: task_info.operator_id.clone(),
+                epoch: 1,
+                min_watermark: Some(0),
+                max_watermark: Some(0),
+                parallelism: 1,
+            }),
+        },
+    )
     .await
     .unwrap();
 
-    StateBackend::write_checkpoint_metadata(CheckpointMetadata {
-        job_id: task_info.job_id.clone(),
-        epoch: 1,
-        min_epoch: 1,
-        start_time: 0,
-        finish_time: 0,
-        operator_ids: vec![task_info.operator_id.clone()],
-    })
+    StateBackend::write_checkpoint_metadata(
+        &StorageProviderFor::Worker,
+        CheckpointMetadata {
+            job_id: task_info.job_id.clone(),
+            epoch: 1,
+            min_epoch: 1,
+            start_time: 0,
+            finish_time: 0,
+            operator_ids: vec![task_info.operator_id.clone()],
+        },
+    )
     .await
     .unwrap();
 

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -40,7 +40,7 @@ SET state = :state,
     restart_nonce = :restart_nonce
 WHERE id = :job_id;
 
---! get_program : PipelineRow(state_url?, tags?)
+--! get_program : PipelineRow(state_url?)
 SELECT program, pub_id as pipeline_id, proto_version, state_url, tags FROM pipelines WHERE id = :id;
 
 --! mark_checkpoints_compacted

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -40,8 +40,8 @@ SET state = :state,
     restart_nonce = :restart_nonce
 WHERE id = :job_id;
 
---! get_program
-SELECT program, pub_id as pipeline_id, proto_version FROM pipelines WHERE id = :id;
+--! get_program : PipelineRow(state_url?, tags?)
+SELECT program, pub_id as pipeline_id, proto_version, state_url, tags FROM pipelines WHERE id = :id;
 
 --! mark_checkpoints_compacted
 UPDATE checkpoints

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -10,7 +10,7 @@ use anyhow::bail;
 use arroyo_rpc::checkpoints::CheckpointMetadataStore;
 use arroyo_rpc::grpc::rpc::{CommitReq, LabelPair, MetricsReq, StopExecutionReq, StopMode};
 use arroyo_rpc::identity::WorkerClient;
-use arroyo_state::{BackingStore, StateBackend};
+use arroyo_state::{BackingStore, StateBackend, StorageProviderFor};
 use arroyo_types::{JobId, PipelineId, WorkerId};
 use rand::{Rng, rng};
 
@@ -65,6 +65,7 @@ impl JobController {
         checkpoint_store: Arc<dyn CheckpointMetadataStore>,
         config: JobConfig,
         pipeline_id: PipelineId,
+        state_url: Option<String>,
         generation: u64,
         program: Arc<LogicalProgram>,
         epoch: u32,
@@ -126,6 +127,9 @@ impl JobController {
                 program,
                 checkpoint_spans: vec![],
                 worker_leader_mode: false,
+                storage_role: StorageProviderFor::Controller {
+                    storage_url: state_url,
+                },
                 finished_operators: vec![],
                 generation_manifest: None,
             },
@@ -400,6 +404,7 @@ impl JobController {
         let min_epoch = self.model.min_epoch.max(1);
         let job_id = self.config.id.clone();
         let store = self.checkpoint_store.clone();
+        let storage_role = self.model.storage_role.clone();
 
         info!(
             message = "Starting cleaning",
@@ -411,11 +416,12 @@ impl JobController {
         let cur_epoch = self.model.epoch;
 
         tokio::spawn(async move {
-            let checkpoint = StateBackend::load_checkpoint_metadata(&job_id, cur_epoch).await?;
+            let checkpoint =
+                StateBackend::load_checkpoint_metadata(&storage_role, &job_id, cur_epoch).await?;
 
             store.mark_compacting(&job_id, min_epoch, new_min).await?;
 
-            StateBackend::cleanup_checkpoint(checkpoint, min_epoch, new_min).await?;
+            StateBackend::cleanup_checkpoint(&storage_role, checkpoint, min_epoch, new_min).await?;
 
             store.mark_checkpoints_compacted(&job_id, new_min).await?;
 

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::needless_lifetimes)]
 
 use anyhow::Result;
+use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::controller_grpc_server::{ControllerGrpc, ControllerGrpcServer};
@@ -25,7 +26,7 @@ use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
 use arroyo_rpc::{config, errors};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_server_common::wrap_start;
-use arroyo_types::{MachineId, WorkerId, from_micros};
+use arroyo_types::{MachineId, PipelineId, WorkerId, from_micros};
 use cornucopia_async::DatabaseSource;
 use states::{Created, State, StateMachine};
 use std::collections::{HashMap, HashSet};
@@ -73,6 +74,14 @@ pub struct JobConfig {
     restart_nonce: i32,
     restart_mode: RestartMode,
     ignore_state_before_epoch: Option<i32>,
+}
+
+/// Per-pipeline data that doesn't change for the lifetime of a job.
+#[derive(Clone, Debug)]
+pub struct PipelineInfo {
+    pub pipeline_id: PipelineId,
+    pub state_url: Option<String>,
+    pub tags: Option<PipelineTags>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(clippy::needless_lifetimes)]
 
 use anyhow::Result;
-use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::controller_grpc_server::{ControllerGrpc, ControllerGrpcServer};
@@ -81,7 +80,7 @@ pub struct JobConfig {
 pub struct PipelineInfo {
     pub pipeline_id: PipelineId,
     pub state_url: Option<String>,
-    pub tags: Option<PipelineTags>,
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -338,6 +338,7 @@ mod test {
             generation: 1,
             slots: 8,
             env_vars: Default::default(),
+            pipeline_tags: None,
         };
 
         let mut config = config().kubernetes_scheduler.clone();

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -338,7 +338,7 @@ mod test {
             generation: 1,
             slots: 8,
             env_vars: Default::default(),
-            pipeline_tags: None,
+            pipeline_tags: Default::default(),
         };
 
         let mut config = config().kubernetes_scheduler.clone();

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::bail;
 use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::connect_grpc;
 use arroyo_rpc::grpc::rpc::node_grpc_client::NodeGrpcClient;
@@ -105,7 +104,7 @@ pub struct StartPipelineReq {
     pub generation: u64,
     pub slots: usize,
     pub env_vars: HashMap<String, String>,
-    pub pipeline_tags: Option<PipelineTags>,
+    pub pipeline_tags: HashMap<String, String>,
 }
 
 #[async_trait::async_trait]

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::connect_grpc;
 use arroyo_rpc::grpc::rpc::node_grpc_client::NodeGrpcClient;
@@ -104,6 +105,7 @@ pub struct StartPipelineReq {
     pub generation: u64,
     pub slots: usize,
     pub env_vars: HashMap<String, String>,
+    pub pipeline_tags: Option<PipelineTags>,
 }
 
 #[async_trait::async_trait]

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -32,8 +32,9 @@ use self::stopping::Stopping;
 use crate::job_controller::JobController;
 use crate::queries::controller_queries;
 use crate::types::public::{LogLevel, StopMode};
-use crate::{JobConfig, JobMessage, JobStatus, queries, schedulers::Scheduler};
+use crate::{JobConfig, JobMessage, JobStatus, PipelineInfo, queries, schedulers::Scheduler};
 use arroyo_datastream::logical::LogicalProgram;
+use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
@@ -542,9 +543,9 @@ pub(crate) use stop_if_desired_running;
 
 pub struct JobContext<'a> {
     pub config: JobConfig,
+    pub pipeline_info: Arc<PipelineInfo>,
     pub status: &'a mut JobStatus,
     pub program: &'a mut LogicalProgram,
-    pub pipeline_id: PipelineId,
     pub db: DatabaseSource,
     pub scheduler: Arc<dyn Scheduler>,
     pub rx: &'a mut Receiver<JobMessage>,
@@ -896,7 +897,7 @@ pub(crate) async fn state_backoff(retries_attempted: usize) {
 #[allow(clippy::too_many_arguments)]
 async fn run_to_completion(
     config: Arc<RwLock<(JobConfig, AppliedStatus)>>,
-    pipeline_pub_id: String,
+    pipeline_info: Arc<PipelineInfo>,
     mut program: LogicalProgram,
     mut status: JobStatus,
     mut state: Box<dyn State>,
@@ -907,9 +908,9 @@ async fn run_to_completion(
 ) {
     let mut ctx = JobContext {
         config: config.read().unwrap().0.clone(),
+        pipeline_info,
         status: &mut status,
         program: &mut program,
-        pipeline_id: PipelineId(pipeline_pub_id.into()),
         db: db.clone(),
         scheduler,
         rx: &mut rx,
@@ -983,7 +984,7 @@ impl StateMachine {
         db: &DatabaseSource,
         job_id: &str,
         id: i64,
-    ) -> anyhow::Result<Option<(String, LogicalProgram)>> {
+    ) -> anyhow::Result<Option<(LogicalProgram, PipelineInfo)>> {
         let res = controller_queries::fetch_get_program(&db.client().await?, &id)
             .await
             .map_err(|e| anyhow!("Failed to fetch program from database: {:?}", e))?
@@ -991,9 +992,26 @@ impl StateMachine {
             .next()
             .ok_or_else(|| anyhow!("Could not find program for job_id {job_id}"))?;
 
+        let tags = res
+            .tags
+            .map(serde_json::from_value::<PipelineTags>)
+            .transpose()
+            .map_err(|e| {
+                anyhow!(
+                    "malformed JSON in pipelines.tags for pipeline {}: {e}",
+                    res.pipeline_id
+                )
+            })?;
+
+        let info = PipelineInfo {
+            pipeline_id: PipelineId(res.pipeline_id.into()),
+            state_url: res.state_url,
+            tags,
+        };
+
         Ok(if res.proto_version == 2 {
             match Self::decode_program(&res.program) {
-                Ok(p) => Some((res.pipeline_id, p)),
+                Ok(p) => Some((p, info)),
                 Err(e) => {
                     warn!("Failed to start {}: {}", job_id, e);
                     None
@@ -1053,13 +1071,14 @@ impl StateMachine {
                 let metrics = self.metrics.clone();
                 let pipeline_id = config.read().unwrap().0.pipeline_id;
                 match Self::get_program(&db, &status.id, pipeline_id).await {
-                    Ok(Some((pipeline_pub_id, program))) => {
+                    Ok(Some((program, pipeline_info))) => {
+                        let pipeline_info = Arc::new(pipeline_info);
                         shutdown_guard.into_spawn_task(async move {
                             let id = { config.read().unwrap().0.id.clone() };
                             info!(message = "starting state machine", job_id = *id);
                             run_to_completion(
                                 config,
-                                pipeline_pub_id,
+                                pipeline_info,
                                 program,
                                 status,
                                 initial_state,

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -34,7 +34,6 @@ use crate::queries::controller_queries;
 use crate::types::public::{LogLevel, StopMode};
 use crate::{JobConfig, JobMessage, JobStatus, PipelineInfo, queries, schedulers::Scheduler};
 use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::api_types::pipelines::PipelineTags;
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
@@ -992,16 +991,12 @@ impl StateMachine {
             .next()
             .ok_or_else(|| anyhow!("Could not find program for job_id {job_id}"))?;
 
-        let tags = res
-            .tags
-            .map(serde_json::from_value::<PipelineTags>)
-            .transpose()
-            .map_err(|e| {
-                anyhow!(
-                    "malformed JSON in pipelines.tags for pipeline {}: {e}",
-                    res.pipeline_id
-                )
-            })?;
+        let tags = serde_json::from_value::<HashMap<String, String>>(res.tags).map_err(|e| {
+            anyhow!(
+                "malformed JSON in pipelines.tags for pipeline {}: {e}",
+                res.pipeline_id
+            )
+        })?;
 
         let info = PipelineInfo {
             pipeline_id: PipelineId(res.pipeline_id.into()),

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -433,7 +433,7 @@ async fn get_and_register_checkpoint_info_leader<'a>(
     let new_gen = initialize_generation(
         get_storage_provider().await?.as_ref(),
         InitializeGenerationRequest {
-            pipeline_id: ctx.pipeline_id.clone(),
+            pipeline_id: ctx.pipeline_info.pipeline_id.clone(),
             job_id: JobId(ctx.config.id.clone()),
             generation: Generation(ctx.status.generation),
             updated_at: SystemTime::now(),
@@ -498,30 +498,33 @@ impl Scheduling {
         slots_needed: usize,
     ) -> Result<Box<Self>, StateError> {
         let start = Instant::now();
+        let mut env_vars = std::collections::HashMap::new();
+        env_vars.insert(
+            "ARROYO__CHECKPOINT_URL".to_string(),
+            ctx.pipeline_info
+                .state_url
+                .clone()
+                .unwrap_or_else(|| config().checkpoint_url.clone()),
+        );
+        env_vars.insert(
+            CLUSTER_ID_ENV.to_string(),
+            arroyo_server_common::get_cluster_id(),
+        );
+
         loop {
             match ctx
                 .scheduler
                 .start_workers(StartPipelineReq {
                     program: ctx.program.clone(),
                     wasm_path: "".to_string(),
-                    pipeline_id: ctx.pipeline_id.clone(),
+                    pipeline_id: ctx.pipeline_info.pipeline_id.clone(),
                     job_id: JobId(ctx.config.id.clone()),
                     generation: ctx.status.generation,
                     name: ctx.config.pipeline_name.clone(),
                     hash: ctx.program.get_hash(),
                     slots: slots_needed,
-                    env_vars: [
-                        (
-                            "ARROYO__CHECKPOINT_URL".to_string(),
-                            config().checkpoint_url.clone(),
-                        ),
-                        (
-                            CLUSTER_ID_ENV.to_string(),
-                            arroyo_server_common::get_cluster_id(),
-                        ),
-                    ]
-                    .into_iter()
-                    .collect(),
+                    env_vars: env_vars.clone(),
+                    pipeline_tags: ctx.pipeline_info.tags.clone(),
                 })
                 .await
             {
@@ -857,7 +860,7 @@ impl State for Scheduling {
                 let mut controller = JobController::new(
                     checkpoint_store,
                     ctx.config.clone(),
-                    ctx.pipeline_id.clone(),
+                    ctx.pipeline_info.pipeline_id.clone(),
                     ctx.status.generation,
                     program,
                     start_epoch as u32,

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -30,7 +30,7 @@ use arroyo_rpc::grpc::api;
 use arroyo_rpc::grpc_channel_builder;
 use arroyo_rpc::worker_types::RunningMessage;
 use arroyo_state::{
-    BackingStore, StateBackend, get_storage_provider,
+    BackingStore, StateBackend, StorageProviderFor, get_storage_provider,
     tables::{ErasedTable, global_keyed_map::GlobalKeyedTable},
 };
 use arroyo_state_protocol::store::read_protobuf;
@@ -317,18 +317,27 @@ async fn get_checkpoint_info_legacy<'a>(
         needs_commits,
     }) = checkpoint_info.clone()
     {
-        let mut metadata =
-            match StateBackend::load_checkpoint_metadata(&ctx.config.id, epoch as u32).await {
-                Ok(m) => m,
-                Err(err) => {
-                    return Err(ctx.retryable(
-                        state,
-                        format!("Failed to load checkpoint metadata for epoch {epoch}"),
-                        err.into(),
-                        10,
-                    ));
-                }
-            };
+        let storage_role = StorageProviderFor::Controller {
+            storage_url: ctx.pipeline_info.state_url.clone(),
+        };
+
+        let mut metadata = match StateBackend::load_checkpoint_metadata(
+            &storage_role,
+            &ctx.config.id,
+            epoch as u32,
+        )
+        .await
+        {
+            Ok(m) => m,
+            Err(err) => {
+                return Err(ctx.retryable(
+                    state,
+                    format!("Failed to load checkpoint metadata for epoch {epoch}"),
+                    err.into(),
+                    10,
+                ));
+            }
+        };
 
         metadata.min_epoch = min_epoch as u32;
         if needs_commits {
@@ -338,6 +347,7 @@ async fn get_checkpoint_info_legacy<'a>(
                 HashMap::new();
             for operator_id in &metadata.operator_ids {
                 let operator_metadata = match StateBackend::load_operator_metadata(
+                    &storage_role,
                     &ctx.config.id,
                     operator_id,
                     epoch as u32,
@@ -412,7 +422,7 @@ async fn get_checkpoint_info_legacy<'a>(
             ));
         }
 
-        if let Err(err) = StateBackend::write_checkpoint_metadata(metadata).await {
+        if let Err(err) = StateBackend::write_checkpoint_metadata(&storage_role, metadata).await {
             return Err(ctx.retryable(
                 state,
                 format!("Failed to write checkpoint metadata for epoch {epoch}"),
@@ -430,8 +440,13 @@ async fn get_and_register_checkpoint_info_leader<'a>(
 ) -> anyhow::Result<Option<CheckpointInfo>> {
     // in the future, this should likely move to the leader, but that will require rethinking how
     // worker initialization works
+    let storage_role = StorageProviderFor::Controller {
+        storage_url: ctx.pipeline_info.state_url.clone(),
+    };
+    let storage_provider = get_storage_provider(&storage_role).await?;
+
     let new_gen = initialize_generation(
-        get_storage_provider().await?.as_ref(),
+        storage_provider.as_ref(),
         InitializeGenerationRequest {
             pipeline_id: ctx.pipeline_info.pipeline_id.clone(),
             job_id: JobId(ctx.config.id.clone()),
@@ -475,10 +490,9 @@ async fn get_and_register_checkpoint_info_leader<'a>(
     };
 
     Ok(if let Some(r) = checkpoint_ref {
-        let manifest =
-            read_protobuf::<_, CheckpointManifest>(get_storage_provider().await?.as_ref(), &r)
-                .await?
-                .ok_or_else(|| anyhow!("recovery checkpoint manifest {r} is missing!"))?;
+        let manifest = read_protobuf::<_, CheckpointManifest>(storage_provider.as_ref(), &r)
+            .await?
+            .ok_or_else(|| anyhow!("recovery checkpoint manifest {r} is missing!"))?;
 
         Some(CheckpointInfo {
             epoch: manifest.epoch,
@@ -861,6 +875,7 @@ impl State for Scheduling {
                     checkpoint_store,
                     ctx.config.clone(),
                     ctx.pipeline_info.pipeline_id.clone(),
+                    ctx.pipeline_info.state_url.clone(),
                     ctx.status.generation,
                     program,
                     start_epoch as u32,

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::api_types::udfs::Udf;
 use crate::errors::ErrorDomain;
 use crate::grpc as grpc_proto;
@@ -26,6 +28,18 @@ pub struct PipelinePost {
     pub udfs: Option<Vec<Udf>>,
     pub parallelism: u64,
     pub checkpoint_interval_micros: Option<u64>,
+    pub pub_id: Option<String>,
+    pub state_url: Option<String>,
+    pub tags: Option<PipelineTags>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
+pub struct PipelineTags(HashMap<String, String>);
+
+impl PipelineTags {
+    pub fn get(&self, k: &str) -> Option<&String> {
+        self.0.get(k)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -28,18 +28,8 @@ pub struct PipelinePost {
     pub udfs: Option<Vec<Udf>>,
     pub parallelism: u64,
     pub checkpoint_interval_micros: Option<u64>,
-    pub pub_id: Option<String>,
     pub state_url: Option<String>,
-    pub tags: Option<PipelineTags>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
-pub struct PipelineTags(HashMap<String, String>);
-
-impl PipelineTags {
-    pub fn get(&self, k: &str) -> Option<&String> {
-        self.0.get(k)
-    }
+    pub tags: Option<HashMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -21,7 +21,7 @@ use arroyo_rpc::grpc::rpc::{
     StopMode, TaskCheckpointCompletedReq, TaskCheckpointEventReq, WorkerContext,
 };
 use arroyo_rpc::{CompactionResult, ControlMessage, ControlResp};
-use arroyo_state::{BackingStore, StateBackend};
+use arroyo_state::{BackingStore, StateBackend, StorageProviderFor};
 use arroyo_types::{CheckpointBarrier, to_micros};
 use arroyo_udf_host::LocalUdf;
 use arroyo_worker::engine::Engine;
@@ -182,9 +182,12 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
                 };
                 if let Some(operator_metadata) = checkpoint_state.checkpoint_finished(req).unwrap()
                 {
-                    StateBackend::write_operator_checkpoint_metadata(operator_metadata)
-                        .await
-                        .unwrap();
+                    StateBackend::write_operator_checkpoint_metadata(
+                        &StorageProviderFor::Worker,
+                        operator_metadata,
+                    )
+                    .await
+                    .unwrap();
                 }
             }
             _ => {}
@@ -192,7 +195,7 @@ async fn checkpoint(ctx: &mut SmokeTestContext<'_>, epoch: u32) {
     }
 
     let checkpoint_metadata = checkpoint_state.build_metadata();
-    StateBackend::write_checkpoint_metadata(checkpoint_metadata)
+    StateBackend::write_checkpoint_metadata(&StorageProviderFor::Worker, checkpoint_metadata)
         .await
         .unwrap();
 
@@ -208,8 +211,13 @@ async fn compact(
     let operator_to_node = running_engine.operator_to_node();
     let operator_controls = running_engine.operator_controls();
     for (operator, _) in tasks_per_operator {
-        if let Ok(compacted) =
-            ParquetBackend::compact_operator(job_id.clone(), &operator, epoch).await
+        if let Ok(compacted) = ParquetBackend::compact_operator(
+            &StorageProviderFor::Worker,
+            job_id.clone(),
+            &operator,
+            epoch,
+        )
+        .await
         {
             let node_id = operator_to_node.get(&operator).unwrap();
             let operator_controls = operator_controls.get(node_id).unwrap();

--- a/crates/arroyo-state/Cargo.toml
+++ b/crates/arroyo-state/Cargo.toml
@@ -29,5 +29,6 @@ prost = {workspace = true}
 prometheus = { workspace = true }
 lazy_static = "1.4.0"
 object_store = { workspace = true }
+moka = { version = "0.12", features = ["future"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"

--- a/crates/arroyo-state/Cargo.toml
+++ b/crates/arroyo-state/Cargo.toml
@@ -29,6 +29,5 @@ prost = {workspace = true}
 prometheus = { workspace = true }
 lazy_static = "1.4.0"
 object_store = { workspace = true }
-moka = { version = "0.12", features = ["future"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"

--- a/crates/arroyo-state/src/lib.rs
+++ b/crates/arroyo-state/src/lib.rs
@@ -12,6 +12,7 @@ use bincode::{Decode, Encode};
 use arroyo_rpc::config::config;
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_storage::StorageProvider;
+pub use arroyo_storage::StorageProviderFor;
 use prost::Message;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -137,12 +138,14 @@ pub enum DataOperation {
 pub trait BackingStore {
     /// loads the checkpoint metadata for a given job id and epoch
     async fn load_checkpoint_metadata(
+        role: &StorageProviderFor,
         job_id: &str,
         epoch: u32,
     ) -> Result<CheckpointMetadata, StateError>;
 
     /// loads the operator checkpoint metadata for a given job id, operator id, and epoch
     async fn load_operator_metadata(
+        role: &StorageProviderFor,
         job_id: &str,
         operator_id: &str,
         epoch: u32,
@@ -153,14 +156,19 @@ pub trait BackingStore {
 
     /// writes the operator checkpoint metadata to the backing store
     async fn write_operator_checkpoint_metadata(
+        role: &StorageProviderFor,
         metadata: OperatorCheckpointMetadata,
     ) -> Result<(), StateError>;
 
     /// writes the checkpoint metadata to the backing store
-    async fn write_checkpoint_metadata(metadata: CheckpointMetadata) -> Result<(), StateError>;
+    async fn write_checkpoint_metadata(
+        role: &StorageProviderFor,
+        metadata: CheckpointMetadata,
+    ) -> Result<(), StateError>;
 
     /// cleans up a checkpoint by deleting data that is no longer needed
     async fn cleanup_checkpoint(
+        role: &StorageProviderFor,
         metadata: CheckpointMetadata,
         old_min_epoch: u32,
         new_min_epoch: u32,
@@ -173,18 +181,105 @@ pub fn hash_key<K: Hash>(key: &K) -> u64 {
     hasher.finish()
 }
 
-static STORAGE_PROVIDER: tokio::sync::OnceCell<Arc<StorageProvider>> =
-    tokio::sync::OnceCell::const_new();
+// TODO: Tweak these numbers and maybe introduce a config knob
+const STORAGE_PROVIDER_CACHE_CAPACITY: u64 = 5_000;
+const STORAGE_PROVIDER_CACHE_TTI: Duration = Duration::from_secs(60 * 60);
 
-pub async fn get_storage_provider() -> Result<&'static Arc<StorageProvider>, StorageError> {
-    // TODO: this should be encoded in the config so that the controller doesn't need
-    // to be synchronized with the workers
+/// Per-URL cache of [`StorageProvider`] instances.
+fn storage_provider_cache() -> &'static moka::future::Cache<String, Arc<StorageProvider>> {
+    static CACHE: std::sync::OnceLock<moka::future::Cache<String, Arc<StorageProvider>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| {
+        moka::future::Cache::builder()
+            .max_capacity(STORAGE_PROVIDER_CACHE_CAPACITY)
+            .time_to_idle(STORAGE_PROVIDER_CACHE_TTI)
+            .build()
+    })
+}
 
-    STORAGE_PROVIDER
-        .get_or_try_init(|| async {
-            let storage_url = &config().checkpoint_url;
+/// Returns a cached [`StorageProvider`] for the given role.
+///
+/// Workers use [`StorageProviderFor::Worker`], which reads `config().checkpoint_url`
+/// (set per-pipeline via the `ARROYO__CHECKPOINT_URL` env var at worker startup).
+///
+/// Controllers manage many pipelines that may have different storage URLs and
+/// pass [`StorageProviderFor::Controller`] with the pipeline's `state_url`.
+/// When `state_url` is `None`, falls back to `config().checkpoint_url`.
+pub async fn get_storage_provider(
+    role: &StorageProviderFor,
+) -> Result<Arc<StorageProvider>, StorageError> {
+    let storage_url: String = match role {
+        StorageProviderFor::Controller {
+            storage_url: Some(url),
+        } => url.clone(),
+        StorageProviderFor::Worker | StorageProviderFor::Controller { storage_url: None } => {
+            config().checkpoint_url.clone()
+        }
+    };
 
-            StorageProvider::for_url(storage_url).await.map(Arc::new)
+    storage_provider_cache()
+        .try_get_with(storage_url.clone(), async move {
+            StorageProvider::for_url(&storage_url).await.map(Arc::new)
         })
         .await
+        .map_err(|e: Arc<StorageError>| StorageError::PathError(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_local_url(suffix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        format!("file:///tmp/arroyo-state-test-{nanos}-{suffix}")
+    }
+
+    #[tokio::test]
+    async fn cache_returns_same_arc_for_same_url() {
+        let url = unique_local_url("same");
+        let role = StorageProviderFor::Controller {
+            storage_url: Some(url),
+        };
+
+        let a = get_storage_provider(&role).await.unwrap();
+        let b = get_storage_provider(&role).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "cache hit on same URL should return the same Arc"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_returns_distinct_arcs_for_different_urls() {
+        let role_a = StorageProviderFor::Controller {
+            storage_url: Some(unique_local_url("a")),
+        };
+        let role_b = StorageProviderFor::Controller {
+            storage_url: Some(unique_local_url("b")),
+        };
+
+        let a = get_storage_provider(&role_a).await.unwrap();
+        let b = get_storage_provider(&role_b).await.unwrap();
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "different URLs should resolve to different cached Arcs"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_with_none_falls_back_to_worker_url() {
+        let worker = StorageProviderFor::Worker;
+        let controller_none = StorageProviderFor::Controller { storage_url: None };
+
+        let from_worker = get_storage_provider(&worker).await.unwrap();
+        let from_none = get_storage_provider(&controller_none).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&from_worker, &from_none),
+            "Worker and Controller{{None}} should share the cached provider"
+        );
+    }
 }

--- a/crates/arroyo-state/src/lib.rs
+++ b/crates/arroyo-state/src/lib.rs
@@ -20,6 +20,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
+use tokio::sync::Mutex;
 
 mod metrics;
 pub mod parquet;
@@ -181,20 +182,11 @@ pub fn hash_key<K: Hash>(key: &K) -> u64 {
     hasher.finish()
 }
 
-// TODO: Tweak these numbers and maybe introduce a config knob
-const STORAGE_PROVIDER_CACHE_CAPACITY: u64 = 5_000;
-const STORAGE_PROVIDER_CACHE_TTI: Duration = Duration::from_secs(60 * 60);
-
 /// Per-URL cache of [`StorageProvider`] instances.
-fn storage_provider_cache() -> &'static moka::future::Cache<String, Arc<StorageProvider>> {
-    static CACHE: std::sync::OnceLock<moka::future::Cache<String, Arc<StorageProvider>>> =
+fn storage_provider_cache() -> &'static Mutex<HashMap<String, Arc<StorageProvider>>> {
+    static CACHE: std::sync::OnceLock<Mutex<HashMap<String, Arc<StorageProvider>>>> =
         std::sync::OnceLock::new();
-    CACHE.get_or_init(|| {
-        moka::future::Cache::builder()
-            .max_capacity(STORAGE_PROVIDER_CACHE_CAPACITY)
-            .time_to_idle(STORAGE_PROVIDER_CACHE_TTI)
-            .build()
-    })
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Returns a cached [`StorageProvider`] for the given role.
@@ -208,78 +200,21 @@ fn storage_provider_cache() -> &'static moka::future::Cache<String, Arc<StorageP
 pub async fn get_storage_provider(
     role: &StorageProviderFor,
 ) -> Result<Arc<StorageProvider>, StorageError> {
-    let storage_url: String = match role {
+    let storage_url = match role {
         StorageProviderFor::Controller {
             storage_url: Some(url),
-        } => url.clone(),
+        } => url,
         StorageProviderFor::Worker | StorageProviderFor::Controller { storage_url: None } => {
-            config().checkpoint_url.clone()
+            &config().checkpoint_url
         }
     };
+    let mut cache = storage_provider_cache().lock().await;
 
-    storage_provider_cache()
-        .try_get_with(storage_url.clone(), async move {
-            StorageProvider::for_url(&storage_url).await.map(Arc::new)
-        })
-        .await
-        .map_err(|e: Arc<StorageError>| StorageError::PathError(e.to_string()))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn unique_local_url(suffix: &str) -> String {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        format!("file:///tmp/arroyo-state-test-{nanos}-{suffix}")
-    }
-
-    #[tokio::test]
-    async fn cache_returns_same_arc_for_same_url() {
-        let url = unique_local_url("same");
-        let role = StorageProviderFor::Controller {
-            storage_url: Some(url),
-        };
-
-        let a = get_storage_provider(&role).await.unwrap();
-        let b = get_storage_provider(&role).await.unwrap();
-        assert!(
-            Arc::ptr_eq(&a, &b),
-            "cache hit on same URL should return the same Arc"
-        );
-    }
-
-    #[tokio::test]
-    async fn cache_returns_distinct_arcs_for_different_urls() {
-        let role_a = StorageProviderFor::Controller {
-            storage_url: Some(unique_local_url("a")),
-        };
-        let role_b = StorageProviderFor::Controller {
-            storage_url: Some(unique_local_url("b")),
-        };
-
-        let a = get_storage_provider(&role_a).await.unwrap();
-        let b = get_storage_provider(&role_b).await.unwrap();
-        assert!(
-            !Arc::ptr_eq(&a, &b),
-            "different URLs should resolve to different cached Arcs"
-        );
-    }
-
-    #[tokio::test]
-    async fn controller_with_none_falls_back_to_worker_url() {
-        let worker = StorageProviderFor::Worker;
-        let controller_none = StorageProviderFor::Controller { storage_url: None };
-
-        let from_worker = get_storage_provider(&worker).await.unwrap();
-        let from_none = get_storage_provider(&controller_none).await.unwrap();
-        assert!(
-            Arc::ptr_eq(&from_worker, &from_none),
-            "Worker and Controller{{None}} should share the cached provider"
-        );
+    if let Some(storage_provider) = cache.get(storage_url) {
+        Ok(storage_provider.clone())
+    } else {
+        let storage_provider = Arc::new(StorageProvider::for_url(storage_url).await?);
+        cache.insert(storage_url.clone(), storage_provider.clone());
+        Ok(storage_provider)
     }
 }

--- a/crates/arroyo-state/src/parquet.rs
+++ b/crates/arroyo-state/src/parquet.rs
@@ -1,7 +1,7 @@
 use crate::tables::expiring_time_key_map::ExpiringTimeKeyTable;
 use crate::tables::global_keyed_map::GlobalKeyedTable;
 use crate::tables::{CompactionConfig, ErasedTable};
-use crate::{BackingStore, get_storage_provider};
+use crate::{BackingStore, StorageProviderFor, get_storage_provider};
 use arroyo_rpc::errors::StateError;
 use arroyo_rpc::grpc::rpc::{
     CheckpointMetadata, OperatorCheckpointMetadata, TableCheckpointMetadata,
@@ -43,10 +43,11 @@ impl BackingStore for ParquetBackend {
     }
 
     async fn load_checkpoint_metadata(
+        role: &StorageProviderFor,
         job_id: &str,
         epoch: u32,
     ) -> Result<CheckpointMetadata, StateError> {
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
         let data = storage_client
             .get(metadata_path(&base_path(job_id, epoch)).as_str())
             .await?;
@@ -55,11 +56,12 @@ impl BackingStore for ParquetBackend {
     }
 
     async fn load_operator_metadata(
+        role: &StorageProviderFor,
         job_id: &str,
         operator_id: &str,
         epoch: u32,
     ) -> Result<Option<OperatorCheckpointMetadata>, StateError> {
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
         storage_client
             .get_if_present(metadata_path(&operator_path(job_id, epoch, operator_id)).as_str())
             .await?
@@ -68,9 +70,10 @@ impl BackingStore for ParquetBackend {
     }
 
     async fn write_operator_checkpoint_metadata(
+        role: &StorageProviderFor,
         metadata: OperatorCheckpointMetadata,
     ) -> Result<(), StateError> {
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
         let operator_metadata =
             metadata
                 .operator_metadata
@@ -91,9 +94,12 @@ impl BackingStore for ParquetBackend {
         Ok(())
     }
 
-    async fn write_checkpoint_metadata(metadata: CheckpointMetadata) -> Result<(), StateError> {
+    async fn write_checkpoint_metadata(
+        role: &StorageProviderFor,
+        metadata: CheckpointMetadata,
+    ) -> Result<(), StateError> {
         debug!("writing checkpoint {:?}", metadata);
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
         let path = metadata_path(&base_path(&metadata.job_id, metadata.epoch));
         storage_client
             .put(path.as_str(), metadata.encode_to_vec())
@@ -102,6 +108,7 @@ impl BackingStore for ParquetBackend {
     }
 
     async fn cleanup_checkpoint(
+        role: &StorageProviderFor,
         mut metadata: CheckpointMetadata,
         old_min_epoch: u32,
         min_epoch: u32,
@@ -117,6 +124,7 @@ impl BackingStore for ParquetBackend {
             .iter()
             .map(|operator_id| {
                 Self::cleanup_operator(
+                    role,
                     metadata.job_id.clone(),
                     operator_id.clone(),
                     old_min_epoch,
@@ -125,7 +133,7 @@ impl BackingStore for ParquetBackend {
             })
             .collect();
 
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
 
         // wait for all of the futures to complete
         while let Some(result) = futures.next().await {
@@ -153,7 +161,7 @@ impl BackingStore for ParquetBackend {
                 .await?;
         }
         metadata.min_epoch = min_epoch;
-        Self::write_checkpoint_metadata(metadata).await?;
+        Self::write_checkpoint_metadata(role, metadata).await?;
         Ok(())
     }
 }
@@ -161,6 +169,7 @@ impl BackingStore for ParquetBackend {
 impl ParquetBackend {
     /// Called after a checkpoint is committed
     pub async fn compact_operator(
+        role: &StorageProviderFor,
         job_id: Arc<String>,
         operator_id: &str,
         epoch: u32,
@@ -168,14 +177,14 @@ impl ParquetBackend {
         let min_files_to_compact = config().pipeline.compaction.checkpoints_to_compact as usize;
 
         let operator_checkpoint_metadata =
-            Self::load_operator_metadata(&job_id, operator_id, epoch)
+            Self::load_operator_metadata(role, &job_id, operator_id, epoch)
                 .await?
                 .expect("expect operator metadata to still be present");
-        let storage_provider = get_storage_provider().await?;
+        let storage_provider = get_storage_provider(role).await?;
         let compaction_config = CompactionConfig {
             compact_generations: vec![0].into_iter().collect(),
             min_compaction_epochs: min_files_to_compact,
-            storage_provider: Arc::clone(storage_provider),
+            storage_provider: Arc::clone(&storage_provider),
             file_path_layout: CheckpointFilePathLayout::Legacy,
         };
         let operator_metadata = operator_checkpoint_metadata.operator_metadata.unwrap();
@@ -222,14 +231,16 @@ impl ParquetBackend {
 
     /// Delete files no longer referenced by the new min epoch
     pub async fn cleanup_operator(
+        role: &StorageProviderFor,
         job_id: String,
         operator_id: String,
         old_min_epoch: u32,
         new_min_epoch: u32,
     ) -> Result<String, StateError> {
-        let operator_metadata = Self::load_operator_metadata(&job_id, &operator_id, new_min_epoch)
-            .await?
-            .expect("expect new_min_epoch metadata to still be present");
+        let operator_metadata =
+            Self::load_operator_metadata(role, &job_id, &operator_id, new_min_epoch)
+                .await?
+                .expect("expect new_min_epoch metadata to still be present");
         let paths_to_keep: HashSet<String> = operator_metadata
             .table_checkpoint_metadata
             .iter()
@@ -253,11 +264,11 @@ impl ParquetBackend {
             .collect();
 
         let mut deleted_paths = HashSet::new();
-        let storage_client = get_storage_provider().await?;
+        let storage_client = get_storage_provider(role).await?;
 
         for epoch_to_remove in old_min_epoch..new_min_epoch {
             let Some(operator_metadata) =
-                Self::load_operator_metadata(&job_id, &operator_id, epoch_to_remove).await?
+                Self::load_operator_metadata(role, &job_id, &operator_id, epoch_to_remove).await?
             else {
                 continue;
             };

--- a/crates/arroyo-state/src/tables/table_manager.rs
+++ b/crates/arroyo-state/src/tables/table_manager.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
 
+use crate::StorageProviderFor;
 use anyhow::{Result, anyhow, bail};
 use arroyo_rpc::CompactionResult;
 use arroyo_rpc::{
@@ -238,11 +239,14 @@ async fn load_operator_metadata(
     operator_id: &str,
 ) -> Result<OperatorCheckpointMetadata, anyhow::Error> {
     match m {
-        MetadataOrManifest::Metadata(m) => {
-            StateBackend::load_operator_metadata(&m.job_id, operator_id, m.epoch)
-                .await?
-                .ok_or_else(|| anyhow!("missing metadata field in checkpoint; invalid protobuf"))
-        }
+        MetadataOrManifest::Metadata(m) => StateBackend::load_operator_metadata(
+            &StorageProviderFor::Worker,
+            &m.job_id,
+            operator_id,
+            m.epoch,
+        )
+        .await?
+        .ok_or_else(|| anyhow!("missing metadata field in checkpoint; invalid protobuf")),
         MetadataOrManifest::Manifest(manifest) => manifest
             .operators
             .iter()
@@ -279,7 +283,7 @@ impl TableManager {
             (None, None)
         };
 
-        let storage = get_storage_provider().await?;
+        let storage = get_storage_provider(&StorageProviderFor::Worker).await?;
 
         let tables = table_configs
             .iter()
@@ -354,7 +358,7 @@ impl TableManager {
                 tables,
                 writer,
                 task_info,
-                storage: Arc::clone(storage),
+                storage: Arc::clone(&storage),
                 caches: HashMap::new(),
             },
             watermark,

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -31,6 +31,27 @@ mod aws;
 /// A reference-counted reference to a [StorageProvider].
 pub type StorageProviderRef = Arc<StorageProvider>;
 
+/// Identifies the role / context a [`StorageProvider`] is being requested for.
+///
+/// Worker processes have a single effective checkpoint URL — the per-pipeline
+/// `state_url` is injected via the `ARROYO__CHECKPOINT_URL` env var at worker
+/// startup, which feeds `config().checkpoint_url`. Workers therefore use the
+/// [`Worker`](StorageProviderFor::Worker) variant.
+///
+/// Controller processes (may) manage many pipelines simultaneously, each potentially
+/// backed by a different storage URL. Controllers should use
+/// [`Controller`](StorageProviderFor::Controller) and supply the pipeline's
+/// `state_url`. When `storage_url` is `None`, the controller falls back to
+/// `config().checkpoint_url`, matching the worker default.
+#[derive(Debug, Clone)]
+pub enum StorageProviderFor {
+    /// Use the process-wide checkpoint URL from `config().checkpoint_url`.
+    Worker,
+    /// Use a per-pipeline `state_url`, falling back to `config().checkpoint_url`
+    /// when `None`.
+    Controller { storage_url: Option<String> },
+}
+
 #[derive(Clone)]
 pub struct StorageProvider {
     config: BackendConfig,

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -26,7 +26,7 @@ use arroyo_rpc::errors::{DataflowError, StateError};
 use arroyo_rpc::grpc::rpc::CheckpointManifest;
 use arroyo_rpc::grpc::{api, rpc::TaskAssignment};
 use arroyo_rpc::{ControlMessage, ControlResp, MetadataOrManifest};
-use arroyo_state::{BackingStore, StateBackend};
+use arroyo_state::{BackingStore, StateBackend, StorageProviderFor};
 use arroyo_types::{
     CheckpointFilePathLayout, JobId, MachineId, PipelineId, TaskInfo, WorkerId, range_for_server,
 };
@@ -224,7 +224,12 @@ impl Program {
         } else if let Some(epoch) = restore_epoch {
             info!("Restoring checkpoint {} for job {}", epoch, job_id);
             Some(MetadataOrManifest::Metadata(
-                StateBackend::load_checkpoint_metadata(job_id, epoch as u32).await?,
+                StateBackend::load_checkpoint_metadata(
+                    &StorageProviderFor::Worker,
+                    job_id,
+                    epoch as u32,
+                )
+                .await?,
             ))
         } else {
             None

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -16,10 +16,10 @@ use arroyo_rpc::grpc::rpc::{
 };
 use arroyo_rpc::log_event;
 use arroyo_server_common::shutdown::ShutdownGuard;
-use arroyo_state::get_storage_provider;
 use arroyo_state::tables::ErasedTable;
 use arroyo_state::tables::expiring_time_key_map::ExpiringTimeKeyTable;
 use arroyo_state::tables::global_keyed_map::GlobalKeyedTable;
+use arroyo_state::{StorageProviderFor, get_storage_provider};
 use arroyo_state_protocol::ProtocolPaths;
 use arroyo_state_protocol::types::{CheckpointRef, Generation};
 use arroyo_state_protocol::workflow::{
@@ -140,7 +140,9 @@ impl WorkerJobController {
         // been created -- ideally we'd just do it here, but the worker initialization process makes
         // that challenging, because we need the restoration point to initialize the workers
         let (generation_manifest, recovery) = match initialize_generation(
-            get_storage_provider().await?.as_ref(),
+            get_storage_provider(&StorageProviderFor::Worker)
+                .await?
+                .as_ref(),
             InitializeGenerationRequest {
                 pipeline_id: worker_context.pipeline_id.clone(),
                 job_id: worker_context.job_id.clone(),
@@ -254,6 +256,7 @@ impl WorkerJobController {
                 checkpoint_parent_ref: parent_ref,
                 checkpoint_spans: vec![],
                 worker_leader_mode: true,
+                storage_role: StorageProviderFor::Worker,
                 finished_operators: vec![],
                 generation_manifest: Some(generation_manifest),
             },
@@ -394,7 +397,9 @@ impl WorkerJobController {
 
             // now we can finalize the commit
             match complete_commit(
-                get_storage_provider().await?.as_ref(),
+                get_storage_provider(&StorageProviderFor::Worker)
+                    .await?
+                    .as_ref(),
                 &commit_permit,
                 Generation(self.worker_context.generation),
             )

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -18,7 +18,7 @@ use arroyo_rpc::grpc::rpc::{
 use arroyo_rpc::identity::WorkerClient;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_state::parquet::ParquetBackend;
-use arroyo_state::{BackingStore, StateBackend, get_storage_provider};
+use arroyo_state::{BackingStore, StateBackend, StorageProviderFor, get_storage_provider};
 use arroyo_state_protocol::ProtocolPaths;
 use arroyo_state_protocol::types::{CheckpointRef, Epoch, Generation, GenerationManifest};
 use arroyo_state_protocol::workflow::{
@@ -56,6 +56,21 @@ pub struct RunningJobModel {
     pub finished_operators: Vec<OperatorCheckpointMetadata>,
 
     pub worker_leader_mode: bool,
+
+    /// Identifies which process / role is running this model and where its
+    /// checkpoint storage lives.
+    ///
+    /// On the worker-leader process, this is [`StorageProviderFor::Worker`]:
+    /// the worker resolves its URL from `config().checkpoint_url` (set
+    /// per-pipeline via `ARROYO__CHECKPOINT_URL` at worker startup).
+    ///
+    /// On the controller process, this is
+    /// [`StorageProviderFor::Controller`] carrying the pipeline's
+    /// `state_url`. The controller's own `config().checkpoint_url` is a
+    /// global default that doesn't differ across pipelines, so the
+    /// per-pipeline override is needed to route storage operations to the
+    /// right URL.
+    pub storage_role: StorageProviderFor,
 
     // checkpoint-wide events
     pub checkpoint_spans: Vec<JobCheckpointSpan>,
@@ -145,6 +160,7 @@ impl RunningJobModel {
         msg: RunningMessage,
         store: &dyn CheckpointMetadataStore,
     ) -> anyhow::Result<()> {
+        let storage_role = self.storage_role.clone();
         match msg {
             RunningMessage::TaskCheckpointEvent(c) => {
                 if let Some(checkpoint_state) = &mut self.checkpoint_state {
@@ -200,8 +216,11 @@ impl RunningJobModel {
                             if self.worker_leader_mode {
                                 self.finished_operators.push(operator_metadata);
                             } else {
-                                StateBackend::write_operator_checkpoint_metadata(operator_metadata)
-                                    .await?;
+                                StateBackend::write_operator_checkpoint_metadata(
+                                    &storage_role,
+                                    operator_metadata,
+                                )
+                                .await?;
                             }
                         }
 
@@ -374,12 +393,14 @@ impl RunningJobModel {
             epoch = self.epoch,
         );
 
+        let storage_role = self.storage_role.clone();
         let mut worker_clients: Vec<WorkerClient> =
             self.workers.values().map(|w| w.connect.clone()).collect();
         for node in self.program.graph.node_weights() {
             for (op, _) in node.operator_chain.iter() {
                 let compacted_tables = ParquetBackend::compact_operator(
                     // compact the operator's state and notify the workers to load the new files
+                    &storage_role,
                     self.job_id.0.clone(),
                     &op.operator_id,
                     self.epoch,
@@ -417,7 +438,7 @@ impl RunningJobModel {
         store: &dyn CheckpointMetadataStore,
     ) -> anyhow::Result<()> {
         let state = self.checkpoint_state.take().unwrap();
-        let storage = get_storage_provider().await?;
+        let storage = get_storage_provider(&self.storage_role).await?;
         match state {
             CheckpointingOrCommittingState::Checkpointing(mut checkpointing) => {
                 let pipeline_id = (*self.pipeline_id).clone();
@@ -623,6 +644,7 @@ impl RunningJobModel {
         &mut self,
         store: &dyn CheckpointMetadataStore,
     ) -> anyhow::Result<()> {
+        let storage_role = self.storage_role.clone();
         let state = self.checkpoint_state.take().unwrap();
         match state {
             CheckpointingOrCommittingState::Checkpointing(mut checkpointing) => {
@@ -630,7 +652,7 @@ impl RunningJobModel {
 
                 let metadata = checkpointing.build_metadata();
 
-                StateBackend::write_checkpoint_metadata(metadata).await?;
+                StateBackend::write_checkpoint_metadata(&storage_role, metadata).await?;
 
                 metadata_span.finish();
 

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -57,7 +57,7 @@ use arroyo_rpc::{
 
 use arroyo_server_common::shutdown::{CancellationToken, ShutdownGuard};
 use arroyo_server_common::wrap_start;
-use arroyo_state::get_storage_provider;
+use arroyo_state::{StorageProviderFor, get_storage_provider};
 use arroyo_state_protocol::store::read_protobuf;
 use arroyo_state_protocol::types::CheckpointRef;
 pub use ordered_float::OrderedFloat;
@@ -343,7 +343,9 @@ impl WorkerState {
 
         let parent = if let Some(parent_ref) = parent_ref {
             let manifest = read_protobuf::<_, CheckpointManifest>(
-                get_storage_provider().await?.as_ref(),
+                get_storage_provider(&StorageProviderFor::Worker)
+                    .await?
+                    .as_ref(),
                 &parent_ref,
             )
             .await?

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -205,7 +205,9 @@ export interface paths {
         put?: never;
         /**
          * Create a new pipeline
-         * @description The API will create a single job for the pipeline.
+         * @description The API will create a single job for the pipeline. The server generates
+         *     a fresh id for the pipeline; if the caller wants to supply its own
+         *     stable id, use `PUT /pipelines/{id}` instead.
          */
         post: operations["create_pipeline"];
         delete?: never;
@@ -257,7 +259,16 @@ export interface paths {
         };
         /** Get a single pipeline */
         get: operations["get_pipeline"];
-        put?: never;
+        /**
+         * Create a new pipeline at a caller-supplied id
+         * @description The API will create a single job for the pipeline, using the
+         *     supplied `id`. Useful when an upstream system wants to address
+         *     the pipeline by an id it already manages.
+         *
+         *     The endpoint is currently create-only: PUTing twice with the same id
+         *     returns a 400 (duplicate-violation) rather than upserting.
+         */
+        put: operations["put_pipeline"];
         post?: never;
         /** Delete a pipeline */
         delete: operations["delete_pipeline"];
@@ -708,7 +719,10 @@ export interface components {
             data: components["schemas"]["JobLogMessage"][];
             hasMore: boolean;
         };
+        /** @enum {string} */
+        JsonCompression: "uncompressed" | "gzip";
         JsonFormat: {
+            compression?: components["schemas"]["JsonCompression"];
             confluent_schema_registry?: boolean;
             debezium?: boolean;
             decimal_encoding?: components["schemas"]["DecimalEncoding"];
@@ -841,6 +855,10 @@ export interface components {
             /** Format: int64 */
             parallelism: number;
             query: string;
+            state_url?: string | null;
+            tags?: {
+                [key: string]: string;
+            } | null;
             udfs?: components["schemas"]["Udf"][] | null;
         };
         PipelineRestart: {
@@ -1366,6 +1384,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Pipeline"];
+                };
+            };
+        };
+    };
+    put_pipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Caller-supplied pipeline id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PipelinePost"];
+            };
+        };
+        responses: {
+            /** @description Created pipeline and job */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Pipeline"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResp"];
                 };
             };
         };


### PR DESCRIPTION
Adds two new optional pipeline-level metadata columns:

  * state_url: per-pipeline override for the worker's checkpoint URL. NULL falls back to controller config().checkpoint_url.
  * tags: a JSONB map of opaque key/value strings, exposed as a PipelineTags newtype on the API surface.

Both are optional on PipelinePost and default to NULL, so existing clients are unaffected.

Refactors the controller's job-startup path to load this data once at boot via a new PipelineInfo struct (carrying pipeline_id, state_url, tags) wrapped in Arc and threaded through JobContext, replacing the prior raw pipeline_pub_id String. The scheduling state now reads state_url from PipelineInfo to populate the worker's ARROYO__CHECKPOINT_URL env var, and forwards tags to the scheduler via StartPipelineReq.pipeline_tags.

There is also quite a bit of plumbing throughout the codebase to pass this new `state_url` around.

This PR also adds a pipeline PUT API that let's the user specify the pipeline ID.

**Testing**
The changes were tested locally, by creating 3 pipelines that have different `state_url`, and making sure that the checkpoint information was going to the right place. I also tested recovery by stopping/starting pipelines.

Pipelines config:
```
❯ rg state_url /tmp/pipeline-*
/tmp/pipeline-a.json
2:  "name": "test_state_url_a",
6:  "state_url": "file:///tmp/arroyo-test/checkpoints-a",

/tmp/pipeline-b.json
2:  "name": "test_state_url_b",
6:  "state_url": "file:///tmp/arroyo-test/checkpoints-b",

/tmp/pipeline-default.json
2:  "name": "test_no_state_url",
```
The DB:
```
SELECT name, state_url, tags
FROM pipelines
WHERE name LIKE 'test_%'
ORDER BY created_at DESC LIMIT 3;"
       name        |               state_url               |        tags
-------------------+---------------------------------------+---------------------
 test_no_state_url |                                       | {"test": "default"}
 test_state_url_b  | file:///tmp/arroyo-test/checkpoints-b | {"test": "b"}
 test_state_url_a  | file:///tmp/arroyo-test/checkpoints-a | {"test": "a"}
```

Also made sure that the new PUT API handled ID conflicts properly:
```
❯ curl -sS -X PUT http://localhost:5115/api/v1/pipelines/test_state_url_b -H 'Content-Type: application/json' -d @/tmp/pipeline-b.json | jq .
{
  "error": "A record already exists with that name or id"
}
```