### PR TITLE
Move common crates to the workspace's Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,6 @@ dependencies = [
  "arrow-array",
  "arrow-ord",
  "arrow-schema",
- "arroyo-datastream",
  "arroyo-rpc",
  "arroyo-storage",
  "arroyo-types",
@@ -1026,7 +1025,6 @@ dependencies = [
  "bincode",
  "chrono",
  "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1090,7 +1088,7 @@ dependencies = [
  "arrow",
  "arroyo-udf-common",
  "datafusion",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "pyo3",
  "tokio",
 ]
@@ -1120,7 +1118,7 @@ dependencies = [
  "datafusion",
  "datafusion-proto",
  "futures",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "mini-moka",
  "ordered-float 3.9.2",
  "petgraph 0.8.2",
@@ -5691,15 +5689,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,35 @@ tokio-rustls = "0.26.2"
 rustls-pemfile = "2.2.0"
 webpki-roots = "1.0.0"
 bincode = "2.0.0-rc.3"
+anyhow = "1.0.82"
+async-trait = "0.1.80"
+base64 = "0.22.1"
+bytes = "1.11.1"
+chrono = "0.4"
+dirs = "6"
+dlopen2 = { version = "0.7", features = ["derive"] }
+flate2 = "1.0.30"
+futures = "0.3.30"
+http = "1"
+itertools = "0.14.0"
+lazy_static = "1.4.0"
+once_cell = "1.17.1"
+regex = "1.10.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+strum = { version = "0.27", features = ["derive"] }
+strum_macros = "0.27"
+syn = { version = "2", features = ["full"] }
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
+tokio-stream = { version = "0.1", features = ["full"] }
+toml = "0.8.13"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
+typify = "0.0.13"
+url = { version = "2.5", features = ["serde"] }
+uuid = { version = "1.17.0", features = ["v4"] }
 
 [profile.release]
 debug = 1

--- a/crates/arroyo-api/Cargo.toml
+++ b/crates/arroyo-api/Cargo.toml
@@ -21,8 +21,8 @@ arroyo-udf-python = { path = "../arroyo-udf/arroyo-udf-python" }
 
 tonic = { workspace = true }
 prost = {workspace = true}
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1.12"
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tower = {workspace = true}
 
 arrow = { workspace = true }
@@ -30,35 +30,35 @@ arrow-schema = {workspace = true, features = ["serde"]}
 
 petgraph = {workspace = true, features = ["serde-1"]}
 
-http = "1"
+http = { workspace = true }
 tower-http = { workspace = true, features = ["trace", "fs", "cors", "validate-request", "auth", "compression-zstd"]}
 axum = {workspace = true, features = ["tokio", "macros"]}
 axum-extra = { version = "0.9", features = ["typed-header"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-thiserror = "2"
+thiserror = { workspace = true }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # logging
-tracing = "0.1"
-anyhow = "1.0.70"
+tracing = { workspace = true }
+anyhow = { workspace = true }
 
 # postgres
 postgres-types = { version = "*", features = ["derive"] }
-tokio-postgres = { version = "*", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
+tokio-postgres = { workspace = true }
 
 # sqlite
 rusqlite = { workspace = true, features = ["bundled", "serde_json", "time"] }
 
-futures = "0.3"
+futures = { workspace = true }
 futures-util = "0.3.28"
 time = "0.3"
 cornucopia_async = { workspace = true, features = ["with-serde_json-1"]}
 apache-avro = { workspace = true }
-toml = "0.8"
+toml = { workspace = true }
 rust-embed = { version = "8", features = ["axum"] }
 mime_guess = "2.0.4"
 

--- a/crates/arroyo-compiler-service/Cargo.toml
+++ b/crates/arroyo-compiler-service/Cargo.toml
@@ -9,10 +9,10 @@ arroyo-server-common = { path = "../arroyo-server-common" }
 arroyo-storage = { path = "../arroyo-storage" }
 
 tonic = {workspace = true}
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
-anyhow = "1.0.75"
-serde_json = "1.0.106"
-base64 = "0.22"
-dlopen2 = "0.7"
-toml = "0.8.12"
+tokio = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+dlopen2 = { workspace = true }
+toml = { workspace = true }

--- a/crates/arroyo-connectors/Cargo.toml
+++ b/crates/arroyo-connectors/Cargo.toml
@@ -20,31 +20,31 @@ arroyo-state = { path = "../arroyo-state" }
 arrow = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 bincode = { workspace = true }
-chrono = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
-typify = "0.0.13"
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+typify = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 governor = "0.8.0"
-anyhow = "1.0.71"
-tracing = "0.1.37"
+anyhow = { workspace = true }
+tracing = { workspace = true }
 regress = "0.10.0"
-futures = "0.3.28"
+futures = { workspace = true }
 rand = { workspace = true }
-bytes = "1.11.1"
-url = "2.5.0"
-itertools = "0.14.0"
-regex = "1"
-uuid = { version = "1.17.0", features = ["v4", "v7"] }
+bytes = { workspace = true }
+url = { workspace = true }
+itertools = { workspace = true }
+regex = { workspace = true }
+uuid = { workspace = true, features = ["v7"] }
 ulid = "1.2.1"
 schemars = "1.0.4"
-strum = "0.27"
-strum_macros = "0.27"
+strum = { workspace = true }
+strum_macros = { workspace = true }
 sha2 = "0.10"
 
 ##########################
@@ -95,7 +95,7 @@ object_store = { workspace = true }
 deltalake = { workspace = true, features = ["s3", "gcs"] }
 delta_kernel = { workspace = true, features = ["arrow-55", "arrow-conversion"] }
 async-compression = { version = "0.4.3", features = ["tokio", "zstd", "gzip"] }
-flate2 = "1.0.30"
+flate2 = { workspace = true }
 iceberg = { version = "0.6.0" }
 iceberg-catalog-rest = "0.6.0"
 apache-avro = {workspace = true}

--- a/crates/arroyo-controller/Cargo.toml
+++ b/crates/arroyo-controller/Cargo.toml
@@ -17,17 +17,17 @@ arroyo-state-protocol = { path = "../arroyo-state-protocol" }
 tonic = {workspace = true}
 
 prost = {workspace = true}
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1.12"
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
 rand = { workspace = true }
 petgraph = {workspace = true, features = ["serde-1"]}
 prometheus = {workspace = true}
-async-trait = "0.1"
-lazy_static = "1.4.0"
+async-trait = { workspace = true }
+lazy_static = { workspace = true }
 
-serde = "1"
+serde = { workspace = true }
 
-anyhow = "1.0.70"
+anyhow = { workspace = true }
 
 # Kubernetes
 kube = { version = "0.99", features = ["runtime", "derive"] }
@@ -35,19 +35,19 @@ k8s-openapi = { workspace = true, features = ["v1_30"] }
 shlex = "1.3"
 
 # json-schema support
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 # logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # SQL
 postgres-types = { version = "*", features = ["derive"] }
-tokio-postgres = { version = "*", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
-futures = "0.3"
+tokio-postgres = { workspace = true }
+futures = { workspace = true }
 time = "0.3"
 cornucopia_async = { workspace = true, features = ["with-serde_json-1"] }
-thiserror = "2"
-regex = "1.7.3"
+thiserror = { workspace = true }
+regex = { workspace = true }
 rusqlite = { workspace = true, features = ["serde_json", "time"] }
 
 [build-dependencies]

--- a/crates/arroyo-datastream/Cargo.toml
+++ b/crates/arroyo-datastream/Cargo.toml
@@ -9,13 +9,13 @@ arroyo-rpc = { path = "../arroyo-rpc" }
 arrow-schema = { workspace = true, features = ["serde"] }
 
 petgraph = {workspace = true, features = ["serde-1"]}
-serde = {version = "1", features = ["derive"]}
-syn = {version = "2", features = ["full"]}
+serde = { workspace = true }
+syn = { workspace = true }
 bincode = { workspace = true, features = ["serde"]}
 rand = { workspace = true }
-anyhow = "1.0.70"
+anyhow = { workspace = true }
 prost = {workspace = true}
-serde_json = "1.0.108"
-strum = { version = "0.27", features = ["derive"] }
+serde_json = { workspace = true }
+strum = { workspace = true }
 datafusion-proto = { workspace = true }
-itertools = "0.14"
+itertools = { workspace = true }

--- a/crates/arroyo-formats/Cargo.toml
+++ b/crates/arroyo-formats/Cargo.toml
@@ -8,22 +8,22 @@ arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 
 apache-avro = {workspace = true}
-serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 arrow = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-array = { workspace = true}
 arrow-json = { workspace = true }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
-anyhow = "1"
+tokio = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
 memchr = "2"
-typify = "0.0.13"
+typify = { workspace = true }
 schemars = "0.8"
 prost = { workspace = true}
 prost-reflect = { workspace = true}
 prost-build = { workspace = true }
-base64 = "0.22.1"
-uuid = { version = "1.10.0", features = ["v4"] }
-regex = "1.10.6"
+base64 = { workspace = true }
+uuid = { workspace = true }
+regex = { workspace = true }
 integer-encoding = "4.0.2"

--- a/crates/arroyo-metrics/Cargo.toml
+++ b/crates/arroyo-metrics/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2024"
 [dependencies]
 arroyo-types = { path = "../arroyo-types" }
 prometheus = { workspace = true, features = ["process"] }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }

--- a/crates/arroyo-node/Cargo.toml
+++ b/crates/arroyo-node/Cargo.toml
@@ -9,10 +9,10 @@ arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-server-common = { path = "../arroyo-server-common" }
 
 tonic = { workspace = true }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
+tokio = { workspace = true }
+tracing = { workspace = true }
 rand = { workspace = true }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 prometheus = { workspace = true }
-anyhow = "1.0.72"
-uuid = { version =  "1.17.0", features = ["v4"] }
+anyhow = { workspace = true }
+uuid = { workspace = true }

--- a/crates/arroyo-openapi/Cargo.toml
+++ b/crates/arroyo-openapi/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2024"
 [dependencies]
 progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
 reqwest = { workspace = true, features = ["json", "stream"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [build-dependencies]
 prettyplease = "0.2"
 progenitor = { version = '0.11' }
-serde_json = "1.0"
-syn = "2"
+serde_json = { workspace = true }
+syn = { workspace = true }
 
 utoipa = {workspace = true}
 arroyo-api = { path = "../arroyo-api" }

--- a/crates/arroyo-operator/Cargo.toml
+++ b/crates/arroyo-operator/Cargo.toml
@@ -16,18 +16,18 @@ arroyo-storage = { path = "../arroyo-storage" }
 arroyo-udf-host = { path = "../arroyo-udf/arroyo-udf-host" }
 arroyo-udf-python = { path = "../arroyo-udf/arroyo-udf-python" }
 
-anyhow = "1.0.71"
+anyhow = { workspace = true }
 arrow = { workspace = true, features = ["ffi"] }
-async-trait = "0.1.68"
+async-trait = { workspace = true }
 bincode = { workspace = true }
 datafusion = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 prost = {workspace = true}
 rand = { workspace = true }
-tokio = { version = "1", features = ["full", "tracing"] }
-tokio-stream = { version = "0.1", features = ["full"] }
-tracing = "0.1"
+tokio = { workspace = true, features = ["tracing"] }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
 async-stream = "0.3.5"
-serde_json = "1.0.111"
-serde = "1.0.195"
-dlopen2 = "0.7.0"
+serde_json = { workspace = true }
+serde = { workspace = true }
+dlopen2 = { workspace = true }

--- a/crates/arroyo-planner/Cargo.toml
+++ b/crates/arroyo-planner/Cargo.toml
@@ -20,25 +20,25 @@ datafusion-functions-json = { workspace = true }
 
 prost = {workspace = true}
 arrow-schema = {workspace = true, features = ["serde"] }
-serde = {version = "1", features = ["derive"]}
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 petgraph = { workspace = true }
-tokio = "1.27"
-tokio-stream = { version = "0.1", features = ["full"] }
-futures = "0.3"
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+futures = { workspace = true }
 arrow = { workspace = true, features = ["ffi"] }
 arrow-array = { workspace = true}
-anyhow = {version = "1.0.70", features = ["backtrace"]}
-async-trait = "0.1"
+anyhow = { workspace = true, features = ["backtrace"] }
+async-trait = { workspace = true }
 
-syn = {version = "2", features = ["full", "parsing", "extra-traits"]}
-tracing = "0.1.37"
+syn = { workspace = true, features = ["parsing", "extra-traits"] }
+tracing = { workspace = true }
 
 serde_json_path = "0.7"
 unicase = "2.7.0"
 xxhash-rust = { version = "0.8.12", features = ["xxh3", "std"] }
-itertools = "0.14.0"
+itertools = { workspace = true }
 
 sqlparser = { workspace = true}
 

--- a/crates/arroyo-rpc/Cargo.toml
+++ b/crates/arroyo-rpc/Cargo.toml
@@ -14,27 +14,27 @@ arrow-ord = { workspace = true }
 arrow-schema = {workspace = true, features = ["serde"]}
 tonic = { workspace = true, features = ["tls-native-roots", "tls-webpki-roots"] }
 prost = {workspace = true}
-tokio = { version = "1", features = ["full"] }
-futures = { version = "0.3.30" }
-serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+tokio = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 nanoid = "0.4"
 utoipa = { workspace = true }
-anyhow = "1"
+anyhow = { workspace = true }
 reqwest = { workspace = true, features = ["default", "json"] }
 log = "0.4.20"
-tracing = "0.1.40"
-async-trait = "0.1.74"
+tracing = { workspace = true }
+async-trait = { workspace = true }
 apache-avro = {workspace =  true}
-regex = "1.9.5"
-base64 = "0.22"
+regex = { workspace = true }
+base64 = { workspace = true }
 ahash = { workspace = true }
-strum_macros = "0.27"
-strum = "0.27"
+strum_macros = { workspace = true }
+strum = { workspace = true }
 figment = { version = "0.10", features = ["toml", "env", "yaml", "json"] }
 k8s-openapi = { workspace = true, features = ["v1_30"] }
-url = { version = "2", features = ["serde"] }
-dirs = "6"
+url = { workspace = true }
+dirs = { workspace = true }
 arc-swap = "1.7.1"
 datafusion = { workspace = true }
 rand = { workspace = true }
@@ -44,10 +44,10 @@ rustls = {workspace = true}
 local-ip-address = "0.6"
 schemars = "1"
 smallvec = "1"
-thiserror = "2"
+thiserror = { workspace = true }
 object_store = { workspace = true, features = ["aws", "gcp", "azure"] }
 bincode = { workspace = true }
-bytes = "1"
+bytes = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/arroyo-server-common/Cargo.toml
+++ b/crates/arroyo-server-common/Cargo.toml
@@ -11,9 +11,9 @@ jemalloc_pprof = "0.7.0"
 
 # logging
 json-subscriber = "0.2.6"
-tracing = "0.1"
+tracing = { workspace = true }
 tracing-logfmt = "0.2.0"
-tracing-subscriber = {version = "0.3.20", features = [ "env-filter", "json" ]}
+tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"
 tracing-log = "0.2"
 
@@ -21,23 +21,23 @@ tracing-log = "0.2"
 tower = { workspace = true }
 tower-http = {workspace = true, features = ["trace", "fs", "validate-request", "auth"]}
 tonic = { workspace = true }
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 prometheus = {workspace = true, features = ["process"] }
 axum = {workspace = true}
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-http = "1"
+http = { workspace = true }
 
-lazy_static = "1.4.0"
-futures = { version = "0.3" }
-once_cell = "1.17.1"
+lazy_static = { workspace = true }
+futures = { workspace = true }
+once_cell = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
-serde_json = "1.0.96"
+serde_json = { workspace = true }
 tokio-util = "0.7.10"
-anyhow = "1.0.82"
-toml = "0.8.13"
-dirs = "6"
-uuid = { version = "1.8.0", features = ["v4"] }
-url = { version = "2.5" }
+anyhow = { workspace = true }
+toml = { workspace = true }
+dirs = { workspace = true }
+uuid = { workspace = true }
+url = { workspace = true }
 rustls = { workspace = true, features = ["std", "aws_lc_rs"] }
 rustls-pemfile = { workspace = true }
 rustls-native-certs = "0.8"
@@ -46,9 +46,9 @@ tokio-postgres-rustls = "0.13"
 webpki-roots = { workspace = true }
 
 # profile
-flate2 = "1.0.30"
+flate2 = { workspace = true }
 pprof = { version = "0.15.0", features = ["flamegraph", "protobuf-codec"] }
-serde = { version = "1.0.96", features = ["derive"] }
+serde = { workspace = true }
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }

--- a/crates/arroyo-sql-testing/Cargo.toml
+++ b/crates/arroyo-sql-testing/Cargo.toml
@@ -9,25 +9,25 @@ integration-tests = []
 
 
 [dependencies]
-syn = "2.0"
+syn = { workspace = true }
 petgraph = { workspace = true }
-serde = "1.0"
-serde_json = "1.0"
-anyhow = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
 
 arroyo-types = { path = "../arroyo-types" }
 arroyo-planner = { path = "../arroyo-planner" }
 arroyo-datastream = { path = "../arroyo-datastream" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-worker = { path = "../arroyo-worker" }
-tokio = { version = "1.16", features = ["full"] }
+tokio = { workspace = true }
 arroyo-state = { path = "../arroyo-state" }
 arroyo-udf-host = { path = "../arroyo-udf/arroyo-udf-host" }
 arroyo-udf-macros = { path = "../arroyo-udf/arroyo-udf-macros" }
 arroyo-udf-plugin = { path = "../arroyo-udf/arroyo-udf-plugin" }
 
 arrow = {workspace = true }
-tracing = "0.1.37"
+tracing = { workspace = true }
 datafusion = { workspace = true }
 
 [dev-dependencies]

--- a/crates/arroyo-state-protocol/Cargo.toml
+++ b/crates/arroyo-state-protocol/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-storage = { path = "../arroyo-storage" }
-async-trait = "0.1"
+async-trait = { workspace = true }
 prost = { workspace = true }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { workspace = true }

--- a/crates/arroyo-state/Cargo.toml
+++ b/crates/arroyo-state/Cargo.toml
@@ -9,25 +9,24 @@ edition = "2024"
 arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 arroyo-storage = { path = "../arroyo-storage" }
-arroyo-datastream = { path = "../arroyo-datastream" }
 
 datafusion = { workspace = true }
 
-anyhow = "1.0"
-tracing = "0.1"
+anyhow = { workspace = true }
+tracing = { workspace = true }
 bincode = {workspace = true}
-tokio = { version = "1", features = ["full", "tracing"] }
+tokio = { workspace = true, features = ["tracing"] }
 arrow = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 parquet = { workspace = true }
-async-trait = "0.1.68"
-once_cell = "1.17.1"
-futures = "0.3"
+async-trait = { workspace = true }
+once_cell = { workspace = true }
+futures = { workspace = true }
 prost = {workspace = true}
 prometheus = { workspace = true }
-lazy_static = "1.4.0"
+lazy_static = { workspace = true }
 object_store = { workspace = true }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/arroyo-storage/Cargo.toml
+++ b/crates/arroyo-storage/Cargo.toml
@@ -10,17 +10,17 @@ default = []
 [dependencies]
 arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
-bytes = "1.11.1"
-tracing = "0.1"
+bytes = { workspace = true }
+tracing = { workspace = true }
 
 aws-credential-types = "1.2.0"
 aws-config = { workspace = true }
 rand = { workspace = true }
 object_store = { workspace = true, features = ["aws", "gcp", "azure"] }
-regex = "1.9.5"
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["fs"] }
+regex = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-util = { version = "0.7.9", features = ["io"] }
-async-trait = "0.1.73"
-futures = "0.3.28"
+async-trait = { workspace = true }
+futures = { workspace = true }

--- a/crates/arroyo-types/Cargo.toml
+++ b/crates/arroyo-types/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2024"
 
 [dependencies]
 bincode = { workspace = true }
-chrono = "0.4"
-serde = { version = "1.0", features = ["derive", "rc"] }
+chrono = { workspace = true }
+serde = { workspace = true, features = ["rc"] }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
-tracing = "0.1.44"

--- a/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-common/Cargo.toml
@@ -14,7 +14,7 @@ description = "Common utilities for the Arroyo UDF FFI API"
 
 [dependencies]
 arrow = { workspace = true, features = ["ffi"]}
-syn = { version = "2", features = ["full"] }
-anyhow = "1.0.82"
-regex = "1.10.3"
-serde = { version = "1.0.197", features = ["derive"] }
+syn = { workspace = true }
+anyhow = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }

--- a/crates/arroyo-udf/arroyo-udf-host/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-host/Cargo.toml
@@ -6,17 +6,17 @@ description = "safe interface for interacting with dynamically-linked UDFs"
 
 [dependencies]
 arroyo-udf-common = { path = "../arroyo-udf-common" }
-dlopen2 = { version = "0.7", features = ["derive"] }
-anyhow = "1.0.82"
+dlopen2 = { workspace = true }
+anyhow = { workspace = true }
 datafusion = { workspace = true }
 async-ffi = { version = "0.5", features = ["macros"] }
 arrow = { workspace = true, features = ["ffi"]}
-toml = "0.8"
-syn = { version = "2", features = ["full"] }
+toml = { workspace = true }
+syn = { workspace = true }
 quote = "1"
-regex = "1.10.3"
+regex = { workspace = true }
 
 [dev-dependencies]
 arroyo-udf-macros = { path = "../arroyo-udf-macros" }
 arroyo-udf-plugin = { path = "../arroyo-udf-plugin" }
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }

--- a/crates/arroyo-udf/arroyo-udf-macros/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-macros/Cargo.toml
@@ -18,6 +18,6 @@ proc-macro = true
 [dependencies]
 arrow-schema = { workspace = true }
 arroyo-udf-common = { path = "../arroyo-udf-common" }
-syn = {version = "2", features = ["full"]}
+syn = { workspace = true }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/crates/arroyo-udf/arroyo-udf-plugin/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-plugin/Cargo.toml
@@ -16,7 +16,7 @@ description = "Plugin interface for Arroyo UDFs"
 arroyo-udf-common = { path = "../arroyo-udf-common" }
 arroyo-udf-macros = { path = "../arroyo-udf-macros" }
 
-tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
-futures = "0.3"
+tokio = { workspace = true }
+futures = { workspace = true }
 arrow = { workspace = true, features = ["ffi"]}
 async-ffi = { version = "0.5.0", features = ["macros"] }

--- a/crates/arroyo-udf/arroyo-udf-python/Cargo.toml
+++ b/crates/arroyo-udf/arroyo-udf-python/Cargo.toml
@@ -11,6 +11,6 @@ arroyo-udf-common = { path = "../arroyo-udf-common" }
 arrow = { workspace = true, features = ["ffi"] }
 datafusion = { workspace = true }
 pyo3 = { version = "0.21", optional = true}
-anyhow = "1"
-tokio = { version = "1", features = ["full"] }
-itertools = "0.13.0"
+anyhow = { workspace = true }
+tokio = { workspace = true }
+itertools = { workspace = true }

--- a/crates/arroyo-worker/Cargo.toml
+++ b/crates/arroyo-worker/Cargo.toml
@@ -22,17 +22,17 @@ rand = { workspace = true }
 bincode = { workspace = true }
 petgraph = { workspace = true }
 prometheus = {workspace = true, features = ["process"] }
-futures = "0.3"
-tokio = { version = "1", features = ["full", "tracing"] }
-tokio-stream = { version = "0.1", features = ["full"] }
+futures = { workspace = true }
+tokio = { workspace = true, features = ["tracing"] }
+tokio-stream = { workspace = true }
 tokio-rustls = { workspace = true }
-async-trait = "0.1.68"
+async-trait = { workspace = true }
 async-stream = "0.3.4"
-bytes = "1.11.1"
-serde_json = "1.0"
-serde = "1.0"
+bytes = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
 ordered-float = "3"
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { workspace = true }
 
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-schema = {workspace = true, features = ["serde"]}
@@ -42,16 +42,16 @@ tonic = { workspace = true }
 prost = {workspace = true}
 
 #logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # connectors
-anyhow = "1.0.71"
+anyhow = { workspace = true }
 
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
-itertools = "0.12.0"
+itertools = { workspace = true }
 mini-moka = { version = "0.10.3" }
-url = "2.5.4"
+url = { workspace = true }
 
 
 [dev-dependencies]

--- a/crates/arroyo/Cargo.toml
+++ b/crates/arroyo/Cargo.toml
@@ -22,23 +22,23 @@ arroyo-udf-python = { path = "../arroyo-udf/arroyo-udf-python" }
 arroyo-planner = { path = "../arroyo-planner" }
 
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-serde = "1"
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = {version = "0.3.20", features = [ "env-filter", "json" ]}
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
-tokio-postgres = { version = "*", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-1"] }
+tokio-postgres = { workspace = true }
 deadpool-postgres = { workspace = true }
 cornucopia_async = { workspace = true }
 rusqlite = {  workspace = true, features = ["backup"] }
-uuid = { version = "1.7.0", features = ["v4"] }
+uuid = { workspace = true }
 refinery = { version = "0.8.14" , features = ["tokio-postgres", "rusqlite"] }
-anyhow = { version = "1.0.79"}
+anyhow = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true}
 clio = { version = "0.3.5", features = ["clap", "clap-parse"] }
-async-trait = "0.1.80"
+async-trait = { workspace = true }
 open = '5.3.0'
 rustls = { workspace = true, features = ["aws_lc_rs"] }
 

--- a/crates/integ/Cargo.toml
+++ b/crates/integ/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2024"
 
 [dependencies]
 arroyo-openapi = { path = "../arroyo-openapi" }
-anyhow = "1.0.71"
-tokio = { version = "1.16.1", features = ["full"] }
+anyhow = { workspace = true }
+tokio = { workspace = true }
 rand = { workspace = true }
-tracing = "0.1.37"
-serde_json = { version = "1", features = ["preserve_order"] }
+tracing = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 rdkafka = "0.37"
 reqwest = { workspace = true }


### PR DESCRIPTION
All of the crates added to the workspace `Cargo.toml` were present in at least 2 arroyo crates.

I think moving to this model will make it easier to upgrade and ensure that our system is consistent between the various crates.