### PR TITLE
Add MsgPack format support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Kafka
         run: |
-          wget --progress=dot --show-progress  https://dlcdn.apache.org/kafka/3.9.2/kafka_2.13-3.9.2.tgz
+          wget --progress=dot --show-progress  https://archive.apache.org/dist/kafka/3.9.2/kafka_2.13-3.9.2.tgz
           tar xvfz kafka*.tgz
           mkdir /tmp/kraft-combined-logs
           kafka_*/bin/kafka-storage.sh format -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/kraft/server.properties

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "prost-build",
  "prost-reflect",
  "regex",
+ "rmpv",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -8460,6 +8461,24 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
 
 [[package]]
 name = "roaring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ itertools = "0.14.0"
 lazy_static = "1.4.0"
 once_cell = "1.17.1"
 regex = "1.10.6"
+rmpv = "1.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }

--- a/crates/arroyo-api/src/connection_tables.rs
+++ b/crates/arroyo-api/src/connection_tables.rs
@@ -459,6 +459,7 @@ pub(crate) async fn expand_schema(
         Format::Parquet(_) => Ok(schema),
         Format::RawString(_) => Ok(schema),
         Format::RawBytes(_) => Ok(schema),
+        Format::MsgPack(_) => Ok(schema),
         Format::Protobuf(_) => {
             expand_proto_schema(
                 connector,

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -331,6 +331,7 @@ impl IntoResponse for HttpError {
         JsonCompression,
         AvroFormat,
         ProtobufFormat,
+        MsgPackFormat,
         ParquetFormat,
         ParquetCompression,
         RawStringFormat,

--- a/crates/arroyo-connectors/src/filesystem/source.rs
+++ b/crates/arroyo-connectors/src/filesystem/source.rs
@@ -295,6 +295,7 @@ impl FileSystemSourceFunc {
             Format::RawString(_) => todo!(),
             Format::RawBytes(_) => todo!(),
             Format::Protobuf(_) => todo!("Protobuf not supported"),
+            Format::MsgPack(_) => todo!("MsgPack not supported"),
         }
     }
 

--- a/crates/arroyo-connectors/src/kafka/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/mod.rs
@@ -718,6 +718,32 @@ impl KafkaTester {
             Format::RawBytes(_) => {
                 // all bytes are valid
             }
+            Format::MsgPack(_) => {
+                let aschema: ArroyoSchema = schema.clone().into();
+                let mut deserializer = ArrowDeserializer::new(
+                    format.clone(),
+                    Arc::new(aschema),
+                    &schema.metadata_fields(),
+                    None,
+                    BadData::Fail {},
+                );
+
+                let mut error = deserializer
+                    .deserialize_slice(&msg, SystemTime::now(), None)
+                    .await
+                    .into_iter()
+                    .next();
+                if let Some(e) = deserializer.flush_buffer().1.pop() {
+                    error.replace(e);
+                }
+
+                if let Some(error) = error {
+                    bail!(
+                        "Failed to parse message according to the provided MsgPack schema: {}",
+                        error
+                    );
+                }
+            }
             Format::Protobuf(_) => {
                 let aschema: ArroyoSchema = schema.clone().into();
                 let mut deserializer = ArrowDeserializer::new(

--- a/crates/arroyo-formats/Cargo.toml
+++ b/crates/arroyo-formats/Cargo.toml
@@ -27,3 +27,4 @@ base64 = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
 integer-encoding = "4.0.2"
+rmpv = { workspace = true }

--- a/crates/arroyo-formats/src/de.rs
+++ b/crates/arroyo-formats/src/de.rs
@@ -1,6 +1,6 @@
 use crate::avro::de;
 use crate::proto::schema::get_pool;
-use crate::{proto, should_flush};
+use crate::{msgpack, proto, should_flush};
 use arrow::array::{Int32Builder, Int64Builder};
 use arrow::compute::kernels;
 use arrow::json::reader::{FailureKind, JsonType, ValidationError};
@@ -13,7 +13,9 @@ use arrow_array::{ArrayRef, BooleanArray, RecordBatch};
 use arrow_schema::{DataType, Schema, SchemaRef};
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::errors::{DataflowError, DataflowResult, SourceError};
-use arroyo_rpc::formats::{AvroFormat, BadData, Format, Framing, JsonFormat, ProtobufFormat};
+use arroyo_rpc::formats::{
+    AvroFormat, BadData, Format, Framing, JsonFormat, MsgPackFormat, ProtobufFormat,
+};
 use arroyo_rpc::log_event;
 use arroyo_rpc::schema_resolver::{FailingSchemaResolver, FixedSchemaResolver, SchemaResolver};
 use arroyo_rpc::{MetadataField, TIMESTAMP_FIELD};
@@ -432,6 +434,10 @@ impl ArrowDeserializer {
             | Format::Protobuf(ProtobufFormat {
                 into_unstructured_json: false,
                 ..
+            })
+            | Format::MsgPack(MsgPackFormat {
+                into_unstructured_json: false,
+                ..
             }) => BufferDecoder::JsonDecoder {
                 decoder: arrow_json::reader::ReaderBuilder::new(schema_without_additional.clone())
                     .with_limit_to_batch_size(false)
@@ -650,6 +656,21 @@ impl ArrowDeserializer {
                         .map_err(|e| SourceError::bad_data(format!("invalid JSON: {e:?}")))?;
                 }
             }
+            Format::MsgPack(msgpack) => {
+                let json = msgpack::msgpack_to_json(msg)?;
+
+                if msgpack.into_unstructured_json {
+                    self.decode_into_json(json);
+                } else {
+                    if !json.is_object() {
+                        return Err(SourceError::bad_data("MsgPack record must be a map/object"));
+                    }
+
+                    self.buffer_decoder
+                        .decode_json(json.to_string().as_bytes())
+                        .map_err(|e| SourceError::bad_data(format!("invalid JSON: {e:?}")))?;
+                }
+            }
             Format::Avro(_) => unreachable!("this should not be called for avro"),
             Format::Parquet(_) => todo!("parquet is not supported as an input format"),
         }
@@ -809,9 +830,11 @@ mod tests {
     use arroyo_rpc::df::ArroyoSchema;
     use arroyo_rpc::errors::DataflowError;
     use arroyo_rpc::formats::{
-        BadData, Format, Framing, JsonFormat, NewlineDelimitedFraming, RawBytesFormat,
+        BadData, Format, Framing, JsonFormat, MsgPackFormat, NewlineDelimitedFraming,
+        RawBytesFormat,
     };
     use arroyo_types::to_nanos;
+    use rmpv::Value as MsgPackValue;
     use serde_json::json;
     use std::sync::Arc;
     use std::time::SystemTime;
@@ -1014,6 +1037,142 @@ mod tests {
                 .value(0),
             to_nanos(time) as i64
         );
+    }
+
+    fn encode_msgpack(value: MsgPackValue) -> Vec<u8> {
+        let mut buf = Vec::new();
+        rmpv::encode::write_value(&mut buf, &value).unwrap();
+        buf
+    }
+
+    #[tokio::test]
+    async fn test_msgpack_deserializes_structured_map() {
+        let schema = Arc::new(Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new("payload", arrow_schema::DataType::Binary, false),
+            arrow_schema::Field::new(
+                "_timestamp",
+                arrow_schema::DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+
+        let arroyo_schema = Arc::new(ArroyoSchema::from_schema_unkeyed(schema).unwrap());
+        let mut deserializer = ArrowDeserializer::new(
+            Format::MsgPack(MsgPackFormat::default()),
+            arroyo_schema,
+            &[],
+            None,
+            BadData::Fail {},
+        );
+
+        let msg = encode_msgpack(MsgPackValue::Map(vec![
+            (MsgPackValue::from("id"), MsgPackValue::from(7)),
+            (MsgPackValue::from("name"), MsgPackValue::from("ada")),
+            (
+                MsgPackValue::from("payload"),
+                MsgPackValue::Binary(vec![0, 1, 2, 3]),
+            ),
+        ]));
+
+        let time = SystemTime::now();
+        let errors = deserializer.deserialize_slice(&msg, time, None).await;
+        assert!(errors.is_empty());
+
+        let (batch, errors) = deserializer.flush_buffer();
+        assert!(errors.is_empty());
+        let batch = batch.unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.columns()[0].as_primitive::<Int64Type>().value(0), 7);
+        assert_eq!(batch.columns()[1].as_string::<i32>().value(0), "ada");
+        assert_eq!(
+            batch.columns()[2]
+                .as_bytes::<GenericBinaryType<i32>>()
+                .value(0),
+            &[0, 1, 2, 3]
+        );
+        assert_eq!(
+            batch.columns()[3]
+                .as_primitive::<TimestampNanosecondType>()
+                .value(0),
+            to_nanos(time) as i64
+        );
+    }
+
+    #[tokio::test]
+    async fn test_msgpack_can_decode_into_unstructured_json() {
+        let schema = Arc::new(Schema::new(vec![
+            arrow_schema::Field::new("value", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new(
+                "_timestamp",
+                arrow_schema::DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+
+        let arroyo_schema = Arc::new(ArroyoSchema::from_schema_unkeyed(schema).unwrap());
+        let mut deserializer = ArrowDeserializer::new(
+            Format::MsgPack(MsgPackFormat {
+                into_unstructured_json: true,
+                ..Default::default()
+            }),
+            arroyo_schema,
+            &[],
+            None,
+            BadData::Fail {},
+        );
+
+        let msg = encode_msgpack(MsgPackValue::Array(vec![
+            MsgPackValue::from(1),
+            MsgPackValue::from("two"),
+        ]));
+
+        let errors = deserializer
+            .deserialize_slice(&msg, SystemTime::now(), None)
+            .await;
+        assert!(errors.is_empty());
+
+        let (batch, errors) = deserializer.flush_buffer();
+        assert!(errors.is_empty());
+        let batch = batch.unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(
+            batch.columns()[0].as_string::<i32>().value(0),
+            r#"[1,"two"]"#
+        );
+    }
+
+    #[tokio::test]
+    async fn test_msgpack_structured_records_must_be_maps() {
+        let schema = Arc::new(Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
+            arrow_schema::Field::new(
+                "_timestamp",
+                arrow_schema::DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+
+        let arroyo_schema = Arc::new(ArroyoSchema::from_schema_unkeyed(schema).unwrap());
+        let mut deserializer = ArrowDeserializer::new(
+            Format::MsgPack(MsgPackFormat::default()),
+            arroyo_schema,
+            &[],
+            None,
+            BadData::Fail {},
+        );
+
+        let msg = encode_msgpack(MsgPackValue::Array(vec![MsgPackValue::from(1)]));
+
+        let errors = deserializer
+            .deserialize_slice(&msg, SystemTime::now(), None)
+            .await;
+
+        assert_eq!(errors.len(), 1);
+        assert!(format!("{}", errors[0]).contains("MsgPack record must be a map"));
     }
 
     #[tokio::test]

--- a/crates/arroyo-formats/src/lib.rs
+++ b/crates/arroyo-formats/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 pub mod avro;
 pub mod json;
+pub mod msgpack;
 
 pub mod de;
 pub mod proto;

--- a/crates/arroyo-formats/src/msgpack.rs
+++ b/crates/arroyo-formats/src/msgpack.rs
@@ -1,0 +1,188 @@
+use crate::float_to_json;
+use arrow_schema::{DataType, Field, Fields};
+use arroyo_rpc::errors::{DataflowError, DataflowResult, SourceError};
+use arroyo_rpc::formats::DecimalEncoding;
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use rmpv::Value as MsgPackValue;
+use serde_json::{Map as JsonMap, Number, Value as JsonValue};
+use std::io::Cursor;
+
+pub(crate) fn msgpack_to_json(msg: &[u8]) -> DataflowResult<JsonValue> {
+    let mut cursor = Cursor::new(msg);
+    let value = rmpv::decode::read_value(&mut cursor)
+        .map_err(|e| SourceError::bad_data(format!("failed to deserialize MsgPack: {e:?}")))?;
+
+    if cursor.position() != msg.len() as u64 {
+        return Err(SourceError::bad_data(
+            "MsgPack message contains trailing bytes",
+        ));
+    }
+
+    value_to_json(value)
+}
+
+pub(crate) fn value_to_json(value: MsgPackValue) -> DataflowResult<JsonValue> {
+    Ok(match value {
+        MsgPackValue::Nil => JsonValue::Null,
+        MsgPackValue::Boolean(b) => JsonValue::Bool(b),
+        MsgPackValue::Integer(i) => integer_to_json(i)?,
+        MsgPackValue::F32(f) => float_to_json(f as f64),
+        MsgPackValue::F64(f) => float_to_json(f),
+        MsgPackValue::String(s) => JsonValue::String(msgpack_string_to_string(s)?),
+        MsgPackValue::Binary(b) => JsonValue::String(BASE64_STANDARD.encode(b)),
+        MsgPackValue::Array(a) => JsonValue::Array(
+            a.into_iter()
+                .map(value_to_json)
+                .collect::<Result<Vec<_>, DataflowError>>()?,
+        ),
+        MsgPackValue::Map(m) => {
+            let mut obj = JsonMap::new();
+            for (key, value) in m {
+                let key = match key {
+                    MsgPackValue::String(s) => msgpack_string_to_string(s)?,
+                    _ => {
+                        return Err(SourceError::bad_data(
+                            "MsgPack map keys must be strings to decode into Arroyo rows",
+                        ));
+                    }
+                };
+                obj.insert(key, value_to_json(value)?);
+            }
+            JsonValue::Object(obj)
+        }
+        MsgPackValue::Ext(_, _) => {
+            return Err(SourceError::bad_data(
+                "MsgPack extension values are not supported",
+            ));
+        }
+    })
+}
+
+fn msgpack_string_to_string(s: rmpv::Utf8String) -> DataflowResult<String> {
+    s.as_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| SourceError::bad_data("MsgPack string is not valid UTF-8"))
+}
+
+fn integer_to_json(i: rmpv::Integer) -> DataflowResult<JsonValue> {
+    if let Some(i) = i.as_i64() {
+        Ok(JsonValue::Number(Number::from(i)))
+    } else if let Some(u) = i.as_u64() {
+        Ok(JsonValue::Number(Number::from(u)))
+    } else {
+        Err(SourceError::bad_data(
+            "MsgPack integer is too large to represent in JSON",
+        ))
+    }
+}
+
+pub(crate) fn json_to_msgpack(
+    value: &JsonValue,
+    field: Option<&Field>,
+    decimal_encoding: DecimalEncoding,
+) -> Result<MsgPackValue, String> {
+    if value.is_null() {
+        return Ok(MsgPackValue::Nil);
+    }
+
+    let data_type = field.map(Field::data_type);
+    match data_type {
+        Some(DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_)) => {
+            return json_base64_to_msgpack_binary(value, "binary field");
+        }
+        Some(DataType::Decimal128(_, _) | DataType::Decimal256(_, _))
+            if matches!(decimal_encoding, DecimalEncoding::Bytes) =>
+        {
+            return json_base64_to_msgpack_binary(value, "decimal field");
+        }
+        Some(DataType::Struct(fields)) => {
+            return json_object_to_msgpack(value, fields, decimal_encoding);
+        }
+        Some(
+            DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _),
+        ) => {
+            return json_array_to_msgpack(value, Some(field.as_ref()), decimal_encoding);
+        }
+        _ => {}
+    }
+
+    match value {
+        JsonValue::Null => Ok(MsgPackValue::Nil),
+        JsonValue::Bool(b) => Ok(MsgPackValue::from(*b)),
+        JsonValue::Number(n) => json_number_to_msgpack(n),
+        JsonValue::String(s) => Ok(MsgPackValue::from(s.as_str())),
+        JsonValue::Array(_) => json_array_to_msgpack(value, None, decimal_encoding),
+        JsonValue::Object(_) => json_object_to_msgpack(value, &Fields::empty(), decimal_encoding),
+    }
+}
+
+fn json_object_to_msgpack(
+    value: &JsonValue,
+    fields: &Fields,
+    decimal_encoding: DecimalEncoding,
+) -> Result<MsgPackValue, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "expected JSON object for MessagePack map".to_string())?;
+
+    let mut entries = Vec::with_capacity(obj.len());
+    if fields.is_empty() {
+        for (key, value) in obj {
+            entries.push((
+                MsgPackValue::from(key.as_str()),
+                json_to_msgpack(value, None, decimal_encoding)?,
+            ));
+        }
+    } else {
+        for field in fields {
+            if let Some(value) = obj.get(field.name()) {
+                entries.push((
+                    MsgPackValue::from(field.name().as_str()),
+                    json_to_msgpack(value, Some(field), decimal_encoding)?,
+                ));
+            }
+        }
+    }
+
+    Ok(MsgPackValue::Map(entries))
+}
+
+fn json_array_to_msgpack(
+    value: &JsonValue,
+    item_field: Option<&Field>,
+    decimal_encoding: DecimalEncoding,
+) -> Result<MsgPackValue, String> {
+    let array = value
+        .as_array()
+        .ok_or_else(|| "expected JSON array for MessagePack array".to_string())?;
+
+    Ok(MsgPackValue::Array(
+        array
+            .iter()
+            .map(|v| json_to_msgpack(v, item_field, decimal_encoding))
+            .collect::<Result<Vec<_>, String>>()?,
+    ))
+}
+
+fn json_base64_to_msgpack_binary(value: &JsonValue, context: &str) -> Result<MsgPackValue, String> {
+    let s = value
+        .as_str()
+        .ok_or_else(|| format!("expected base64 string for {context}"))?;
+    let bytes = BASE64_STANDARD
+        .decode(s)
+        .map_err(|e| format!("invalid base64 string for {context}: {e}"))?;
+    Ok(MsgPackValue::Binary(bytes))
+}
+
+fn json_number_to_msgpack(n: &Number) -> Result<MsgPackValue, String> {
+    if let Some(i) = n.as_i64() {
+        Ok(MsgPackValue::from(i))
+    } else if let Some(u) = n.as_u64() {
+        Ok(MsgPackValue::from(u))
+    } else if let Some(f) = n.as_f64() {
+        Ok(MsgPackValue::from(f))
+    } else {
+        Err("JSON number cannot be represented as MessagePack".to_string())
+    }
+}

--- a/crates/arroyo-formats/src/ser.rs
+++ b/crates/arroyo-formats/src/ser.rs
@@ -1,6 +1,6 @@
 use crate::avro::schema;
 use crate::json::encoders::ArroyoEncoderFactory;
-use crate::{avro, json};
+use crate::{avro, json, msgpack};
 use arrow_array::cast::AsArray;
 use arrow_array::types::GenericBinaryType;
 use arrow_array::{Array, RecordBatch, StructArray};
@@ -9,8 +9,8 @@ use arrow_json::writer::make_encoder;
 use arrow_schema::{ArrowError, DataType, Field};
 use arroyo_rpc::TIMESTAMP_FIELD;
 use arroyo_rpc::formats::{
-    AvroFormat, DecimalEncoding, Format, JsonFormat, RawBytesFormat, RawStringFormat,
-    TimestampFormat,
+    AvroFormat, DecimalEncoding, Format, JsonFormat, MsgPackFormat, RawBytesFormat,
+    RawStringFormat, TimestampFormat,
 };
 use serde_json::Value;
 use std::sync::Arc;
@@ -121,6 +121,7 @@ impl ArrowSerializer {
             Format::Parquet(_) => todo!("parquet"),
             Format::RawString(RawStringFormat {}) => self.serialize_raw_string(&batch),
             Format::RawBytes(RawBytesFormat {}) => self.serialize_raw_bytes(&batch),
+            Format::MsgPack(msgpack) => self.serialize_msgpack(msgpack, &batch),
             Format::Protobuf(_) => {
                 todo!("protobuf serializer!")
             }
@@ -227,6 +228,36 @@ impl ArrowSerializer {
         Box::new(values.into_iter())
     }
 
+    fn serialize_msgpack(
+        &self,
+        msgpack_format: &MsgPackFormat,
+        batch: &RecordBatch,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + Send> {
+        let rows = record_batch_to_vec(
+            batch,
+            true,
+            msgpack_format.timestamp_format,
+            msgpack_format.decimal_encoding,
+        )
+        .unwrap();
+        let fields = batch.schema().fields().clone();
+        let decimal_encoding = msgpack_format.decimal_encoding;
+
+        Box::new(rows.into_iter().map(move |row| {
+            let parsed: serde_json::Value = serde_json::from_slice(&row).unwrap();
+            let value = msgpack::json_to_msgpack(
+                &parsed,
+                Some(&Field::new_struct("", fields.clone(), false)),
+                decimal_encoding,
+            )
+            .expect("failed to convert JSON row to MessagePack");
+
+            let mut buf = Vec::with_capacity(row.len());
+            rmpv::encode::write_value(&mut buf, &value).expect("msgpack serialization failed");
+            buf
+        }))
+    }
+
     fn serialize_avro(
         &self,
         format: &AvroFormat,
@@ -280,9 +311,12 @@ mod tests {
     use arrow_array::builder::{Decimal128Builder, TimestampNanosecondBuilder};
     use arrow_schema::{Schema, TimeUnit};
     use arroyo_rpc::formats::{
-        DecimalEncoding, Format, JsonFormat, RawBytesFormat, RawStringFormat, TimestampFormat,
+        DecimalEncoding, Format, JsonFormat, MsgPackFormat, RawBytesFormat, RawStringFormat,
+        TimestampFormat,
     };
     use arroyo_types::to_nanos;
+    use rmpv::Value as MsgPackValue;
+    use std::io::Cursor;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
@@ -622,5 +656,88 @@ mod tests {
         assert_eq!(iter.next().unwrap(), br#"{"value":"MTIzMTIz"}"#);
         assert_eq!(iter.next().unwrap(), br#"{"value":"AAECAwQ="}"#);
         assert_eq!(iter.next(), None);
+    }
+
+    fn msgpack_map_value<'a>(value: &'a MsgPackValue, key: &str) -> &'a MsgPackValue {
+        let MsgPackValue::Map(entries) = value else {
+            panic!("expected msgpack map, got {value:?}");
+        };
+
+        entries
+            .iter()
+            .find_map(|(k, v)| (k.as_str() == Some(key)).then_some(v))
+            .unwrap_or_else(|| panic!("missing msgpack key {key}"))
+    }
+
+    #[test]
+    fn test_msgpack_serializes_rows_and_binary_values() {
+        let mut serializer = ArrowSerializer::new(Format::MsgPack(MsgPackFormat::default()));
+
+        let names = vec!["ada".to_string(), "grace".to_string()];
+        let scores = vec![7, 11];
+        let active = vec![true, false];
+        let payloads = vec![b"\x00\x01\x02".as_slice(), b"hello".as_slice()];
+        let ts: Vec<_> = names
+            .iter()
+            .enumerate()
+            .map(|(i, _)| to_nanos(SystemTime::now() + Duration::from_secs(i as u64)) as i64)
+            .collect();
+
+        let schema = Arc::new(Schema::new(vec![
+            arrow_schema::Field::new("name", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new("score", arrow_schema::DataType::Int32, false),
+            arrow_schema::Field::new("active", arrow_schema::DataType::Boolean, false),
+            arrow_schema::Field::new("payload", arrow_schema::DataType::Binary, false),
+            arrow_schema::Field::new(
+                "_timestamp",
+                arrow_schema::DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+
+        let batch = arrow_array::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(arrow_array::StringArray::from(names)),
+                Arc::new(arrow_array::Int32Array::from(scores)),
+                Arc::new(arrow_array::BooleanArray::from(active)),
+                Arc::new(arrow_array::GenericBinaryArray::<i32>::from(payloads)),
+                Arc::new(arrow_array::TimestampNanosecondArray::from(ts)),
+            ],
+        )
+        .unwrap();
+
+        let mut iter = serializer.serialize(&batch);
+        let first = rmpv::decode::read_value(&mut Cursor::new(iter.next().unwrap())).unwrap();
+        let second = rmpv::decode::read_value(&mut Cursor::new(iter.next().unwrap())).unwrap();
+        assert_eq!(iter.next(), None);
+
+        assert_eq!(
+            msgpack_map_value(&first, "name"),
+            &MsgPackValue::from("ada")
+        );
+        assert_eq!(msgpack_map_value(&first, "score"), &MsgPackValue::from(7));
+        assert_eq!(
+            msgpack_map_value(&first, "active"),
+            &MsgPackValue::from(true)
+        );
+        assert_eq!(
+            msgpack_map_value(&first, "payload"),
+            &MsgPackValue::Binary(vec![0, 1, 2])
+        );
+
+        assert_eq!(
+            msgpack_map_value(&second, "name"),
+            &MsgPackValue::from("grace")
+        );
+        assert_eq!(msgpack_map_value(&second, "score"), &MsgPackValue::from(11));
+        assert_eq!(
+            msgpack_map_value(&second, "active"),
+            &MsgPackValue::from(false)
+        );
+        assert_eq!(
+            msgpack_map_value(&second, "payload"),
+            &MsgPackValue::Binary(b"hello".to_vec())
+        );
     }
 }

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -504,16 +504,15 @@ impl ConnectionSchema {
                     "json format with unstructured flag enabled requires a schema with a single field called `value` of type JSON"
                 );
             }
-            Some(Format::MsgPack(msgpack_format)) => {
+            Some(Format::MsgPack(msgpack_format))
                 if msgpack_format.into_unstructured_json
                     && (non_metadata_fields.len() != 1
                         || non_metadata_fields.first().unwrap().field_type != FieldType::Json
-                        || non_metadata_fields.first().unwrap().name != "value")
-                {
-                    bail!(
-                        "msgpack format with into_unstructured_json enabled requires a schema with a single field called `value` of type JSON"
-                    );
-                }
+                        || non_metadata_fields.first().unwrap().name != "value") =>
+            {
+                bail!(
+                    "msgpack format with into_unstructured_json enabled requires a schema with a single field called `value` of type JSON"
+                );
             }
             _ => {
                 // Other formats currently do not impose schema-shape checks here.

--- a/crates/arroyo-rpc/src/api_types/connections.rs
+++ b/crates/arroyo-rpc/src/api_types/connections.rs
@@ -490,8 +490,19 @@ impl ConnectionSchema {
                     );
                 }
             }
+            Some(Format::MsgPack(msgpack_format)) => {
+                if msgpack_format.into_unstructured_json
+                    && (non_metadata_fields.len() != 1
+                        || non_metadata_fields.first().unwrap().field_type != FieldType::Json
+                        || non_metadata_fields.first().unwrap().name != "value")
+                {
+                    bail!(
+                        "msgpack format with into_unstructured_json enabled requires a schema with a single field called `value` of type JSON"
+                    );
+                }
+            }
             _ => {
-                // Right now only RawString has checks, but we may add checks for other formats in the future
+                // Other formats currently do not impose schema-shape checks here.
             }
         }
 
@@ -613,6 +624,7 @@ pub struct ConfluentSchemaQueryParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::formats::MsgPackFormat;
     use arrow_schema::{DataType, Field as ArrowField, TimeUnit};
     use serde_json::{Value as J, json};
     use std::sync::Arc;
@@ -707,6 +719,49 @@ mod tests {
         assert_eq!(arrow.data_type(), &DataType::Utf8);
         let back: SourceField = arrow.try_into().unwrap();
         assert_eq!(back.field_type, FieldType::Json);
+    }
+
+    #[test]
+    fn msgpack_unstructured_json_schema_validation() {
+        let schema = ConnectionSchema::try_new(
+            Some(Format::MsgPack(MsgPackFormat {
+                into_unstructured_json: true,
+                ..Default::default()
+            })),
+            None,
+            None,
+            vec![SourceField {
+                name: "value".into(),
+                field_type: FieldType::Json,
+                required: true,
+                sql_name: None,
+                metadata_key: None,
+            }],
+            None,
+            None,
+            HashSet::default(),
+        );
+        assert!(schema.is_ok());
+
+        let invalid = ConnectionSchema::try_new(
+            Some(Format::MsgPack(MsgPackFormat {
+                into_unstructured_json: true,
+                ..Default::default()
+            })),
+            None,
+            None,
+            vec![SourceField {
+                name: "payload".into(),
+                field_type: FieldType::String,
+                required: true,
+                sql_name: None,
+                metadata_key: None,
+            }],
+            None,
+            None,
+            HashSet::default(),
+        );
+        assert!(invalid.unwrap_err().to_string().contains("msgpack format"));
     }
 
     #[test]

--- a/crates/arroyo-rpc/src/formats.rs
+++ b/crates/arroyo-rpc/src/formats.rs
@@ -391,6 +391,83 @@ impl ProtobufFormat {
     }
 }
 
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, ToSchema, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub struct MsgPackFormat {
+    #[serde(default)]
+    pub into_unstructured_json: bool,
+
+    #[serde(default)]
+    pub timestamp_format: TimestampFormat,
+
+    #[serde(default)]
+    pub decimal_encoding: DecimalEncoding,
+}
+
+impl MsgPackFormat {
+    pub fn from_opts(opts: &mut ConnectorOptions) -> DFResult<Self> {
+        let into_unstructured_json = opts
+            .pull_opt_bool("msgpack.into_unstructured_json")?
+            .unwrap_or(false);
+
+        let timestamp_format: TimestampFormat = opts
+            .pull_opt_str("msgpack.timestamp_format")?
+            .map(|t| t.as_str().try_into())
+            .transpose()
+            .map_err(|_| plan_datafusion_err!("invalid value for `msgpack.timestamp_format`"))?
+            .unwrap_or_default();
+
+        let decimal_encoding: DecimalEncoding = opts
+            .pull_opt_str("msgpack.decimal_encoding")?
+            .map(|t| t.as_str().try_into())
+            .transpose()
+            .map_err(|_| plan_datafusion_err!("invalid value for `msgpack.decimal_encoding`"))?
+            .unwrap_or_default();
+
+        Ok(Self {
+            into_unstructured_json,
+            timestamp_format,
+            decimal_encoding,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecimalEncoding, Format, MsgPackFormat, TimestampFormat};
+    use serde_json::json;
+
+    #[test]
+    fn msgpack_format_has_expected_defaults() {
+        let format = Format::MsgPack(MsgPackFormat::default());
+
+        assert_eq!(format.name(), "msgpack");
+        assert!(!format.is_updating());
+
+        let Format::MsgPack(msgpack) = format else {
+            panic!("expected msgpack format");
+        };
+
+        assert!(!msgpack.into_unstructured_json);
+        assert_eq!(msgpack.timestamp_format, TimestampFormat::RFC3339);
+        assert_eq!(msgpack.decimal_encoding, DecimalEncoding::Number);
+
+        assert_eq!(
+            serde_json::to_value(Format::MsgPack(MsgPackFormat::default())).unwrap(),
+            json!({
+                "type": "msgpack",
+                "into_unstructured_json": false,
+                "timestamp_format": "rfc3339",
+                "decimal_encoding": "number"
+            })
+        );
+        assert!(serde_json::from_value::<Format>(json!({ "type": "msgpack" })).is_ok());
+        assert!(serde_json::from_value::<Format>(json!({ "type": "msg_pack" })).is_ok());
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, ToSchema)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum Format {
@@ -400,6 +477,9 @@ pub enum Format {
     Avro(AvroFormat),
     #[schema(title = "Protobuf")]
     Protobuf(ProtobufFormat),
+    #[serde(rename = "msgpack", alias = "msg_pack")]
+    #[schema(title = "MsgPack")]
+    MsgPack(MsgPackFormat),
     #[schema(title = "Parquet")]
     Parquet(ParquetFormat),
     #[schema(title = "RawString")]
@@ -420,6 +500,7 @@ impl Format {
             Format::Json(_) => "json",
             Format::Avro(_) => "avro",
             Format::Protobuf(_) => "protobuf",
+            Format::MsgPack(_) => "msgpack",
             Format::Parquet(_) => "parquet",
             Format::RawString(_) => "raw_string",
             Format::RawBytes(_) => "raw_bytes",
@@ -435,6 +516,7 @@ impl Format {
             "json" => Format::Json(JsonFormat::from_opts(false, opts)?),
             "debezium_json" => Format::Json(JsonFormat::from_opts(true, opts)?),
             "protobuf" => Format::Protobuf(ProtobufFormat::from_opts(opts)?),
+            "msgpack" | "msg_pack" => Format::MsgPack(MsgPackFormat::from_opts(opts)?),
             "avro" => Format::Avro(AvroFormat::from_opts(opts)?),
             "raw_string" => Format::RawString(RawStringFormat {}),
             "raw_bytes" => Format::RawBytes(RawBytesFormat {}),
@@ -450,6 +532,7 @@ impl Format {
             | Format::Avro(_)
             | Format::Parquet(_)
             | Format::RawString(_)
+            | Format::MsgPack(_)
             | Format::Protobuf(_) => false,
             Format::RawBytes(_) => false,
         }

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -646,6 +646,11 @@ export interface components {
             type: "protobuf";
         })) | ({
             type: "Format";
+        } & (components["schemas"]["MsgPackFormat"] & {
+            /** @enum {string} */
+            type: "msgpack";
+        })) | ({
+            type: "Format";
         } & (components["schemas"]["ParquetFormat"] & {
             /** @enum {string} */
             type: "parquet";
@@ -692,6 +697,10 @@ export interface components {
             /** Format: int64 */
             run_id: number;
             running_desired: boolean;
+            /** @description Per-job scheduler configuration overlay (see `PipelinePost`).
+             *     An empty object means "no overrides, use the controller's
+             *     global scheduler config unchanged". */
+            scheduler_config: unknown;
             /** Format: int64 */
             start_time?: number | null;
             state: string;
@@ -754,6 +763,11 @@ export interface components {
         };
         /** @enum {string} */
         MetricName: "bytes_recv" | "bytes_sent" | "messages_recv" | "messages_sent" | "backpressure" | "tx_queue_size" | "tx_queue_rem";
+        MsgPackFormat: {
+            decimal_encoding?: components["schemas"]["DecimalEncoding"];
+            into_unstructured_json?: boolean;
+            timestamp_format?: components["schemas"]["TimestampFormat"];
+        };
         NewlineDelimitedFraming: {
             /** Format: int64 */
             max_line_length?: number | null;
@@ -808,6 +822,7 @@ export interface components {
             checkpoint_interval_micros: number;
             /** Format: int64 */
             created_at: number;
+            env_vars: unknown;
             graph: components["schemas"]["PipelineGraph"];
             id: string;
             name: string;
@@ -851,10 +866,21 @@ export interface components {
         PipelinePost: {
             /** Format: int64 */
             checkpoint_interval_micros?: number | null;
+            /** @description Per-job environment variables forwarded to workers. */
+            env_vars?: {
+                [key: string]: string;
+            } | null;
             name: string;
             /** Format: int64 */
             parallelism: number;
             query: string;
+            /** @description Per-job scheduler configuration overlay. The shape mirrors the
+             *     controller's global scheduler config (e.g. the
+             *     `kubernetes-scheduler.*` block) and is merged on top of it at
+             *     scheduling time. An omitted field, `null`, or an empty object
+             *     all mean "use the controller's global scheduler config
+             *     unchanged". */
+            scheduler_config?: unknown;
             state_url?: string | null;
             tags?: {
                 [key: string]: string;


### PR DESCRIPTION
## Summary
- Adds `msgpack` as a first-class Arroyo `Format`, including SQL connector options and OpenAPI/client type exposure.
- Implements MsgPack source deserialization for structured map records and `into_unstructured_json` payloads.
- Implements MsgPack sink serialization, including native MsgPack binary values for Arrow binary fields.
- Wires Kafka schema validation and format/schema validation coverage for the new format.

## Notes
- Structured MsgPack records are decoded through Arroyo's existing Arrow JSON path, so top-level records must be MsgPack maps with string keys.
- MsgPack extension values are currently rejected instead of silently lossy-converted.

## Testing
- `cargo fmt --check`
- `cargo test -p arroyo-formats`
- `cargo test -p arroyo-rpc msgpack`
- `cargo check -p arroyo-connectors -p arroyo-planner -p arroyo-formats -p arroyo-rpc`
- `cargo check -p arroyo-api` with a temporary local Postgres database for compile-time SQL validation
- `pnpm run openapi`
- `pnpm exec tsc --noEmit`
- `pnpm run build`

Fixes #904
