### PR TITLE
fix: remove references to Internet libraries for monaco-editor and fonts

### DIFF
--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -1,4 +1,5 @@
 import './index.css';
+import './monacoSetup';
 
 import { extendTheme, ThemeConfig } from '@chakra-ui/react';
 import { theme as proTheme } from '@chakra-ui/pro-theme';

--- a/webui/src/monacoSetup.ts
+++ b/webui/src/monacoSetup.ts
@@ -1,0 +1,13 @@
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+
+(window as Window & typeof globalThis & { MonacoEnvironment: unknown }).MonacoEnvironment = {
+  getWorker(_moduleId: string, label: string) {
+    if (label === 'json') return new jsonWorker();
+    return new editorWorker();
+  },
+};
+
+loader.config({ monaco });

--- a/webui/src/styles/data-grid-style.css
+++ b/webui/src/styles/data-grid-style.css
@@ -4,7 +4,8 @@
  * See installation docs at https://www.ag-grid.com/javascript-data-grid/applying-theme-builder-styling-grid/
  */
 
-@import url('https://fonts.googleapis.com/css2?family=IBM%20Plex%20Mono:wght@400;700&display=swap');
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/700.css';
 
 .ag-theme-custom {
   --ag-background-color: #26262617;

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    exclude: ['monaco-editor'],
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
Follow-up to https://github.com/ArroyoSystems/arroyo/issues/1061

Has the following changes

1. Reference fonts locally
2. Reference monaco-editor as a dependency rather than Internet CDN.