### PR TITLE
Return 404 instead of 400 in PATCH pipeline

### DIFF
--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -757,7 +757,7 @@ pub async fn patch_pipeline(
             .await?
             .into_iter()
             .next()
-            .ok_or_else(|| bad_request("There are no jobs for the pipeline"))?
+            .ok_or_else(|| not_found("Job for pipeline"))?
             .id;
 
     let interval = pipeline_patch


### PR DESCRIPTION
**Testing**
Before
```
❯ curl -i -X PATCH http://localhost:5115/api/v1/pipelines/pl_doesnotexist -H 'Content-Type: application/json' -d '{"parallelism": 2}'
HTTP/1.1 400 Bad Request
content-type: application/json
vary: origin, access-control-request-method, access-control-request-headers
vary: accept-encoding
access-control-allow-origin: *
content-length: 46
date: Tue, 12 May 2026 17:57:22 GMT

{"error":"There are no jobs for the pipeline"}%
```
After
```

❯ curl -i -X PATCH http://localhost:5115/api/v1/pipelines/pl_doesnotexist -H 'Content-Type: application/json' -d '{"parallelism": 2}'
HTTP/1.1 404 Not Found
content-type: application/json
vary: origin, access-control-request-method, access-control-request-headers
vary: accept-encoding
access-control-allow-origin: *
content-length: 38
date: Tue, 12 May 2026 17:58:36 GMT

{"error":"Job for pipeline not found"}%
```