### PR TITLE
Support checkpoint status API for leader mode

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -202,28 +202,28 @@ FROM job_configs
 WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
---! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at
+--! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
+SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
 WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pub_id
 ORDER BY job_configs.created_at DESC;
 
---! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at
+--! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
+SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
 WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY job_configs.created_at DESC;
 
---! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at
+--! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
+SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
-WHERE job_configs.organization_id = :organization_id AND job_configs.id = :job_id
+WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pipeline_id AND job_configs.id = :job_id
 ORDER BY job_configs.created_at DESC;
 
 

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -1,6 +1,8 @@
 use crate::queries::api_queries::{DbCheckpoint, DbLogMessage, DbPipelineJob};
+use anyhow::Context;
 use arroyo_rpc::api_types::checkpoints::{
-    Checkpoint, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
+    Checkpoint, CheckpointEventSpan, JobCheckpointSpan, OperatorCheckpointGroup,
+    SubtaskCheckpointGroup,
 };
 use arroyo_rpc::api_types::pipelines::{JobLogLevel, JobLogMessage, OutputData, StopType};
 use arroyo_rpc::api_types::{
@@ -9,7 +11,7 @@ use arroyo_rpc::api_types::{
 };
 use arroyo_rpc::grpc::api::OperatorCheckpointDetail;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
-use arroyo_rpc::{get_event_spans, grpc};
+use arroyo_rpc::{LeaderContext, StateContext, get_event_spans, grpc, job_status_client};
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::response::sse::{Event, Sse};
@@ -35,7 +37,101 @@ use crate::{AuthData, queries::api_queries, to_micros, types::public};
 use arroyo_rpc::config::config;
 use arroyo_rpc::controller_client;
 use arroyo_rpc::errors::ErrorDomain;
+use arroyo_rpc::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient;
+use arroyo_rpc::grpc::rpc::{GetCheckpointDetailsReq, GetJobCheckpointsReq};
+use arroyo_rpc::identity::InjectWorkerId;
 use cornucopia_async::DatabaseSource;
+use http::StatusCode;
+use tonic::codegen::InterceptedService;
+use tonic::transport::Channel;
+
+type LeaderCheckpointClient = JobStatusGrpcClient<InterceptedService<Channel, InjectWorkerId>>;
+
+async fn fetch_from_leader<
+    R,
+    F: Future<Output = Result<R, tonic::Status>>,
+    T: FnOnce(LeaderCheckpointClient, u64) -> F,
+>(
+    leader_context: LeaderContext,
+    req: T,
+) -> Result<R, ErrorResp> {
+    let client = job_status_client(
+        "api",
+        &config().api.tls,
+        leader_context.worker_id,
+        leader_context.rpc_address,
+    )
+    .await
+    .map_err(|_| ErrorResp {
+        status_code: StatusCode::BAD_GATEWAY,
+        message: "the leader is not currently available; try again later".to_string(),
+    })?;
+
+    req(client, leader_context.generation)
+        .await
+        .map_err(|e| match e.code() {
+            Code::FailedPrecondition | Code::NotFound => bad_request(e.message().to_string()),
+            Code::Unavailable => ErrorResp {
+                status_code: StatusCode::BAD_GATEWAY,
+                message: "the leader is not currently available; try again later".to_string(),
+            },
+            _ => log_and_map(e),
+        })
+}
+
+fn checkpoint_from_leader(checkpoint: grpc::rpc::JobCheckpointMetadata) -> Checkpoint {
+    Checkpoint {
+        epoch: checkpoint.epoch,
+        backend: checkpoint.state_backend,
+        start_time: checkpoint.start_time,
+        finish_time: checkpoint.finish_time,
+        events: checkpoint
+            .event_spans
+            .into_iter()
+            .map(|span| CheckpointEventSpan {
+                start_time: span.start_time,
+                finish_time: span.finish_time,
+                event: span.event,
+                description: span.description,
+            })
+            .collect(),
+    }
+}
+
+fn operator_checkpoint_groups(
+    operator_details: HashMap<String, OperatorCheckpointDetail>,
+) -> Vec<OperatorCheckpointGroup> {
+    let mut operators = vec![];
+
+    operator_details
+        .iter()
+        .for_each(|(operator_id, operator_details)| {
+            let mut operator_bytes = 0;
+            let mut subtasks = vec![];
+
+            operator_details
+                .tasks
+                .iter()
+                .for_each(|(subtask_index, subtask_details)| {
+                    operator_bytes += subtask_details.bytes.unwrap_or(0);
+                    subtasks.push(SubtaskCheckpointGroup {
+                        index: *subtask_index,
+                        bytes: subtask_details.bytes.unwrap_or(0),
+                        event_spans: get_event_spans(subtask_details).into(),
+                    });
+                });
+
+            operators.push(OperatorCheckpointGroup {
+                operator_id: operator_id.to_string(),
+                bytes: operator_bytes,
+                started_metadata_write: operator_details.started_metadata_write,
+                finish_time: operator_details.finish_time,
+                subtasks,
+            });
+        });
+
+    operators
+}
 
 pub(crate) async fn create_job(
     pipeline_name: &str,
@@ -271,15 +367,49 @@ pub async fn get_job_checkpoints(
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
-    query_job_by_pub_id(&pipeline_pub_id, &job_pub_id, &db, &auth_data).await?;
+    let job = api_queries::fetch_get_pipeline_job(
+        &db,
+        &auth_data.organization_id,
+        &pipeline_pub_id,
+        &job_pub_id,
+    )
+    .await?
+    .into_iter()
+    .next()
+    .ok_or_else(|| not_found("Job"))?;
 
-    let checkpoints =
+    let state_context: Option<StateContext> = job
+        .state_context
+        .map(serde_json::from_value)
+        .transpose()
+        .with_context(|| format!("converting state context for job {}", job_pub_id))
+        .map_err(log_and_map)?;
+
+    let checkpoints = if let Some(state_context) = state_context
+        && let Some(leader) = state_context.leader
+    {
+        fetch_from_leader(leader, move |mut client, generation| async move {
+            client
+                .get_job_checkpoints(GetJobCheckpointsReq {
+                    job_id: job.id,
+                    generation,
+                })
+                .await
+        })
+        .await?
+        .into_inner()
+        .checkpoints
+        .into_iter()
+        .map(checkpoint_from_leader)
+        .collect()
+    } else {
         api_queries::fetch_get_job_checkpoints(&db, &job_pub_id, &auth_data.organization_id)
             .await
             .map_err(log_and_map)?
             .into_iter()
             .filter_map(|m| m.try_into().ok())
-            .collect();
+            .collect()
+    };
 
     Ok(Json(CheckpointCollection { data: checkpoints }))
 }
@@ -306,55 +436,63 @@ pub async fn get_checkpoint_details(
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
-    query_job_by_pub_id(&pipeline_pub_id, &job_pub_id, &db, &auth_data).await?;
-
-    let checkpoint_details = api_queries::fetch_get_checkpoint_details(
+    let job = api_queries::fetch_get_pipeline_job(
         &db,
-        &job_pub_id,
         &auth_data.organization_id,
-        &(epoch as i32),
+        &pipeline_pub_id,
+        &job_pub_id,
     )
-    .await
-    .map_err(log_and_map)?
+    .await?
     .into_iter()
     .next()
-    .ok_or_else(|| {
-        not_found(&format!(
-            "Checkpoint with epoch {epoch} for job '{job_pub_id}'"
-        ))
-    })?;
+    .ok_or_else(|| not_found("Job"))?;
 
-    let mut operators: Vec<OperatorCheckpointGroup> = vec![];
+    let state_context: Option<StateContext> = job
+        .state_context
+        .map(serde_json::from_value)
+        .transpose()
+        .with_context(|| format!("converting state context for job {}", job_pub_id))
+        .map_err(log_and_map)?;
 
-    checkpoint_details
+    let operators = if let Some(state_context) = state_context
+        && let Some(leader) = state_context.leader
+    {
+        fetch_from_leader(leader, move |mut client, generation| async move {
+            client
+                .get_checkpoint_details(GetCheckpointDetailsReq {
+                    job_id: job.id,
+                    generation,
+                    epoch: epoch as u64,
+                })
+                .await
+        })
+        .await?
+        .into_inner()
         .operators
-        .map(|o| serde_json::from_value(o).unwrap())
-        .unwrap_or_else(HashMap::<String, OperatorCheckpointDetail>::new)
-        .iter()
-        .for_each(|(operator_id, operator_details)| {
-            let mut operator_bytes = 0;
-            let mut subtasks = vec![];
+    } else {
+        let checkpoint_details = api_queries::fetch_get_checkpoint_details(
+            &db,
+            &job_pub_id,
+            &auth_data.organization_id,
+            &(epoch as i32),
+        )
+        .await
+        .map_err(log_and_map)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            not_found(&format!(
+                "Checkpoint with epoch {epoch} for job '{job_pub_id}'"
+            ))
+        })?;
 
-            operator_details
-                .tasks
-                .iter()
-                .for_each(|(subtask_index, subtask_details)| {
-                    operator_bytes += subtask_details.bytes.unwrap_or(0);
-                    subtasks.push(SubtaskCheckpointGroup {
-                        index: *subtask_index,
-                        bytes: subtask_details.bytes.unwrap_or(0),
-                        event_spans: get_event_spans(subtask_details).into(),
-                    });
-                });
+        checkpoint_details
+            .operators
+            .map(|o| serde_json::from_value(o).unwrap())
+            .unwrap_or_else(HashMap::<String, OperatorCheckpointDetail>::new)
+    };
 
-            operators.push(OperatorCheckpointGroup {
-                operator_id: operator_id.to_string(),
-                bytes: operator_bytes,
-                started_metadata_write: operator_details.started_metadata_write,
-                finish_time: operator_details.finish_time,
-                subtasks,
-            });
-        });
+    let operators = operator_checkpoint_groups(operators);
 
     Ok(Json(OperatorCheckpointGroupCollection { data: operators }))
 }

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -1,8 +1,7 @@
 use crate::queries::api_queries::{DbCheckpoint, DbLogMessage, DbPipelineJob};
 use anyhow::Context;
 use arroyo_rpc::api_types::checkpoints::{
-    Checkpoint, CheckpointEventSpan, JobCheckpointSpan, OperatorCheckpointGroup,
-    SubtaskCheckpointGroup,
+    Checkpoint, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
 };
 use arroyo_rpc::api_types::pipelines::{JobLogLevel, JobLogMessage, OutputData, StopType};
 use arroyo_rpc::api_types::{
@@ -77,25 +76,6 @@ async fn fetch_from_leader<
             },
             _ => log_and_map(e),
         })
-}
-
-fn checkpoint_from_leader(checkpoint: grpc::rpc::JobCheckpointMetadata) -> Checkpoint {
-    Checkpoint {
-        epoch: checkpoint.epoch,
-        backend: checkpoint.state_backend,
-        start_time: checkpoint.start_time,
-        finish_time: checkpoint.finish_time,
-        events: checkpoint
-            .event_spans
-            .into_iter()
-            .map(|span| CheckpointEventSpan {
-                start_time: span.start_time,
-                finish_time: span.finish_time,
-                event: span.event,
-                description: span.description,
-            })
-            .collect(),
-    }
 }
 
 fn operator_checkpoint_groups(
@@ -400,7 +380,7 @@ pub async fn get_job_checkpoints(
         .into_inner()
         .checkpoints
         .into_iter()
-        .map(checkpoint_from_leader)
+        .map(Checkpoint::from)
         .collect()
     } else {
         api_queries::fetch_get_job_checkpoints(&db, &job_pub_id, &auth_data.organization_id)

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -1070,15 +1070,15 @@ pub async fn query_job_by_pub_id<'a>(
     db: &Database<'a>,
     auth_data: &AuthData,
 ) -> Result<Job, ErrorResp> {
-    // make sure pipeline exists
-    query_pipeline_by_pub_id(pipeline_pub_id, db, auth_data).await?;
-
-    Ok(
-        api_queries::fetch_get_pipeline_job(db, &auth_data.organization_id, &job_pub_id)
-            .await?
-            .into_iter()
-            .next()
-            .ok_or_else(|| not_found("Job"))?
-            .into(),
+    Ok(api_queries::fetch_get_pipeline_job(
+        db,
+        &auth_data.organization_id,
+        pipeline_pub_id,
+        &job_pub_id,
     )
+    .await?
+    .into_iter()
+    .next()
+    .ok_or_else(|| not_found("Job"))?
+    .into())
 }

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -56,6 +56,7 @@ impl LeaderManager {
         let response = retry!(
             self.leader_client.get_job_status(JobStatusReq {
                   job_id: self.job_id.to_string(),
+                   generation: self.generation,
                 }).await,
                 5,
                 Duration::from_millis(100),

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -48,7 +48,7 @@ rpc-port = 0
 data-port = 0
 task-slots = 16
 queue-size = 8192
-checkpoint-details-to-keeper = 10
+checkpoint-details-to-keep = 10
 
 [node]
 bind-address = "0.0.0.0"

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -48,6 +48,7 @@ rpc-port = 0
 data-port = 0
 task-slots = 16
 queue-size = 8192
+checkpoint-details-to-keeper = 10
 
 [node]
 bind-address = "0.0.0.0"

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -250,6 +250,7 @@ service JobControllerGrpc {
 
 message JobStatusReq {
   string job_id = 1;
+  uint64 generation = 2;
 }
 
 message CheckpointStatus {
@@ -257,6 +258,21 @@ message CheckpointStatus {
   uint64 started_at = 2;
   optional uint64 finished_at = 3;
   uint64 size_bytes = 4;
+}
+
+message JobCheckpointEventSpan {
+  uint64 start_time = 1;
+  uint64 finish_time = 2;
+  string event = 3;
+  string description = 4;
+}
+
+message JobCheckpointMetadata {
+  uint32 epoch = 1;
+  string state_backend = 2;
+  uint64 start_time = 3;
+  optional uint64 finish_time = 4;
+  repeated JobCheckpointEventSpan event_spans = 5;
 }
 
 enum JobState {
@@ -284,7 +300,7 @@ message JobStatus {
   JobState job_state = 1;
   uint64 updated_at = 2;
   uint64 transitioned_at = 3;
-  optional CheckpointStatus last_checkpoint = 4;
+  optional uint64 last_checkpointed_at = 4;
   optional JobFailure job_failure = 5;
 }
 
@@ -292,6 +308,25 @@ message JobStatusResp {
   string job_id = 1;
   uint64 generation = 2;
   JobStatus job_status = 3;
+}
+
+message GetJobCheckpointsReq {
+  string job_id = 1;
+  uint64 generation = 2;
+}
+
+message GetJobCheckpointsResp {
+  repeated JobCheckpointMetadata checkpoints = 1;
+}
+
+message GetCheckpointDetailsReq {
+  string job_id = 1;
+  uint64 generation = 2;
+  uint64 epoch = 3;
+}
+
+message GetCheckpointDetailsResp {
+  map<string, api.OperatorCheckpointDetail> operators = 1;
 }
 
 message StopJobReq {
@@ -304,6 +339,8 @@ message StopJobResp {
 service JobStatusGrpc {
   rpc GetJobStatus(JobStatusReq) returns (JobStatusResp);
   rpc StopJob(StopJobReq) returns (StopJobResp);
+  rpc GetJobCheckpoints(GetJobCheckpointsReq) returns (GetJobCheckpointsResp);
+  rpc GetCheckpointDetails(GetCheckpointDetailsReq) returns (GetCheckpointDetailsResp);
 }
 
 // Checkpoint metadata

--- a/crates/arroyo-rpc/src/api_types/checkpoints.rs
+++ b/crates/arroyo-rpc/src/api_types/checkpoints.rs
@@ -1,3 +1,4 @@
+use crate::grpc;
 use arroyo_types::to_micros;
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
@@ -11,6 +12,27 @@ pub struct Checkpoint {
     pub start_time: u64,
     pub finish_time: Option<u64>,
     pub events: Vec<CheckpointEventSpan>,
+}
+
+impl From<grpc::rpc::JobCheckpointMetadata> for Checkpoint {
+    fn from(value: grpc::rpc::JobCheckpointMetadata) -> Self {
+        Self {
+            epoch: value.epoch,
+            backend: value.state_backend,
+            start_time: value.start_time,
+            finish_time: value.finish_time,
+            events: value
+                .event_spans
+                .into_iter()
+                .map(|span| CheckpointEventSpan {
+                    start_time: span.start_time,
+                    finish_time: span.finish_time,
+                    event: span.event,
+                    description: span.description,
+                })
+                .collect(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -448,6 +448,9 @@ pub struct WorkerConfig {
     /// TLS configuration for worker TCP shuffling
     #[serde(default)]
     pub tls: Option<TlsConfig>,
+
+    /// Maximum number of checkpoints to keep in history for serving the checkpoint details APIs
+    pub checkpoint_details_to_keep: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -3,8 +3,8 @@ use crate::job_controller::model::{
     WorkerStatus,
 };
 use crate::job_controller::{
-    JobControllerStatus, RetireWorkerLeader, RunningMessage, TaskFailedEvent, WorkerContext,
-    connect_to_worker,
+    CheckpointHistory, JobControllerStatus, RetireWorkerLeader, RunningMessage, TaskFailedEvent,
+    WorkerContext, connect_to_worker,
 };
 use anyhow::{anyhow, bail};
 use arroyo_datastream::logical::LogicalProgram;
@@ -82,6 +82,7 @@ impl WorkerJobController {
         min_epoch: u64,
         rx: Receiver<RunningMessage>,
         job_status: Arc<Mutex<JobStatus>>,
+        checkpoint_history: Arc<Mutex<CheckpointHistory>>,
         checkpoint_interval: Duration,
         parent_ref: Option<(CheckpointRef, CheckpointManifest)>,
     ) -> anyhow::Result<Self> {
@@ -133,7 +134,10 @@ impl WorkerJobController {
             })
             .collect();
 
-        let status = JobControllerStatus { job_status };
+        let status = JobControllerStatus {
+            job_status,
+            checkpoint_history,
+        };
         status.transition(rpc::JobState::JobRunning)?;
 
         // this is also happening on the controller, so the generation manifest should already have

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -1,19 +1,22 @@
-use anyhow::{anyhow, bail};
+use anyhow::bail;
+use arroyo_rpc::api_types::checkpoints::{JobCheckpointEventType, JobCheckpointSpan};
 use arroyo_rpc::checkpoints::{
     CheckpointMetadataStore, CreateCheckpointReq, FinishCheckpointReq, UpdateCheckpointReq,
 };
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::{ErrorDomain, RetryHint};
+use arroyo_rpc::grpc::api::OperatorCheckpointDetail;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::{
     JobFailure, JobStatus, SubtaskCheckpointMetadata, TaskCheckpointEventType,
 };
 use arroyo_rpc::grpc_channel_builder;
 use arroyo_rpc::identity::{WorkerClient, worker_client};
+use arroyo_state::{BackingStore, StateBackend};
 use arroyo_types::WorkerId;
 use arroyo_types::to_micros;
 use async_trait::async_trait;
-use serde_json::Value;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
@@ -22,8 +25,156 @@ use tracing::{error, info};
 // Re-export shared types from arroyo-rpc
 pub use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent, WorkerContext};
 
-pub const CHECKPOINTS_TO_KEEP: u32 = 4;
+pub const CHECKPOINTS_TO_KEEP: u32 = 10;
 pub const COMPACT_EVERY: u32 = 2;
+
+#[derive(Debug, Clone)]
+pub struct StoredCheckpointMetadata {
+    checkpoint_id: String,
+    epoch: u64,
+    state_backend: String,
+    start_time: SystemTime,
+    finish_time: Option<SystemTime>,
+    event_spans: Vec<JobCheckpointSpan>,
+    operator_details: HashMap<String, OperatorCheckpointDetail>,
+    status: arroyo_rpc::checkpoints::CheckpointStatus,
+}
+
+#[derive(Debug, Default)]
+pub struct CheckpointHistory {
+    checkpoints: VecDeque<StoredCheckpointMetadata>,
+}
+
+fn checkpoint_event_description(event: JobCheckpointEventType) -> &'static str {
+    match event {
+        JobCheckpointEventType::Checkpointing => "The entire checkpointing process",
+        JobCheckpointEventType::CheckpointingOperators => {
+            "The time spent checkpointing operator states"
+        }
+        JobCheckpointEventType::WritingMetadata => "Writing the final checkpoint metadata",
+        JobCheckpointEventType::Compacting => "Compacting old checkpoints",
+        JobCheckpointEventType::Committing => {
+            "Running two-phase commit for transactional connectors"
+        }
+    }
+}
+
+fn checkpoint_span_to_rpc(span: JobCheckpointSpan) -> rpc::JobCheckpointEventSpan {
+    rpc::JobCheckpointEventSpan {
+        start_time: span.start_time,
+        finish_time: span.finish_time.unwrap_or_default(),
+        event: format!("{:?}", span.event),
+        description: checkpoint_event_description(span.event).to_string(),
+    }
+}
+
+impl CheckpointHistory {
+    fn prune(&mut self) {
+        while self.checkpoints.len() > CHECKPOINTS_TO_KEEP as usize {
+            self.checkpoints.pop_front();
+        }
+    }
+
+    fn create_checkpoint(&mut self, req: &CreateCheckpointReq) {
+        let checkpoint = StoredCheckpointMetadata {
+            checkpoint_id: req.checkpoint_id.clone(),
+            epoch: req.epoch as u64,
+            state_backend: StateBackend::name().to_string(),
+            start_time: req.start_time,
+            finish_time: None,
+            event_spans: vec![],
+            operator_details: HashMap::new(),
+            status: arroyo_rpc::checkpoints::CheckpointStatus::InProgress,
+        };
+
+        if let Some(existing) = self
+            .checkpoints
+            .iter_mut()
+            .find(|c| c.checkpoint_id == req.checkpoint_id)
+        {
+            *existing = checkpoint;
+        } else {
+            self.checkpoints.push_back(checkpoint);
+        }
+
+        self.prune();
+    }
+
+    fn update_checkpoint(
+        &mut self,
+        checkpoint_id: &str,
+        operator_details: HashMap<String, OperatorCheckpointDetail>,
+        event_spans: Vec<JobCheckpointSpan>,
+        finish_time: Option<SystemTime>,
+        status: arroyo_rpc::checkpoints::CheckpointStatus,
+    ) {
+        if let Some(checkpoint) = self
+            .checkpoints
+            .iter_mut()
+            .find(|c| c.checkpoint_id == checkpoint_id)
+        {
+            checkpoint.operator_details = operator_details;
+            checkpoint.event_spans = event_spans;
+            checkpoint.finish_time = finish_time;
+            checkpoint.status = status;
+        }
+    }
+
+    fn finish_checkpoint(
+        &mut self,
+        checkpoint_id: &str,
+        finish_time: SystemTime,
+        event_spans: Vec<JobCheckpointSpan>,
+    ) {
+        if let Some(checkpoint) = self
+            .checkpoints
+            .iter_mut()
+            .find(|c| c.checkpoint_id == checkpoint_id)
+        {
+            checkpoint.finish_time = Some(finish_time);
+            checkpoint.event_spans = event_spans;
+            checkpoint.status = arroyo_rpc::checkpoints::CheckpointStatus::Ready;
+        }
+    }
+
+    pub fn checkpoints(&self) -> Vec<rpc::JobCheckpointMetadata> {
+        self.checkpoints
+            .iter()
+            .filter(|c| {
+                !matches!(
+                    c.status,
+                    arroyo_rpc::checkpoints::CheckpointStatus::Failed
+                        | arroyo_rpc::checkpoints::CheckpointStatus::Compacted
+                )
+            })
+            .map(|c| rpc::JobCheckpointMetadata {
+                epoch: c.epoch as u32,
+                state_backend: c.state_backend.clone(),
+                start_time: to_micros(c.start_time),
+                finish_time: c.finish_time.map(to_micros),
+                event_spans: c
+                    .event_spans
+                    .iter()
+                    .cloned()
+                    .map(checkpoint_span_to_rpc)
+                    .collect(),
+            })
+            .collect()
+    }
+
+    pub fn operators_for_epoch(
+        &self,
+        epoch: u64,
+    ) -> Option<HashMap<String, OperatorCheckpointDetail>> {
+        self.checkpoints
+            .iter()
+            .find(|c| {
+                c.epoch == epoch
+                    && !matches!(c.status, arroyo_rpc::checkpoints::CheckpointStatus::Failed)
+            })
+            .map(|c| c.operator_details.clone())
+    }
+}
 
 pub mod checkpoint_state;
 pub mod committing_state;
@@ -146,6 +297,7 @@ pub(crate) async fn connect_to_worker(id: WorkerId, addr: String) -> anyhow::Res
 #[derive(Clone)]
 pub struct JobControllerStatus {
     pub job_status: Arc<Mutex<JobStatus>>,
+    pub checkpoint_history: Arc<Mutex<CheckpointHistory>>,
 }
 
 impl JobControllerStatus {
@@ -200,66 +352,44 @@ impl JobControllerStatus {
     }
 }
 
-fn checkpoint_size_bytes(operator_details: &Value) -> u64 {
-    operator_details
-        .as_object()
-        .into_iter()
-        .flat_map(|operators| operators.values())
-        .filter_map(|operator| operator.get("tasks"))
-        .filter_map(Value::as_object)
-        .flat_map(|tasks| tasks.values())
-        .filter_map(|task| task.get("bytes"))
-        .filter_map(Value::as_u64)
-        .sum()
-}
-
-fn update_last_checkpoint(
-    job_status: &Arc<Mutex<JobStatus>>,
-    f: impl FnOnce(&mut rpc::CheckpointStatus),
-) -> anyhow::Result<()> {
-    let mut status = job_status
-        .lock()
-        .map_err(|e| anyhow!("job status mutex poisoned: {e}"))?;
-
-    status.updated_at = to_micros(SystemTime::now());
-
-    let checkpoint = status
-        .last_checkpoint
-        .as_mut()
-        .ok_or_else(|| anyhow!("job status missing last checkpoint"))?;
-
-    f(checkpoint);
-    Ok(())
-}
-
 #[async_trait]
 impl CheckpointMetadataStore for JobControllerStatus {
     async fn create_checkpoint(&self, req: CreateCheckpointReq) -> anyhow::Result<()> {
-        let mut status = self
-            .job_status
+        self.checkpoint_history
             .lock()
-            .map_err(|e| anyhow!("job status mutex poisoned: {e}"))?;
-        status.last_checkpoint = Some(rpc::CheckpointStatus {
-            epoch: req.epoch,
-            started_at: to_micros(req.start_time),
-            finished_at: None,
-            size_bytes: 0,
-        });
+            .unwrap()
+            .create_checkpoint(&req);
+
         Ok(())
     }
 
     async fn update_checkpoint(&self, req: UpdateCheckpointReq) -> anyhow::Result<()> {
-        let size_bytes = checkpoint_size_bytes(&req.operator_details);
-        update_last_checkpoint(&self.job_status, |checkpoint| {
-            checkpoint.size_bytes = size_bytes;
-            checkpoint.finished_at = req.finish_time.map(to_micros);
-        })
+        let operator_details = serde_json::from_value(req.operator_details.clone())?;
+        let event_spans = serde_json::from_value(req.event_spans.clone())?;
+
+        self.checkpoint_history.lock().unwrap().update_checkpoint(
+            &req.checkpoint_id,
+            operator_details,
+            event_spans,
+            req.finish_time,
+            req.status,
+        );
+
+        Ok(())
     }
 
     async fn finish_checkpoint(&self, req: FinishCheckpointReq) -> anyhow::Result<()> {
-        update_last_checkpoint(&self.job_status, |checkpoint| {
-            checkpoint.finished_at = Some(to_micros(req.finish_time));
-        })
+        let event_spans = serde_json::from_value(req.event_spans.clone())?;
+
+        self.job_status.lock().unwrap().last_checkpointed_at = Some(to_micros(req.finish_time));
+
+        self.checkpoint_history.lock().unwrap().finish_checkpoint(
+            &req.checkpoint_id,
+            req.finish_time,
+            event_spans,
+        );
+
+        Ok(())
     }
 
     async fn mark_compacting(

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -70,7 +70,7 @@ fn checkpoint_span_to_rpc(span: JobCheckpointSpan) -> rpc::JobCheckpointEventSpa
 
 impl CheckpointHistory {
     fn prune(&mut self) {
-        while self.checkpoints.len() > CHECKPOINTS_TO_KEEP as usize {
+        while self.checkpoints.len() > config().worker.checkpoint_details_to_keep as usize {
             self.checkpoints.pop_front();
         }
     }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -2,21 +2,24 @@
 #![allow(clippy::type_complexity)]
 
 use crate::engine::{Engine, Program, SubtaskNode};
-use crate::job_controller::{RetireWorkerLeader, RunningMessage, TaskFailedEvent, WorkerContext};
+use crate::job_controller::{
+    CheckpointHistory, RetireWorkerLeader, RunningMessage, TaskFailedEvent, WorkerContext,
+};
 use crate::network_manager::NetworkManager;
 use anyhow::{Context, Result, anyhow};
 
 use arroyo_rpc::grpc::rpc::worker_grpc_server::{WorkerGrpc, WorkerGrpcServer};
 use arroyo_rpc::grpc::rpc::{
-    CheckpointManifest, CheckpointReq, CheckpointResp, CommitReq, CommitResp, GetWorkerPhaseReq,
-    GetWorkerPhaseResp, HeartbeatReq, HeartbeatResp, JobControllerInitReq, JobControllerInitResp,
-    JobFinishedReq, JobFinishedResp, JobMetricsReq, JobMetricsResp, JobStatus, JobStatusReq,
-    JobStatusResp, JobStopMode, LoadCompactedDataReq, LoadCompactedDataRes, MetricFamily,
-    MetricsReq, MetricsResp, NonfatalErrorReq, RegisterWorkerReq, StartExecutionReq,
-    StartExecutionResp, StopExecutionReq, StopExecutionResp, StopJobReq, StopJobResp,
-    TaskAssignment, TaskCheckpointCompletedReq, TaskCheckpointCompletedResp,
-    TaskCheckpointEventReq, TaskCheckpointEventResp, TaskFailedReq, TaskFailedResp,
-    TaskFinishedReq, TaskFinishedResp, TaskStartedReq, WorkerErrorRes,
+    CheckpointManifest, CheckpointReq, CheckpointResp, CommitReq, CommitResp,
+    GetCheckpointDetailsReq, GetCheckpointDetailsResp, GetJobCheckpointsReq, GetJobCheckpointsResp,
+    GetWorkerPhaseReq, GetWorkerPhaseResp, HeartbeatReq, HeartbeatResp, JobControllerInitReq,
+    JobControllerInitResp, JobFinishedReq, JobFinishedResp, JobMetricsReq, JobMetricsResp,
+    JobStatus, JobStatusReq, JobStatusResp, JobStopMode, LoadCompactedDataReq,
+    LoadCompactedDataRes, MetricFamily, MetricsReq, MetricsResp, NonfatalErrorReq,
+    RegisterWorkerReq, StartExecutionReq, StartExecutionResp, StopExecutionReq, StopExecutionResp,
+    StopJobReq, StopJobResp, TaskAssignment, TaskCheckpointCompletedReq,
+    TaskCheckpointCompletedResp, TaskCheckpointEventReq, TaskCheckpointEventResp, TaskFailedReq,
+    TaskFailedResp, TaskFinishedReq, TaskFinishedResp, TaskStartedReq, WorkerErrorRes,
     WorkerInitializationCompleteReq, WorkerPhase, WorkerResources,
 };
 use arroyo_rpc::identity::VerifyWorkerId;
@@ -204,6 +207,7 @@ pub struct WorkerState {
     // used to send messages to the local job controller -- only on the leader node
     job_controller_tx: Arc<OnceLock<Sender<RunningMessage>>>,
     job_status: Arc<Mutex<JobStatus>>,
+    checkpoint_history: Arc<Mutex<CheckpointHistory>>,
 }
 
 impl WorkerState {
@@ -273,6 +277,7 @@ impl WorkerState {
             min_epoch,
             rx,
             self.job_status.clone(),
+            self.checkpoint_history.clone(),
             checkpoint_interval,
             parent,
         )
@@ -659,9 +664,10 @@ impl WorkerServer {
                     job_state: rpc::JobState::JobInitializing.into(),
                     updated_at: to_micros(SystemTime::now()),
                     transitioned_at: to_micros(SystemTime::now()),
-                    last_checkpoint: None,
+                    last_checkpointed_at: None,
                     job_failure: None,
                 })),
+                checkpoint_history: Arc::new(Mutex::new(CheckpointHistory::default())),
             },
             shutdown_guard,
         }
@@ -1102,6 +1108,20 @@ pub struct LeaderServer {
 }
 
 impl LeaderServer {
+    #[allow(clippy::result_large_err)]
+    fn validate_job_generation(&self, job_id: &str, generation: u64) -> Result<(), Status> {
+        if *self.state.worker_context.job_id != job_id
+            || self.state.worker_context.generation != generation
+        {
+            return Err(Status::failed_precondition(format!(
+                "requested job data for invalid job or generation ({job_id}, {generation}) - expected ({}, {})",
+                self.state.worker_context.job_id, self.state.worker_context.generation,
+            )));
+        }
+
+        Ok(())
+    }
+
     async fn send_job_message(&self, msg: RunningMessage) -> Result<(), Status> {
         self.state
             .job_controller_tx
@@ -1289,26 +1309,51 @@ impl JobStatusGrpc for LeaderServer {
         &self,
         request: Request<JobStatusReq>,
     ) -> std::result::Result<Response<JobStatusResp>, Status> {
-        if self.state.job_controller_tx.get().is_none() {
-            return Err(Status::failed_precondition(
-                "requested job status from non-leader node",
-            ));
-        }
-
-        let job_id = (*self.state.worker_context.job_id.0).clone();
         let req = request.into_inner();
-        if job_id != req.job_id {
-            return Err(Status::failed_precondition(format!(
-                "requested job status for invalid job {} - expected {}",
-                req.job_id, job_id
-            )));
-        }
+        self.validate_job_generation(&req.job_id, req.generation)?;
 
         Ok(Response::new(JobStatusResp {
-            job_id,
+            job_id: req.job_id,
             generation: self.state.worker_context.generation,
             job_status: Some((*self.state.job_status.lock().unwrap()).clone()),
         }))
+    }
+
+    async fn get_job_checkpoints(
+        &self,
+        request: Request<GetJobCheckpointsReq>,
+    ) -> std::result::Result<Response<GetJobCheckpointsResp>, Status> {
+        let req = request.into_inner();
+        self.validate_job_generation(&req.job_id, req.generation)?;
+
+        let checkpoints = self
+            .state
+            .checkpoint_history
+            .lock()
+            .map_err(|e| Status::internal(format!("checkpoint history mutex poisoned: {e}")))?
+            .checkpoints();
+
+        Ok(Response::new(GetJobCheckpointsResp { checkpoints }))
+    }
+
+    async fn get_checkpoint_details(
+        &self,
+        request: Request<GetCheckpointDetailsReq>,
+    ) -> std::result::Result<Response<GetCheckpointDetailsResp>, Status> {
+        let req = request.into_inner();
+        self.validate_job_generation(&req.job_id, req.generation)?;
+
+        let operators = self
+            .state
+            .checkpoint_history
+            .lock()
+            .map_err(|e| Status::internal(format!("checkpoint history mutex poisoned: {e}")))?
+            .operators_for_epoch(req.epoch)
+            .ok_or_else(|| {
+                Status::not_found(format!("checkpoint with epoch {} was not found", req.epoch))
+            })?;
+
+        Ok(Response::new(GetCheckpointDetailsResp { operators }))
     }
 
     async fn stop_job(

--- a/webui/src/components/CheckpointDetails.tsx
+++ b/webui/src/components/CheckpointDetails.tsx
@@ -27,23 +27,27 @@ interface CheckpointTimelineProps {
 }
 
 export function formatDuration(micros: number): string {
-  let millis = micros / 1000;
+  const sign = micros < 0 ? '-' : '';
+  let millis = Math.abs(micros) / 1000;
   let secs = Math.floor(millis / 1000);
   if (millis < 1000) {
-    return `${millis.toFixed(1)} ms`;
+    return `${sign}${millis.toFixed(1)} ms`;
   } else if (millis < 10000) {
-    return `${Math.floor(millis)} ms`;
+    return `${sign}${Math.floor(millis)} ms`;
   } else if (secs < 60) {
-    return `${secs} s`;
+    return `${sign}${secs} s`;
   } else if (millis / 1000 < 60 * 60) {
     let minutes = Math.floor(secs / 60);
     let seconds = secs - minutes * 60;
-    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    return `${sign}${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   } else {
     let hours = Math.floor(secs / (60 * 60));
     let minutes = Math.floor((secs - hours * 60 * 60) / 60);
     let seconds = secs - hours * 60 * 60 - minutes * 60;
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    return `${sign}${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(
+      2,
+      '0'
+    )}`;
   }
 }
 
@@ -182,11 +186,13 @@ const CheckpointTimeline: React.FC<CheckpointTimelineProps> = ({ operators, chec
     const height = currentY;
 
     const tooltip = d3.select(tooltipRef.current!);
-    const checkpointDuration = checkpointEndTime! - checkpointStartTime;
-    const xScale = d3
-      .scaleLinear()
-      .domain([0, checkpointDuration > 0 ? checkpointDuration : 1])
-      .range([0, width]);
+    const checkpointDuration =
+      checkpointEndTime != null ? checkpointEndTime - checkpointStartTime : 0;
+    const firstSpanStart = d3.min(initialFlatData, d => d.start_time) ?? 0;
+    const lastSpanFinish = d3.max(initialFlatData, d => d.finish_time) ?? checkpointDuration;
+    const timelineStart = Math.min(0, firstSpanStart);
+    const timelineEnd = Math.max(checkpointDuration, lastSpanFinish, timelineStart + 1);
+    const xScale = d3.scaleLinear().domain([timelineStart, timelineEnd]).range([0, width]);
 
     // Dynamic color scale
     const colorScale = d3.scaleOrdinal<string>(d3.schemeTableau10).domain(Array.from(allSpanTypes));

--- a/webui/src/components/Checkpoints.tsx
+++ b/webui/src/components/Checkpoints.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
   Badge,
   Box,
   Flex,
@@ -14,18 +18,55 @@ import {
   UnorderedList,
 } from '@chakra-ui/react';
 import { Checkpoint, Job, Pipeline, useCheckpointDetails } from '../lib/data_fetching';
-import { dataFormat } from '../lib/util';
+import { dataFormat, formatError } from '../lib/util';
 import { CheckpointDetails, formatDuration } from './CheckpointDetails';
 
 export interface CheckpointsProps {
   pipeline: Pipeline;
   job: Job;
   checkpoints: Array<Checkpoint>;
+  checkpointsError?: any;
 }
 
-const Checkpoints: React.FC<CheckpointsProps> = ({ pipeline, job, checkpoints }) => {
+const CHECKPOINT_LEADER_UNAVAILABLE_MESSAGE =
+  'Checkpoint data for a running job is served by the job leader. The API server is online, but it could not reach the current leader to proxy this request. The leader may be restarting, failing over, or temporarily unreachable; refresh or try again in a moment.';
+
+const CheckpointErrorAlert: React.FC<{ error: any }> = ({ error }) => {
+  const leaderUnavailable = error?.status === 502;
+
+  return (
+    <Alert status={leaderUnavailable ? 'warning' : 'error'} marginTop={5}>
+      <AlertIcon />
+      <Box>
+        <AlertTitle>
+          {leaderUnavailable
+            ? 'Checkpoint information unavailable'
+            : 'Failed to load checkpoint information'}
+        </AlertTitle>
+        <AlertDescription>
+          {leaderUnavailable ? CHECKPOINT_LEADER_UNAVAILABLE_MESSAGE : formatError(error)}
+        </AlertDescription>
+      </Box>
+    </Alert>
+  );
+};
+
+const Checkpoints: React.FC<CheckpointsProps> = ({
+  pipeline,
+  job,
+  checkpoints,
+  checkpointsError,
+}) => {
   const [epoch, setEpoch] = useState<number | undefined>(undefined);
-  const { checkpointDetails } = useCheckpointDetails(pipeline.id, job.id, epoch);
+  const { checkpointDetails, checkpointLoading, checkpointDetailsError } = useCheckpointDetails(
+    pipeline.id,
+    job.id,
+    epoch
+  );
+
+  if (checkpointsError) {
+    return <CheckpointErrorAlert error={checkpointsError} />;
+  }
 
   if (!checkpoints.length) {
     return <Text textStyle="italic">No checkpoints</Text>;
@@ -35,55 +76,82 @@ const Checkpoints: React.FC<CheckpointsProps> = ({ pipeline, job, checkpoints })
 
   let checkpoint: Checkpoint | undefined = checkpoints.find(c => c.epoch == epoch);
 
-  if (checkpoint && checkpointDetails) {
-    let start = Number(checkpoint.start_time);
-    let end = Number(checkpoint.finish_time ?? new Date().getTime() * 1000);
-
-    let checkpointBytes = checkpointDetails.map(d => d.bytes).reduce((a, b) => a + b, 0);
-
-    const checkpointStats = (
-      <StatGroup width={800} border="1px solid #666" borderRadius="5px" marginTop={5} padding={3}>
-        <Stat>
-          <StatLabel>Started</StatLabel>
-          <StatNumber>
-            {new Intl.DateTimeFormat('en-us', {
-              dateStyle: undefined,
-              timeStyle: 'medium',
-            }).format(new Date(Number(checkpoint.start_time) / 1000))}
-          </StatNumber>
-        </Stat>
-        <Stat marginLeft={10}>
-          <StatLabel>Finished</StatLabel>
-          <StatNumber>
-            {checkpoint.finish_time != null
-              ? new Intl.DateTimeFormat('en-us', {
-                  dateStyle: undefined,
-                  timeStyle: 'medium',
-                }).format(new Date(Number(checkpoint.finish_time) / 1000))
-              : '-'}
-          </StatNumber>
-        </Stat>
-        <Stat marginLeft={10}>
-          <StatLabel>Duration</StatLabel>
-          <StatNumber>{formatDuration(end - start)}</StatNumber>
-        </Stat>
-        <Stat marginLeft={10}>
-          <StatLabel>Total Size</StatLabel>
-          <StatNumber> {dataFormat(checkpointBytes)} </StatNumber>
-        </Stat>
-      </StatGroup>
+  if (checkpoint) {
+    const checkpointHeading = (
+      <Heading size="md">
+        Checkpoint {epoch}
+        <Badge marginLeft={2}>{checkpoint.backend}</Badge>
+      </Heading>
     );
 
-    details = (
-      <Flex flexDirection={'column'} flexGrow={1}>
-        <Heading size="md">
-          Checkpoint {epoch}
-          <Badge marginLeft={2}>{checkpoint.backend}</Badge>
-        </Heading>
-        {checkpointStats}
-        <CheckpointDetails operators={checkpointDetails} checkpoint={checkpoint} />
-      </Flex>
-    );
+    if (checkpointDetailsError) {
+      details = (
+        <Flex flexDirection={'column'} flexGrow={1}>
+          {checkpointHeading}
+          <CheckpointErrorAlert error={checkpointDetailsError} />
+        </Flex>
+      );
+    } else if (checkpointDetails) {
+      let start = Number(checkpoint.start_time);
+      let end = Number(checkpoint.finish_time ?? new Date().getTime() * 1000);
+
+      let checkpointBytes = checkpointDetails.map(d => d.bytes).reduce((a, b) => a + b, 0);
+
+      const checkpointStats = (
+        <StatGroup width={800} border="1px solid #666" borderRadius="5px" marginTop={5} padding={3}>
+          <Stat>
+            <StatLabel>Started</StatLabel>
+            <StatNumber>
+              {new Intl.DateTimeFormat('en-us', {
+                dateStyle: undefined,
+                timeStyle: 'medium',
+              }).format(new Date(Number(checkpoint.start_time) / 1000))}
+            </StatNumber>
+          </Stat>
+          <Stat marginLeft={10}>
+            <StatLabel>Finished</StatLabel>
+            <StatNumber>
+              {checkpoint.finish_time != null
+                ? new Intl.DateTimeFormat('en-us', {
+                    dateStyle: undefined,
+                    timeStyle: 'medium',
+                  }).format(new Date(Number(checkpoint.finish_time) / 1000))
+                : '-'}
+            </StatNumber>
+          </Stat>
+          <Stat marginLeft={10}>
+            <StatLabel>Duration</StatLabel>
+            <StatNumber>{formatDuration(end - start)}</StatNumber>
+          </Stat>
+          <Stat marginLeft={10}>
+            <StatLabel>Total Size</StatLabel>
+            <StatNumber> {dataFormat(checkpointBytes)} </StatNumber>
+          </Stat>
+        </StatGroup>
+      );
+
+      details = (
+        <Flex flexDirection={'column'} flexGrow={1}>
+          {checkpointHeading}
+          {checkpointStats}
+          <CheckpointDetails operators={checkpointDetails} checkpoint={checkpoint} />
+        </Flex>
+      );
+    } else if (checkpointLoading) {
+      details = (
+        <Flex flexDirection={'column'} flexGrow={1}>
+          {checkpointHeading}
+          <Text marginTop={5}>Loading checkpoint details...</Text>
+        </Flex>
+      );
+    } else {
+      details = (
+        <Flex flexDirection={'column'} flexGrow={1}>
+          {checkpointHeading}
+          <Text marginTop={5}>Select checkpoint</Text>
+        </Flex>
+      );
+    }
   }
 
   return (

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -39,11 +39,14 @@ const BASE_URL = `${base}/api`;
 
 export const { get, post, patch, del } = createClient<paths>({ baseUrl: BASE_URL });
 
-const processResponse = (data: any | undefined, error: any | undefined) => {
+const processResponse = (data: any | undefined, error: any | undefined, response?: Response) => {
   // SWR expects fetchers to throw errors, but openapi-fetch returns the error as a named field,
   // so this function throws the error if it exists
   if (error) {
-    throw error;
+    if (typeof error === 'object' && error != null) {
+      throw { ...error, status: response?.status };
+    }
+    throw { error: String(error), status: response?.status };
   }
   return data;
 };
@@ -318,21 +321,24 @@ export const useJobMetrics = (pipelineId?: string, jobId?: string) => {
 
 const jobCheckpointsFetcher = () => {
   return async (params: { key: string; pipelineId: string; jobId: string }) => {
-    const { data, error } = await get('/v1/pipelines/{pipeline_id}/jobs/{job_id}/checkpoints', {
-      params: {
-        path: {
-          pipeline_id: params.pipelineId,
-          job_id: params.jobId,
+    const { data, error, response } = await get(
+      '/v1/pipelines/{pipeline_id}/jobs/{job_id}/checkpoints',
+      {
+        params: {
+          path: {
+            pipeline_id: params.pipelineId,
+            job_id: params.jobId,
+          },
         },
-      },
-    });
+      }
+    );
 
-    return processResponse(data, error);
+    return processResponse(data, error, response);
   };
 };
 
 export const useJobCheckpoints = (pipelineId?: string, jobId?: string) => {
-  const { data } = useSWR<schemas['CheckpointCollection']>(
+  const { data, error } = useSWR<schemas['CheckpointCollection']>(
     jobCheckpointsKey(pipelineId, jobId),
     jobCheckpointsFetcher(),
     {
@@ -342,6 +348,7 @@ export const useJobCheckpoints = (pipelineId?: string, jobId?: string) => {
 
   return {
     checkpoints: data?.data,
+    checkpointsError: error,
   };
 };
 
@@ -349,7 +356,7 @@ export const useJobCheckpoints = (pipelineId?: string, jobId?: string) => {
 
 const checkpointDetailsFetcher = () => {
   return async (params: { key: string; pipelineId: string; jobId: string; epoch: number }) => {
-    const { data, error } = await get(
+    const { data, error, response } = await get(
       '/v1/pipelines/{pipeline_id}/jobs/{job_id}/checkpoints/{epoch}/operator_checkpoint_groups',
       {
         params: {
@@ -357,12 +364,12 @@ const checkpointDetailsFetcher = () => {
         },
       }
     );
-    return processResponse(data, error);
+    return processResponse(data, error, response);
   };
 };
 
 export const useCheckpointDetails = (pipelineId?: string, jobId?: string, epoch?: number) => {
-  const { data, isLoading } = useSWR<schemas['OperatorCheckpointGroupCollection']>(
+  const { data, isLoading, error } = useSWR<schemas['OperatorCheckpointGroupCollection']>(
     checkpointDetailsKey(pipelineId, jobId, epoch),
     checkpointDetailsFetcher(),
     {}
@@ -371,6 +378,7 @@ export const useCheckpointDetails = (pipelineId?: string, jobId?: string, epoch?
   return {
     checkpointDetails: data?.data,
     checkpointLoading: isLoading,
+    checkpointDetailsError: error,
   };
 };
 

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -82,7 +82,7 @@ export function PipelineDetails() {
   const { pipeline, pipelineError, updatePipeline, restartPipeline } = usePipeline(id, true);
   const { jobs, jobsError } = usePipelineJobs(id, true);
   const job = jobs?.length ? jobs[0] : undefined;
-  const { checkpoints } = useJobCheckpoints(id, job?.id);
+  const { checkpoints, checkpointsError } = useJobCheckpoints(id, job?.id);
   const { operatorErrorsPages, operatorErrorsTotalPages, setOperatorErrorsMaxPages } =
     useOperatorErrors(id, job?.id);
   const [operatorErrors, setOperatorErrors] = useState<JobLogMessage[]>([]);
@@ -185,7 +185,14 @@ export function PipelineDetails() {
 
   const checkpointsTab = (
     <TabPanel>
-      {<Checkpoints pipeline={pipeline} job={job} checkpoints={checkpoints ?? []} />}
+      {
+        <Checkpoints
+          pipeline={pipeline}
+          job={job}
+          checkpoints={checkpoints ?? []}
+          checkpointsError={checkpointsError}
+        />
+      }
     </TabPanel>
   );
 


### PR DESCRIPTION
The checkpoint status and details view of the web ui is backed by checkpoint metadata stored in the database. In leader mode, we can no longer store this in the DB, so we need a different approach.

This PR adds a new in-memory checkpoint metadata store in the leader and a new pair of RPC methods to expose the list of checkpoints and details of a particular checkpoint.

These are called by the API server, which looks up the leader information via the state_context field added in #1055.

I've also included a fix to the checkpoint timeline view, which could overlap with the labels if the there were events with times before the checkpoint start time (which can be off by a few ms).
