### PR TITLE
Support state machine adoption of existing clusters in leader mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "bincode",
  "chrono",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/arroyo-api/migrations/V29__add_job_state_context.sql
+++ b/crates/arroyo-api/migrations/V29__add_job_state_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_statuses ADD COLUMN state_context JSONB DEFAULT '{"version": 1}' NOT NULL;

--- a/crates/arroyo-api/sqlite_migrations/V7__add_job_state_context.sql
+++ b/crates/arroyo-api/sqlite_migrations/V7__add_job_state_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_statuses ADD COLUMN state_context TEXT DEFAULT '{"version": 1}' NOT NULL;

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -21,7 +21,8 @@ SELECT
     c.restart_nonce as config_restart_nonce,
     s.restart_nonce as status_restart_nonce,
     restart_mode,
-    ignore_state_before_epoch
+    ignore_state_before_epoch,
+    state_context
 FROM job_configs c
 INNER JOIN job_statuses s ON c.id = s.id;
 
@@ -37,7 +38,8 @@ SET state = :state,
     pipeline_path = :pipeline_path,
     wasm_path = :wasm_path,
     run_id = :run_id,
-    restart_nonce = :restart_nonce
+    restart_nonce = :restart_nonce,
+    state_context = :state_context
 WHERE id = :job_id;
 
 --! get_program : PipelineRow(state_url?)

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -8,23 +8,36 @@ use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient;
 use arroyo_rpc::grpc::rpc::{JobFailure, JobState, JobStatusReq, JobStopMode, StopJobReq};
+use arroyo_rpc::identity::InjectWorkerId;
 use arroyo_rpc::{job_status_client, retry};
-use arroyo_types::JobId;
+use arroyo_types::{JobId, WorkerId};
 use std::time::{Duration, Instant};
+use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
 pub struct LeaderManager {
-    leader_client: JobStatusGrpcClient<Channel>,
+    leader_client: JobStatusGrpcClient<InterceptedService<Channel, InjectWorkerId>>,
     pub job_id: JobId,
     pub generation: u64,
     pub last_heartbeat: Instant,
 }
 
 impl LeaderManager {
-    pub async fn connect(job_id: JobId, run_id: u64, addr: String) -> anyhow::Result<Self> {
+    pub async fn connect(
+        job_id: JobId,
+        generation: u64,
+        worker_id: WorkerId,
+        address: String,
+    ) -> anyhow::Result<Self> {
         let leader_client = retry!(
-            job_status_client("controller", &config().worker.tls, addr.clone()).await,
+            job_status_client(
+                "controller",
+                &config().worker.tls,
+                worker_id,
+                address.clone()
+            )
+            .await,
             5,
             Duration::from_millis(100),
             Duration::from_secs(2),
@@ -33,7 +46,7 @@ impl LeaderManager {
 
         Ok(Self {
             job_id,
-            generation: run_id,
+            generation,
             leader_client,
             last_heartbeat: Instant::now(),
         })

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -22,7 +22,7 @@ use arroyo_rpc::grpc::rpc::{
 };
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
-use arroyo_rpc::{config, errors};
+use arroyo_rpc::{StateContext, config, errors};
 use arroyo_server_common::shutdown::ShutdownGuard;
 use arroyo_server_common::wrap_start;
 use arroyo_types::{MachineId, PipelineId, WorkerId, from_micros};
@@ -97,6 +97,7 @@ pub struct JobStatus {
     pipeline_path: Option<String>,
     wasm_path: Option<String>,
     restart_nonce: i32,
+    state_context: StateContext,
 }
 
 impl JobStatus {
@@ -115,6 +116,7 @@ impl JobStatus {
             &self.wasm_path,
             &(self.generation as i64),
             &self.restart_nonce,
+            &serde_json::to_value(&self.state_context).expect("failed to serialize"),
             &*self.id,
         )
         .await
@@ -627,6 +629,16 @@ impl ControllerServer {
 
                     let mut jobs = jobs.lock().await;
 
+                    let state_context: StateContext =
+                        serde_json::from_value(p.state_context.clone()).unwrap_or_else(|e| {
+                            warn!(job_id = *id, original =? p.state_context, error =? e,
+                                "failed to deserialize state context");
+                            StateContext {
+                                version: 1,
+                                leader: None,
+                            }
+                        });
+
                     let status = JobStatus {
                         id: id.clone(),
                         generation: p.run_id.unwrap_or(0).max(0) as u64,
@@ -640,6 +652,7 @@ impl ControllerServer {
                         pipeline_path: p.pipeline_path,
                         wasm_path: p.wasm_path,
                         restart_nonce: p.status_restart_nonce,
+                        state_context,
                     };
 
                     if let Some(sm) = jobs.get_mut(&*id) {

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -188,7 +188,7 @@ impl Scheduler for ProcessScheduler {
                     .env(PIPELINE_ID_ENV, &*pipeline_id)
                     .env(JOB_ID_ENV, &*job_id)
                     .env(GENERATION_ENV, format!("{}", start_pipeline_req.generation))
-                    .kill_on_drop(true)
+                    .kill_on_drop(config.process_scheduler.shutdown_with_controller)
                     .spawn()
                 {
                     Ok(child) => child,
@@ -214,14 +214,16 @@ impl Scheduler for ProcessScheduler {
                         info!("Child ({:?}) exited with status {:?}", path, status);
                     }
                     _ = rx => {
-                        info!(message = "Killing child", worker_id = worker_id, job_id = *job_id);
-                        if let Err(e) = child.kill().await {
-                            warn!(
-                                message = "failed to kill process scheduler worker",
-                                worker_id,
-                                job_id = %job_id,
-                                error = format!("{:?}", e),
-                            );
+                        if config.process_scheduler.shutdown_with_controller {
+                            info!(message = "Killing child", worker_id = worker_id, job_id = *job_id);
+                            if let Err(e) = child.kill().await {
+                                warn!(
+                                    message = "failed to kill process scheduler worker",
+                                    worker_id,
+                                    job_id = %job_id,
+                                    error = format!("{:?}", e),
+                                );
+                            }
                         }
                     }
                 }
@@ -284,7 +286,7 @@ impl Scheduler for ProcessScheduler {
     async fn shutdown(&self) {
         let workers: Vec<_> = self.workers.lock().await.drain().collect();
 
-        if workers.is_empty() {
+        if workers.is_empty() || !config().process_scheduler.shutdown_with_controller {
             return;
         }
 

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -1,4 +1,4 @@
-use super::{JobContext, State, Transition};
+use super::{JobContext, State, Transition, controller_job_failure};
 use crate::JobMessage;
 use crate::states::leader_finishing::LeaderFinishing;
 use crate::states::leader_rescaling::LeaderRescaling;
@@ -36,6 +36,34 @@ impl State for LeaderRunning {
 
         leader_stop_if_desired_running!(self, ctx.config, ctx);
 
+        if ctx.leader_manager.is_none() {
+            return ctx
+                .handle_job_failure(
+                    *self,
+                    controller_job_failure(
+                        "leader_manager was None entering Running state",
+                        ErrorDomain::Internal,
+                        RetryHint::WithBackoff,
+                    ),
+                )
+                .await;
+        }
+
+        if ctx.leader_manager().generation != ctx.status.generation {
+            let generation = ctx.status.generation;
+            let msg = format!(
+                "leader_manager has incorrect generation (expected {}, found {})",
+                generation,
+                ctx.leader_manager().generation
+            );
+            return ctx
+                .handle_job_failure(
+                    *self,
+                    controller_job_failure(msg, ErrorDomain::Internal, RetryHint::WithBackoff),
+                )
+                .await;
+        }
+
         let operator_parallelism = ctx.program.tasks_per_node();
 
         loop {
@@ -45,17 +73,14 @@ impl State for LeaderRunning {
                 return ctx
                     .handle_job_failure(
                         *self,
-                        JobFailure {
-                            operator_id: None,
-                            task_id: None,
-                            subtask_index: None,
-                            message: format!(
+                        controller_job_failure(
+                            format!(
                                 "no response from job controller after {} seconds",
                                 pipeline_config.worker_heartbeat_timeout.as_secs()
                             ),
-                            error_domain: ErrorDomain::Internal as i32,
-                            retry_hint: RetryHint::WithBackoff as i32,
-                        },
+                            ErrorDomain::Internal,
+                            RetryHint::WithBackoff,
+                        ),
                     )
                     .await;
             }

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -34,13 +34,15 @@ use crate::queries::controller_queries;
 use crate::types::public::{LogLevel, StopMode};
 use crate::{JobConfig, JobMessage, JobStatus, PipelineInfo, queries, schedulers::Scheduler};
 use arroyo_datastream::logical::LogicalProgram;
-use arroyo_rpc::config::config;
+use arroyo_rpc::config::{JobControllerMode, config};
 use arroyo_rpc::errors::ErrorDomain;
+use arroyo_rpc::grpc::rpc;
+use arroyo_rpc::grpc::rpc::JobFailure;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
 use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent};
 use arroyo_rpc::{errors, log_event};
 use arroyo_server_common::shutdown::ShutdownGuard;
-use arroyo_types::PipelineId;
+use arroyo_types::{JobId, PipelineId};
 use prost::Message;
 
 pub(crate) mod checkpoint_stopping;
@@ -533,6 +535,21 @@ macro_rules! leader_stop_if_desired_running {
     };
 }
 
+pub fn controller_job_failure(
+    message: impl Into<String>,
+    error_domain: rpc::ErrorDomain,
+    retry_hint: rpc::RetryHint,
+) -> JobFailure {
+    JobFailure {
+        operator_id: None,
+        task_id: None,
+        subtask_index: None,
+        message: message.into(),
+        error_domain: error_domain as i32,
+        retry_hint: retry_hint as i32,
+    }
+}
+
 use crate::job_controller::job_metrics::JobMetrics;
 use crate::job_controller::leader_manager::LeaderManager;
 use crate::states::restarting::Restarting;
@@ -905,8 +922,31 @@ async fn run_to_completion(
     scheduler: Arc<dyn Scheduler>,
     metrics: Arc<tokio::sync::RwLock<HashMap<Arc<String>, JobMetrics>>>,
 ) {
+    let job_config = config.read().unwrap().0.clone();
+
+    let leader_manager = if let Some(ctx) = &status.state_context.leader {
+        LeaderManager::connect(
+            JobId(job_config.id.clone()),
+            ctx.generation,
+            ctx.worker_id,
+            ctx.rpc_address.clone(),
+        )
+        .await
+        .map(Some)
+        .unwrap_or_else(|e| {
+            warn!(job_id = *job_config.id,
+                    pipeline_id = *pipeline_info.pipeline_id,
+                    leader_ctx =? ctx,
+                    error =? e,
+                    "failed to connect to leader worker on start");
+            None
+        })
+    } else {
+        None
+    };
+
     let mut ctx = JobContext {
-        config: config.read().unwrap().0.clone(),
+        config: job_config,
         pipeline_info,
         status: &mut status,
         program: &mut program,
@@ -915,7 +955,7 @@ async fn run_to_completion(
         rx: &mut rx,
         retries_attempted: 0,
         job_controller: None,
-        leader_manager: None,
+        leader_manager,
         last_transitioned_at: Instant::now(),
         metrics,
     };
@@ -1023,12 +1063,17 @@ impl StateMachine {
             return;
         }
 
+        let leader_mode = matches!(config().job_controller, JobControllerMode::Worker);
+
         // TODO: This seems pretty error-prone and easy to miss adding when we add states
         let initial_state: Option<Box<dyn State>> = match status.state.as_str() {
             "Created" => Some(Box::new(Created {})),
             "Stopped" => Some(Box::new(Stopped {})),
             "Finished" => Some(Box::new(Finished {})),
             "Failed" => Some(Box::new(Failed {})),
+            "Running" if leader_mode => Some(Box::new(LeaderRunning {
+                started: Instant::now(),
+            })),
             "Compiling" | "Scheduling" | "Running" | "Recovering" | "Rescaling" | "Restarting" => {
                 Some(Box::new(Compiling {}))
             }

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -166,6 +166,11 @@ impl Recovering {
             }
         };
 
+        // clear workers
+        ctx.leader_manager = None;
+        ctx.status.state_context.leader = None;
+        ctx.job_controller = None;
+
         // then tear down the workers
         retry!(
             Self::tear_down_workers(ctx).await,

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -27,8 +27,8 @@ use anyhow::{anyhow, bail};
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_rpc::config::{JobControllerMode, config};
 use arroyo_rpc::grpc::api;
-use arroyo_rpc::grpc_channel_builder;
 use arroyo_rpc::worker_types::RunningMessage;
+use arroyo_rpc::{LeaderContext, grpc_channel_builder};
 use arroyo_state::{
     BackingStore, StateBackend, StorageProviderFor, get_storage_provider,
     tables::{ErasedTable, global_keyed_map::GlobalKeyedTable},
@@ -167,7 +167,7 @@ async fn handle_worker_connect<'a>(
                         Ok(channel) => {
                             {
                                 let mut connects = connects.lock().await;
-                                connects.insert(worker_id, worker_client(channel, *worker_id));
+                                connects.insert(worker_id, worker_client(channel, worker_id));
                             }
                             return;
                         }
@@ -695,15 +695,13 @@ impl State for Scheduling {
             .map(|info| info.min_epoch)
             .unwrap_or(default_epoch);
 
-        let (leader_id, leader_addr) = leader_mode
-            .then(|| {
-                workers
-                    .iter()
-                    .min_by_key(|w| w.0.0)
-                    .map(|(id, status)| (*id, status.rpc_address.clone()))
-                    .unwrap()
-            })
-            .unzip();
+        let leader_info = leader_mode.then(|| {
+            workers
+                .iter()
+                .min_by_key(|w| w.0.0)
+                .map(|(id, status)| (*id, status.rpc_address.clone()))
+                .unwrap()
+        });
 
         let checkpoint_interval_micros = ctx.config.checkpoint_interval.as_micros() as u64;
 
@@ -715,10 +713,10 @@ impl State for Scheduling {
                 let restore_epoch = checkpoint_info.as_ref().map(|info| info.epoch);
                 let program = program.clone();
                 let machine_id = workers.get(&id).as_ref().unwrap().machine_id.clone();
-                let leader_addr = leader_addr.clone();
+                let (leader_id, leader_addr) = leader_info.clone().unzip();
+
                 let checkpoint_manifest_ref =
                     leader_id.and(checkpoint_info.as_ref().map(|ci| ci.id.clone()));
-
                 tokio::spawn(async move {
                     info!(
                         message = "starting execution on worker",
@@ -863,7 +861,7 @@ impl State for Scheduling {
             .await
             .insert(ctx.config.id.clone(), metrics.clone());
 
-        match leader_addr {
+        match leader_info {
             None => {
                 let checkpoint_store = Arc::new(DbCheckpointMetadataStore {
                     organization_id: ctx.config.organization_id.clone(),
@@ -895,13 +893,14 @@ impl State for Scheduling {
                 ctx.job_controller = Some(controller);
                 Ok(Transition::next(*self, Running {}))
             }
-            Some(leader_addr) => {
+            Some((id, addr)) => {
                 ctx.job_controller = None;
 
                 let leader_manager = match LeaderManager::connect(
                     JobId(ctx.config.id.clone()),
                     ctx.status.generation,
-                    leader_addr,
+                    id,
+                    addr.clone(),
                 )
                 .await
                 {
@@ -917,6 +916,11 @@ impl State for Scheduling {
                 };
 
                 ctx.leader_manager = Some(leader_manager);
+                ctx.status.state_context.leader = Some(LeaderContext {
+                    worker_id: id,
+                    rpc_address: addr,
+                    generation: ctx.status.generation,
+                });
 
                 Ok(Transition::next(
                     *self,

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -63,6 +63,7 @@ http-port = 5114
 
 [process-scheduler]
 slots-per-process = 16
+shutdown-with-controller = true
 
 [kubernetes-scheduler]
 namespace = "default"

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -685,6 +685,10 @@ pub enum Scheduler {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ProcessSchedulerConfig {
     pub slots_per_process: u32,
+    /// If enabled, the workers spun up by the process scheduler will be killed when the controller
+    /// shuts down. Note if disabled, this may orphan workers -- this is primarily used for testing
+    /// state machine recovery.
+    pub shutdown_with_controller: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/arroyo-rpc/src/identity.rs
+++ b/crates/arroyo-rpc/src/identity.rs
@@ -7,14 +7,14 @@
 //! 64-bit random values in production, so they are effectively globally
 //! unique across jobs, runs, and clusters.
 
+use crate::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
+use arroyo_types::WorkerId;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
 use tracing::warn;
-
-use crate::grpc::rpc::worker_grpc_client::WorkerGrpcClient;
 
 /// Target worker_id header, ASCII decimal.
 pub const WORKER_ID_HEADER: &str = "x-target-worker-id";
@@ -23,7 +23,7 @@ pub const WORKER_ID_HEADER: &str = "x-target-worker-id";
 pub type WorkerClient = WorkerGrpcClient<InterceptedService<Channel, InjectWorkerId>>;
 
 /// Construct a worker client that injects `target` as `x-target-worker-id`.
-pub fn worker_client(channel: Channel, target: u64) -> WorkerClient {
+pub fn worker_client(channel: Channel, target: WorkerId) -> WorkerClient {
     WorkerGrpcClient::with_interceptor(channel, InjectWorkerId::new(target))
 }
 
@@ -32,7 +32,7 @@ pub fn worker_client(channel: Channel, target: u64) -> WorkerClient {
 pub struct InjectWorkerId(MetadataValue<Ascii>);
 
 impl InjectWorkerId {
-    pub fn new(target: u64) -> Self {
+    pub fn new(target: WorkerId) -> Self {
         Self(
             target
                 .to_string()
@@ -87,7 +87,9 @@ mod tests {
     #[test]
     fn inject_writes_decimal_metadata() {
         for id in [0, 42, 1234567890, u64::MAX] {
-            let req = InjectWorkerId::new(id).call(Request::new(())).unwrap();
+            let req = InjectWorkerId::new(WorkerId(id))
+                .call(Request::new(()))
+                .unwrap();
             let parsed: u64 = req
                 .metadata()
                 .get(WORKER_ID_HEADER)
@@ -133,7 +135,7 @@ mod tests {
 
     #[test]
     fn round_trip_through_both_interceptors() {
-        let req = InjectWorkerId::new(1234567890)
+        let req = InjectWorkerId::new(WorkerId(1234567890))
             .call(Request::new(()))
             .unwrap();
         VerifyWorkerId(1234567890).call(req).unwrap();

--- a/crates/arroyo-rpc/src/lib.rs
+++ b/crates/arroyo-rpc/src/lib.rs
@@ -13,13 +13,15 @@ use crate::grpc::api::TaskCheckpointDetail;
 use crate::grpc::rpc::controller_grpc_client::ControllerGrpcClient;
 use crate::grpc::rpc::{
     CheckpointManifest, CheckpointMetadata, LoadCompactedDataReq, SubtaskCheckpointMetadata,
+    job_controller_grpc_client, job_status_grpc_client,
 };
+use crate::identity::InjectWorkerId;
 use anyhow::{Context, Result, anyhow};
 use arrow::compute::kernels::cast_utils::parse_interval_day_time;
 use arrow::row::{OwnedRow, RowConverter, RowParser, Rows, SortField};
 use arrow_array::{Array, ArrayRef, BooleanArray};
 use arrow_schema::{ArrowError, DataType, Field, Fields};
-use arroyo_types::{CheckpointBarrier, HASH_SEEDS};
+use arroyo_types::{CheckpointBarrier, HASH_SEEDS, WorkerId};
 use bincode::de::Decoder;
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
@@ -55,6 +57,7 @@ use tokio::sync::{
     mpsc::{Receiver, Sender, channel},
     oneshot,
 };
+use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Identity};
 use tonic::{
     metadata::{Ascii, MetadataValue},
@@ -1067,7 +1070,7 @@ pub async fn job_controller_client(
     our_tls: &Option<TlsConfig>,
     addr: String,
     is_worker_job_controller: bool,
-) -> Result<crate::grpc::rpc::job_controller_grpc_client::JobControllerGrpcClient<Channel>> {
+) -> Result<job_controller_grpc_client::JobControllerGrpcClient<Channel>> {
     let their_tls = if is_worker_job_controller {
         &config().worker.tls
     } else {
@@ -1075,16 +1078,25 @@ pub async fn job_controller_client(
     };
 
     let channel = connect_grpc(our_name, addr, our_tls, their_tls).await?;
-    Ok(crate::grpc::rpc::job_controller_grpc_client::JobControllerGrpcClient::new(channel))
+    Ok(job_controller_grpc_client::JobControllerGrpcClient::new(
+        channel,
+    ))
 }
 
 pub async fn job_status_client(
     our_name: &str,
     our_tls: &Option<TlsConfig>,
+    worker_id: WorkerId,
     addr: String,
-) -> Result<crate::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient<Channel>> {
-    let channel = connect_grpc(our_name, addr, our_tls, &config().controller.tls).await?;
-    Ok(crate::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient::new(channel))
+) -> Result<job_status_grpc_client::JobStatusGrpcClient<InterceptedService<Channel, InjectWorkerId>>>
+{
+    let channel = connect_grpc(our_name, addr, our_tls, &config().worker.tls).await?;
+    Ok(
+        job_status_grpc_client::JobStatusGrpcClient::with_interceptor(
+            channel,
+            InjectWorkerId::new(worker_id),
+        ),
+    )
 }
 
 pub fn local_address(bind_address: IpAddr) -> String {
@@ -1229,6 +1241,19 @@ impl_borrow_decode!(SerializableBytes);
 pub enum MetadataOrManifest {
     Metadata(CheckpointMetadata),
     Manifest(CheckpointManifest),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LeaderContext {
+    pub worker_id: WorkerId,
+    pub rpc_address: String,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StateContext {
+    pub version: u32,
+    pub leader: Option<LeaderContext>,
 }
 
 #[cfg(test)]

--- a/crates/arroyo-types/Cargo.toml
+++ b/crates/arroyo-types/Cargo.toml
@@ -9,3 +9,4 @@ chrono = "0.4"
 serde = { version = "1.0", features = ["derive", "rc"] }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
+tracing = "0.1.44"

--- a/crates/arroyo-types/src/lib.rs
+++ b/crates/arroyo-types/src/lib.rs
@@ -27,7 +27,8 @@ pub const HASH_SEEDS: [u64; 4] = [
     17942305062735447798,
 ];
 
-#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct WorkerId(pub u64);
 
 impl Deref for WorkerId {

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -127,7 +127,7 @@ pub(crate) async fn connect_to_worker(id: WorkerId, addr: String) -> anyhow::Res
         .connect()
         .await
         {
-            Ok(channel) => return Ok(worker_client(channel, *id)),
+            Ok(channel) => return Ok(worker_client(channel, id)),
             Err(e) => {
                 error!(
                     message = "Failed to connect to worker",

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -724,7 +724,10 @@ impl WorkerServer {
                             VerifyWorkerId(*context.worker_id),
                         ))
                         .add_service(JobControllerGrpcServer::new(leader.clone()))
-                        .add_service(JobStatusGrpcServer::new(leader))
+                        .add_service(JobStatusGrpcServer::with_interceptor(
+                            leader,
+                            VerifyWorkerId(*context.worker_id),
+                        ))
                         .serve_with_incoming(TcpListenerStream::new(listener))
                 } else {
                     info!("Started worker-rpc on {}", local_addr);
@@ -734,7 +737,10 @@ impl WorkerServer {
                             VerifyWorkerId(*context.worker_id),
                         ))
                         .add_service(JobControllerGrpcServer::new(leader.clone()))
-                        .add_service(JobStatusGrpcServer::new(leader))
+                        .add_service(JobStatusGrpcServer::with_interceptor(
+                            leader,
+                            VerifyWorkerId(*context.worker_id),
+                        ))
                         .serve_with_incoming(TcpListenerStream::new(listener))
                 },
             ));


### PR DESCRIPTION
This PR continues the work to enable pipeline clusters (the Arroyo data plane) to operate independently of the controller (control plane). Before we introduced the worker leader mode in #1035, the workers were completely dependent on the controller to operate, and if the controller became unavailable the workers would shutdown. And so the controller, on startup, could just assume that all existing clusters were shut down or could be shut down, and would start over with a new cluster.

However, now that clusters can survive controller downtime, this is no longer desirable behavior. Here, we allow (in leader mode) the controller to adopt a running cluster from a previous controller process back into Running mode, so that there is no interruption to the worker cluster.

In order to do so, we need to store a bit more information, in particular the cluster leader's WorkerId and address, so that we can reconnect to it. This is added a new JSON column in the job_status table.

Currently we will only attempt adoption if the job is in Running. In the future, we may extend this to other states as well to further reduce the disruption of controller restarts.

In addition to the core change, there are a few other improvements:
* We've added worker id verification to the controller -> job status RPCs
* We're now correctly clearing the worker connection cache once we move into recovering
* We've added an option on the process scheduler to allow workers to survive controller (i.e., their parent process) shutdown, to make testing these features locally easier