### PR TITLE
Introduce `env_vars` column to the job_configs table

### DIFF
--- a/crates/arroyo-api/migrations/V30__add_job_env_vars.sql
+++ b/crates/arroyo-api/migrations/V30__add_job_env_vars.sql
@@ -1,0 +1,3 @@
+-- Per-job environment variables forwarded to workers at scheduling time.
+-- Stored as a JSON object of the form {"KEY": "VALUE", ...}.
+ALTER TABLE job_configs ADD COLUMN env_vars JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -128,7 +128,7 @@ INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_
 VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 
 --! get_pipelines : DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -143,7 +143,7 @@ ORDER BY pipelines.created_at DESC
 LIMIT cast(:limit as integer);
 
 --! get_pipeline: DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -188,8 +188,8 @@ WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
-(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros)
-VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros);
+(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros, env_vars)
+VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros, :env_vars);
 
 --! create_job_status
 INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :organization_id);

--- a/crates/arroyo-api/sqlite_migrations/V8__add_job_env_vars.sql
+++ b/crates/arroyo-api/sqlite_migrations/V8__add_job_env_vars.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_configs ADD COLUMN env_vars TEXT NOT NULL DEFAULT '{}';

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -1,5 +1,4 @@
 use crate::queries::api_queries::{DbCheckpoint, DbLogMessage, DbPipelineJob};
-use anyhow::anyhow;
 use arroyo_rpc::api_types::checkpoints::{
     Checkpoint, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
 };
@@ -84,8 +83,8 @@ pub(crate) async fn create_job(
 
     let job_id = generate_id(IdTypes::JobConfig);
 
-    let env_vars_json = serde_json::to_value(&env_vars)
-        .map_err(|e| log_and_map(anyhow!("env_vars serialization failed: {e}")))?;
+    let env_vars_json =
+        serde_json::to_value(&env_vars).expect("HashMap<String, String> is always serializable");
 
     // TODO: handle chance of collision in ids
     api_queries::execute_create_job(

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -1,4 +1,5 @@
 use crate::queries::api_queries::{DbCheckpoint, DbLogMessage, DbPipelineJob};
+use anyhow::anyhow;
 use arroyo_rpc::api_types::checkpoints::{
     Checkpoint, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
 };
@@ -44,6 +45,7 @@ pub(crate) async fn create_job(
     preview: bool,
     auth: &AuthData,
     db: &DatabaseSource,
+    env_vars: HashMap<String, String>,
 ) -> Result<String, ErrorResp> {
     let checkpoint_interval = if preview {
         Duration::from_secs(24 * 60 * 60)
@@ -82,6 +84,9 @@ pub(crate) async fn create_job(
 
     let job_id = generate_id(IdTypes::JobConfig);
 
+    let env_vars_json = serde_json::to_value(&env_vars)
+        .map_err(|e| log_and_map(anyhow!("env_vars serialization failed: {e}")))?;
+
     // TODO: handle chance of collision in ids
     api_queries::execute_create_job(
         &db.client().await?,
@@ -96,6 +101,7 @@ pub(crate) async fn create_job(
         } else {
             None
         }),
+        &env_vars_json,
     )
     .await?;
 

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -496,9 +496,6 @@ impl TryInto<Pipeline> for DbPipeline {
             StopMode::force => StopType::Force,
         };
 
-        let env_vars: HashMap<String, String> =
-            serde_json::from_value(self.env_vars).map_err(log_and_map)?;
-
         Ok(Pipeline {
             id: self.pub_id,
             name: self.name,
@@ -512,7 +509,7 @@ impl TryInto<Pipeline> for DbPipeline {
             action_text,
             action_in_progress,
             preview: self.ttl_micros.is_some(),
-            env_vars,
+            env_vars: self.env_vars,
         })
     }
 }

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -305,6 +305,7 @@ pub(crate) async fn create_pipeline_int(
     pub_id: Option<String>,
     state_url: Option<String>,
     tags: HashMap<String, String>,
+    env_vars: HashMap<String, String>,
 ) -> Result<String, ErrorResp> {
     if parallelism > auth.org_metadata.max_parallelism as u64 {
         return Err(bad_request(format!(
@@ -441,6 +442,7 @@ pub(crate) async fn create_pipeline_int(
         is_preview,
         &auth,
         db,
+        env_vars,
     )
     .await?;
 
@@ -494,6 +496,9 @@ impl TryInto<Pipeline> for DbPipeline {
             StopMode::force => StopType::Force,
         };
 
+        let env_vars: HashMap<String, String> =
+            serde_json::from_value(self.env_vars).map_err(log_and_map)?;
+
         Ok(Pipeline {
             id: self.pub_id,
             name: self.name,
@@ -507,6 +512,7 @@ impl TryInto<Pipeline> for DbPipeline {
             action_text,
             action_in_progress,
             preview: self.ttl_micros.is_some(),
+            env_vars,
         })
     }
 }
@@ -667,6 +673,7 @@ async fn create_pipeline_inner(
         pub_id,
         pipeline_post.state_url,
         pipeline_post.tags.unwrap_or_default(),
+        pipeline_post.env_vars.unwrap_or_default(),
     )
     .await?;
 
@@ -719,6 +726,7 @@ pub async fn create_preview_pipeline(
         compiled,
         None,
         None,
+        HashMap::default(),
         HashMap::default(),
     )
     .await?;

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -22,7 +22,8 @@ SELECT
     s.restart_nonce as status_restart_nonce,
     restart_mode,
     ignore_state_before_epoch,
-    state_context
+    state_context,
+    env_vars
 FROM job_configs c
 INNER JOIN job_statuses s ON c.id = s.id;
 

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -42,7 +42,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::codec::CompressionEncoding;
 use tonic::{Request, Response, Status};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 //pub mod compiler;
 pub mod job_controller;
@@ -74,7 +74,7 @@ pub struct JobConfig {
     restart_mode: RestartMode,
     ignore_state_before_epoch: Option<i32>,
     /// Per-job environment variables forwarded to workers at scheduling time.
-    env_vars: HashMap<String, String>,
+    env_vars: serde_json::Value,
 }
 
 /// Per-pipeline data that doesn't change for the lifetime of a job.
@@ -605,17 +605,6 @@ impl ControllerServer {
                 let res = queries::controller_queries::fetch_all_jobs(&client).await?;
                 for p in res {
                     let id = Arc::new(p.id);
-                    let env_vars: HashMap<String, String> =
-                        serde_json::from_value(p.env_vars.clone()).unwrap_or_else(|e| {
-                            error!(
-                                job_id = *id,
-                                original =? p.env_vars,
-                                error =? e,
-                                "failed to deserialize env_vars; falling back to empty map"
-                            );
-                            HashMap::new()
-                        });
-
                     let config = JobConfig {
                         id: id.clone(),
                         organization_id: p.org_id,
@@ -638,7 +627,7 @@ impl ControllerServer {
                         restart_nonce: p.config_restart_nonce,
                         restart_mode: p.restart_mode,
                         ignore_state_before_epoch: p.ignore_state_before_epoch,
-                        env_vars,
+                        env_vars: p.env_vars,
                     };
 
                     let mut jobs = jobs.lock().await;

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -42,7 +42,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::codec::CompressionEncoding;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 //pub mod compiler;
 pub mod job_controller;
@@ -73,6 +73,8 @@ pub struct JobConfig {
     restart_nonce: i32,
     restart_mode: RestartMode,
     ignore_state_before_epoch: Option<i32>,
+    /// Per-job environment variables forwarded to workers at scheduling time.
+    env_vars: HashMap<String, String>,
 }
 
 /// Per-pipeline data that doesn't change for the lifetime of a job.
@@ -603,6 +605,17 @@ impl ControllerServer {
                 let res = queries::controller_queries::fetch_all_jobs(&client).await?;
                 for p in res {
                     let id = Arc::new(p.id);
+                    let env_vars: HashMap<String, String> =
+                        serde_json::from_value(p.env_vars.clone()).unwrap_or_else(|e| {
+                            error!(
+                                job_id = *id,
+                                original =? p.env_vars,
+                                error =? e,
+                                "failed to deserialize env_vars; falling back to empty map"
+                            );
+                            HashMap::new()
+                        });
+
                     let config = JobConfig {
                         id: id.clone(),
                         organization_id: p.org_id,
@@ -625,6 +638,7 @@ impl ControllerServer {
                         restart_nonce: p.config_restart_nonce,
                         restart_mode: p.restart_mode,
                         ignore_state_before_epoch: p.ignore_state_before_epoch,
+                        env_vars,
                     };
 
                     let mut jobs = jobs.lock().await;

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -512,18 +512,35 @@ impl Scheduling {
         slots_needed: usize,
     ) -> Result<Box<Self>, StateError> {
         let start = Instant::now();
-        let mut env_vars = std::collections::HashMap::new();
-        env_vars.insert(
-            "ARROYO__CHECKPOINT_URL".to_string(),
-            ctx.pipeline_info
-                .state_url
-                .clone()
-                .unwrap_or_else(|| config().checkpoint_url.clone()),
-        );
-        env_vars.insert(
-            CLUSTER_ID_ENV.to_string(),
-            arroyo_server_common::get_cluster_id(),
-        );
+        let mut env_vars = ctx.config.env_vars.clone();
+
+        let checkpoint_url = ctx
+            .pipeline_info
+            .state_url
+            .clone()
+            .unwrap_or_else(|| config().checkpoint_url.clone());
+        env_vars
+            .insert("ARROYO__CHECKPOINT_URL".to_string(), checkpoint_url)
+            .inspect(|_| {
+                warn!(
+                    job_id = *ctx.config.id,
+                    key = "ARROYO__CHECKPOINT_URL",
+                    "job env_vars contained a reserved infrastructure key; \
+                     user-supplied value has been overridden by the controller"
+                );
+            });
+
+        let cluster_id = arroyo_server_common::get_cluster_id();
+        env_vars
+            .insert(CLUSTER_ID_ENV.to_string(), cluster_id)
+            .inspect(|_| {
+                warn!(
+                    job_id = *ctx.config.id,
+                    key = CLUSTER_ID_ENV,
+                    "job env_vars contained a reserved infrastructure key; \
+                     user-supplied value has been overridden by the controller"
+                );
+            });
 
         loop {
             match ctx

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -512,7 +512,13 @@ impl Scheduling {
         slots_needed: usize,
     ) -> Result<Box<Self>, StateError> {
         let start = Instant::now();
-        let mut env_vars = ctx.config.env_vars.clone();
+        let mut env_vars: HashMap<String, String> =
+            serde_json::from_value(ctx.config.env_vars.clone()).map_err(|e| {
+                fatal(
+                    format!("failed to deserialize env_vars from job_configs: {e}"),
+                    anyhow::anyhow!("malformed env_vars in job_configs row"),
+                )
+            })?;
 
         let checkpoint_url = ctx
             .pipeline_info

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -73,7 +73,7 @@ pub struct Pipeline {
     pub action_in_progress: bool,
     pub graph: PipelineGraph,
     pub preview: bool,
-    pub env_vars: HashMap<String, String>,
+    pub env_vars: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -30,6 +30,8 @@ pub struct PipelinePost {
     pub checkpoint_interval_micros: Option<u64>,
     pub state_url: Option<String>,
     pub tags: Option<HashMap<String, String>>,
+    /// Per-job environment variables forwarded to workers.
+    pub env_vars: Option<HashMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -71,6 +73,7 @@ pub struct Pipeline {
     pub action_in_progress: bool,
     pub graph: PipelineGraph,
     pub preview: bool,
+    pub env_vars: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]


### PR DESCRIPTION
This can be used to pass environment variables to the worker at scheduling time.

**Testing**

Claude made a script that tested the APIs and validated the state of the DB.
```
❯ ./scripts/test_env_vars.sh

▶ Preflight
  ✓ cluster is reachable at http://localhost:5115
  ✓ job_configs.env_vars is JSONB
  latest applied migration: add_job_env_vars

▶ Test 1 — POST /api/v1/pipelines with env_vars
  ✓ POST succeeded — pipeline id = pl_W0d5fOIVQu
  ✓ POST response.env_vars matches input
  value: {"MY_SECRET":"redacted-1","ANOTHER_VAR":"redacted-2"}

▶ Test 2 — env_vars persisted in job_configs
  ✓ DB row env_vars matches input
  value: {"MY_SECRET": "redacted-1", "ANOTHER_VAR": "redacted-2"}

▶ Test 3 — GET /api/v1/pipelines/{id} returns env_vars
  ✓ GET response.env_vars matches input
  value: {"ANOTHER_VAR":"redacted-2","MY_SECRET":"redacted-1"}

▶ Test 4 — POST without env_vars defaults to {}
  ✓ POST response defaults to env_vars = {}
  ✓ DB row defaults to env_vars = {}

▶ Test 5 — controller warns on reserved-key collision
  ✓ POST with reserved key succeeded — pipeline id = pl_VKBoYgm9tU
  ✓ controller emitted collision warning
  2026-05-14T23:18:35.926968Z  WARN arroyo_controller::states::scheduling: job env_vars contained a reserved infrastructure key; user-supplied value has been overridden by the controller job_id="job_Ni0FX0gMk3" key="ARROYO__CHECKPOINT_URL"
  ✓ user-supplied value was NOT logged

─────────────────────────────────────────
All checks passed (11 ok, 0 failed)

Cleaning up test pipelines…
```