### PR TITLE
Redact Sensitive<T> Debug output to avoid leaking secrets

### DIFF
--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -880,8 +880,14 @@ pub struct RunConfig {
     pub state_dir: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Sensitive<T: Serialize + DeserializeOwned + Debug + Clone>(T);
+
+impl<T: Serialize + DeserializeOwned + Debug + Clone> std::fmt::Debug for Sensitive<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{SENSITIVE_MASK}")
+    }
+}
 
 impl<'de, T: Serialize + DeserializeOwned + Debug + Clone> Deserialize<'de> for Sensitive<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
**Testing**
Before:
```
     Running `target/debug/arroyo migrate`
2026-05-06T23:07:41.235772Z ERROR arroyo: Failed to connect to database PostgresConfig { database_name: "arroyo", host: "123.123.123", port: 5432, user: "arroyo", password: Sensitive("password"), schema: "public" }: error connecting to server: Network is unreachable (os error 51)
```
After
```
     Running `target/debug/arroyo migrate`
2026-05-06T23:05:17.547429Z ERROR arroyo: Failed to connect to database PostgresConfig { database_name: "arroyo", host: "123.123.123", port: 5432, user: "arroyo", password: *********, schema: "public" }: error connecting to server: Network is unreachable (os error 51)
```