### PR TITLE
Set finish time on checkpoint details in leader mode when committing

### DIFF
--- a/crates/arroyo-worker/src/job_controller/committing_state.rs
+++ b/crates/arroyo-worker/src/job_controller/committing_state.rs
@@ -7,7 +7,7 @@ pub enum CheckpointIdOrRef {
     // used by database-backed mode, checkpoint metadata v0
     CheckpointId(String),
     // used by checkpoint metadata v1
-    CheckpointRef(CommitPermit, String),
+    CheckpointIdAndRef(String, CommitPermit),
 }
 
 pub struct CommittingState {
@@ -31,7 +31,7 @@ impl CommittingState {
 
     pub fn checkpoint_id(&self) -> &str {
         match &self.checkpoint_id {
-            CheckpointIdOrRef::CheckpointId(id) | CheckpointIdOrRef::CheckpointRef(_, id) => {
+            CheckpointIdOrRef::CheckpointId(id) | CheckpointIdOrRef::CheckpointIdAndRef(id, _) => {
                 id.as_str()
             }
         }
@@ -42,7 +42,7 @@ impl CommittingState {
             CheckpointIdOrRef::CheckpointId(_) => {
                 panic!("asked for commit permit in controller mode, which is not allowed");
             }
-            CheckpointIdOrRef::CheckpointRef(commit_permit, _) => commit_permit,
+            CheckpointIdOrRef::CheckpointIdAndRef(_, commit_permit) => commit_permit,
         }
     }
 

--- a/crates/arroyo-worker/src/job_controller/committing_state.rs
+++ b/crates/arroyo-worker/src/job_controller/committing_state.rs
@@ -7,7 +7,7 @@ pub enum CheckpointIdOrRef {
     // used by database-backed mode, checkpoint metadata v0
     CheckpointId(String),
     // used by checkpoint metadata v1
-    CheckpointRef(CommitPermit),
+    CheckpointRef(CommitPermit, String),
 }
 
 pub struct CommittingState {
@@ -31,9 +31,8 @@ impl CommittingState {
 
     pub fn checkpoint_id(&self) -> &str {
         match &self.checkpoint_id {
-            CheckpointIdOrRef::CheckpointId(id) => id.as_str(),
-            CheckpointIdOrRef::CheckpointRef(_) => {
-                panic!("asked for checkpoint id in leader mode, which is not allowed");
+            CheckpointIdOrRef::CheckpointId(id) | CheckpointIdOrRef::CheckpointRef(_, id) => {
+                id.as_str()
             }
         }
     }
@@ -43,7 +42,7 @@ impl CommittingState {
             CheckpointIdOrRef::CheckpointId(_) => {
                 panic!("asked for commit permit in controller mode, which is not allowed");
             }
-            CheckpointIdOrRef::CheckpointRef(commit_permit) => commit_permit,
+            CheckpointIdOrRef::CheckpointRef(commit_permit, _) => commit_permit,
         }
     }
 

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // Re-export shared types from arroyo-rpc
 pub use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent, WorkerContext};
@@ -117,6 +117,8 @@ impl CheckpointHistory {
             checkpoint.event_spans = event_spans;
             checkpoint.finish_time = finish_time;
             checkpoint.status = status;
+        } else {
+            warn!("tried to finish checkpoint for unknown id {checkpoint_id}")
         }
     }
 
@@ -134,6 +136,8 @@ impl CheckpointHistory {
             checkpoint.finish_time = Some(finish_time);
             checkpoint.event_spans = event_spans;
             checkpoint.status = arroyo_rpc::checkpoints::CheckpointStatus::Ready;
+        } else {
+            warn!("tried to finish checkpoint for unknown id {checkpoint_id}")
         }
     }
 

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -118,7 +118,7 @@ impl CheckpointHistory {
             checkpoint.finish_time = finish_time;
             checkpoint.status = status;
         } else {
-            warn!("tried to finish checkpoint for unknown id {checkpoint_id}")
+            warn!("tried to update checkpoint for unknown id {checkpoint_id}")
         }
     }
 

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -539,9 +539,9 @@ impl RunningJobModel {
                 };
 
                 let checkpoint_id = checkpointing.checkpoint_id.clone();
-                let commit = checkpointing.into_commit(CheckpointIdOrRef::CheckpointRef(
-                    commit_permit.clone(),
+                let commit = checkpointing.into_commit(CheckpointIdOrRef::CheckpointIdAndRef(
                     checkpoint_id,
+                    commit_permit.clone(),
                 ));
 
                 let committing_data = commit.committing_data();

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -538,8 +538,11 @@ impl RunningJobModel {
                     }
                 };
 
-                let commit = checkpointing
-                    .into_commit(CheckpointIdOrRef::CheckpointRef(commit_permit.clone()));
+                let checkpoint_id = checkpointing.checkpoint_id.clone();
+                let commit = checkpointing.into_commit(CheckpointIdOrRef::CheckpointRef(
+                    commit_permit.clone(),
+                    checkpoint_id,
+                ));
 
                 let committing_data = commit.committing_data();
 
@@ -622,7 +625,7 @@ impl RunningJobModel {
                 complete_commit(storage.as_ref(), commit_permit, Generation(self.generation))
                     .await?;
 
-                self.finish_committing(commit_permit.checkpoint_ref().as_str(), store)
+                self.finish_committing(committing.checkpoint_id(), store)
                     .await?;
 
                 self.last_checkpoint = Instant::now();

--- a/webui/src/components/Checkpoints.tsx
+++ b/webui/src/components/Checkpoints.tsx
@@ -29,7 +29,7 @@ export interface CheckpointsProps {
 }
 
 const CHECKPOINT_LEADER_UNAVAILABLE_MESSAGE =
-  'Checkpoint data for a running job is served by the job leader. The API server is online, but it could not reach the current leader to proxy this request. The leader may be restarting, failing over, or temporarily unreachable; refresh or try again in a moment.';
+  'The leader for this pipeline could not be reached, possibly because it\'s failed or stopped';
 
 const CheckpointErrorAlert: React.FC<{ error: any }> = ({ error }) => {
   const leaderUnavailable = error?.status === 502;

--- a/webui/src/components/Checkpoints.tsx
+++ b/webui/src/components/Checkpoints.tsx
@@ -246,6 +246,7 @@ const Checkpoints: React.FC<CheckpointsProps> = ({
   const checkpointMenuItems = checkpoints.slice();
   if (checkpoint && !checkpointMenuItems.some(c => c.epoch == checkpoint.epoch)) {
     checkpointMenuItems.push(checkpoint);
+    checkpointMenuItems.sort((a, b) => a.epoch - b.epoch);
   }
 
   return (

--- a/webui/src/components/Checkpoints.tsx
+++ b/webui/src/components/Checkpoints.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Alert,
   AlertDescription,
@@ -17,7 +17,13 @@ import {
   Text,
   UnorderedList,
 } from '@chakra-ui/react';
-import { Checkpoint, Job, Pipeline, useCheckpointDetails } from '../lib/data_fetching';
+import {
+  Checkpoint,
+  Job,
+  OperatorCheckpointGroup,
+  Pipeline,
+  useCheckpointDetails,
+} from '../lib/data_fetching';
 import { dataFormat, formatError } from '../lib/util';
 import { CheckpointDetails, formatDuration } from './CheckpointDetails';
 
@@ -29,7 +35,12 @@ export interface CheckpointsProps {
 }
 
 const CHECKPOINT_LEADER_UNAVAILABLE_MESSAGE =
-  'The leader for this pipeline could not be reached, possibly because it\'s failed or stopped';
+  "The leader for this pipeline could not be reached, possibly because it's failed or stopped";
+
+interface CachedCheckpoint {
+  checkpoint?: Checkpoint;
+  details?: OperatorCheckpointGroup[];
+}
 
 const CheckpointErrorAlert: React.FC<{ error: any }> = ({ error }) => {
   const leaderUnavailable = error?.status === 502;
@@ -51,6 +62,32 @@ const CheckpointErrorAlert: React.FC<{ error: any }> = ({ error }) => {
   );
 };
 
+const CheckpointCacheAlert: React.FC<{
+  checkpointsError?: any;
+  checkpointDetailsError?: any;
+  showingCachedCheckpoint: boolean;
+}> = ({ checkpointsError, checkpointDetailsError, showingCachedCheckpoint }) => {
+  let reason = 'the latest checkpoint information is unavailable';
+
+  if (showingCachedCheckpoint) {
+    reason = 'this checkpoint is no longer present in the refreshed checkpoint history';
+  } else if (checkpointDetailsError) {
+    reason = 'the latest checkpoint details could not be loaded';
+  } else if (checkpointsError) {
+    reason = 'the checkpoint list could not be refreshed';
+  }
+
+  return (
+    <Alert status="warning" marginTop={5}>
+      <AlertIcon />
+      <Box>
+        <AlertTitle>Showing cached checkpoint information</AlertTitle>
+        <AlertDescription>{`Using the previously loaded data because ${reason}.`}</AlertDescription>
+      </Box>
+    </Alert>
+  );
+};
+
 const Checkpoints: React.FC<CheckpointsProps> = ({
   pipeline,
   job,
@@ -58,23 +95,64 @@ const Checkpoints: React.FC<CheckpointsProps> = ({
   checkpointsError,
 }) => {
   const [epoch, setEpoch] = useState<number | undefined>(undefined);
+  const [checkpointCache, setCheckpointCache] = useState<Record<number, CachedCheckpoint>>({});
   const { checkpointDetails, checkpointLoading, checkpointDetailsError } = useCheckpointDetails(
     pipeline.id,
     job.id,
     epoch
   );
 
-  if (checkpointsError) {
+  useEffect(() => {
+    setEpoch(undefined);
+    setCheckpointCache({});
+  }, [pipeline.id, job.id]);
+
+  useEffect(() => {
+    if (epoch == null) return;
+
+    const checkpoint = checkpoints.find(c => c.epoch == epoch);
+    if (!checkpoint) return;
+
+    setCheckpointCache(cache => ({
+      ...cache,
+      [epoch]: {
+        ...cache[epoch],
+        checkpoint,
+      },
+    }));
+  }, [epoch, checkpoints]);
+
+  useEffect(() => {
+    if (epoch == null || !checkpointDetails) return;
+
+    setCheckpointCache(cache => ({
+      ...cache,
+      [epoch]: {
+        ...cache[epoch],
+        details: checkpointDetails,
+      },
+    }));
+  }, [epoch, checkpointDetails]);
+
+  const cachedCheckpoint = epoch == null ? undefined : checkpointCache[epoch];
+  const liveCheckpoint = epoch == null ? undefined : checkpoints.find(c => c.epoch == epoch);
+  const checkpoint = liveCheckpoint ?? cachedCheckpoint?.checkpoint;
+  const selectedCheckpointDetails = checkpointDetails ?? cachedCheckpoint?.details;
+  const showingCachedCheckpoint = liveCheckpoint == null && cachedCheckpoint?.checkpoint != null;
+  const shouldShowCachedAlert =
+    checkpoint != null &&
+    selectedCheckpointDetails != null &&
+    (checkpointsError || checkpointDetailsError || showingCachedCheckpoint);
+
+  if (checkpointsError && !checkpoint) {
     return <CheckpointErrorAlert error={checkpointsError} />;
   }
 
-  if (!checkpoints.length) {
+  if (!checkpoints.length && !checkpoint) {
     return <Text textStyle="italic">No checkpoints</Text>;
   }
 
   let details = <Text>Select checkpoint</Text>;
-
-  let checkpoint: Checkpoint | undefined = checkpoints.find(c => c.epoch == epoch);
 
   if (checkpoint) {
     const checkpointHeading = (
@@ -84,18 +162,26 @@ const Checkpoints: React.FC<CheckpointsProps> = ({
       </Heading>
     );
 
-    if (checkpointDetailsError) {
+    const cachedAlert = shouldShowCachedAlert ? (
+      <CheckpointCacheAlert
+        checkpointsError={checkpointsError}
+        checkpointDetailsError={checkpointDetailsError}
+        showingCachedCheckpoint={showingCachedCheckpoint}
+      />
+    ) : null;
+
+    if (checkpointDetailsError && !selectedCheckpointDetails) {
       details = (
         <Flex flexDirection={'column'} flexGrow={1}>
           {checkpointHeading}
           <CheckpointErrorAlert error={checkpointDetailsError} />
         </Flex>
       );
-    } else if (checkpointDetails) {
+    } else if (selectedCheckpointDetails) {
       let start = Number(checkpoint.start_time);
       let end = Number(checkpoint.finish_time ?? new Date().getTime() * 1000);
 
-      let checkpointBytes = checkpointDetails.map(d => d.bytes).reduce((a, b) => a + b, 0);
+      let checkpointBytes = selectedCheckpointDetails.map(d => d.bytes).reduce((a, b) => a + b, 0);
 
       const checkpointStats = (
         <StatGroup width={800} border="1px solid #666" borderRadius="5px" marginTop={5} padding={3}>
@@ -133,14 +219,16 @@ const Checkpoints: React.FC<CheckpointsProps> = ({
       details = (
         <Flex flexDirection={'column'} flexGrow={1}>
           {checkpointHeading}
+          {cachedAlert}
           {checkpointStats}
-          <CheckpointDetails operators={checkpointDetails} checkpoint={checkpoint} />
+          <CheckpointDetails operators={selectedCheckpointDetails} checkpoint={checkpoint} />
         </Flex>
       );
     } else if (checkpointLoading) {
       details = (
         <Flex flexDirection={'column'} flexGrow={1}>
           {checkpointHeading}
+          {cachedAlert}
           <Text marginTop={5}>Loading checkpoint details...</Text>
         </Flex>
       );
@@ -148,29 +236,29 @@ const Checkpoints: React.FC<CheckpointsProps> = ({
       details = (
         <Flex flexDirection={'column'} flexGrow={1}>
           {checkpointHeading}
+          {cachedAlert}
           <Text marginTop={5}>Select checkpoint</Text>
         </Flex>
       );
     }
   }
 
+  const checkpointMenuItems = checkpoints.slice();
+  if (checkpoint && !checkpointMenuItems.some(c => c.epoch == checkpoint.epoch)) {
+    checkpointMenuItems.push(checkpoint);
+  }
+
   return (
     <Flex>
       <Box w="100px">
         <UnorderedList className="checkpoint-menu">
-          {checkpoints
-            .slice()
-            .reverse()
-            .map(c => {
-              return (
-                <ListItem
-                  key={'a' + String(c.epoch)}
-                  className={c.epoch == epoch ? 'selected' : ''}
-                >
-                  <Link onClick={() => setEpoch(c.epoch)}> {c.epoch}</Link>
-                </ListItem>
-              );
-            })}
+          {checkpointMenuItems.reverse().map(c => {
+            return (
+              <ListItem key={'a' + String(c.epoch)} className={c.epoch == epoch ? 'selected' : ''}>
+                <Link onClick={() => setEpoch(c.epoch)}> {c.epoch}</Link>
+              </ListItem>
+            );
+          })}
         </UnorderedList>
       </Box>
       <Flex flexGrow={1}>{details}</Flex>

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -372,7 +372,7 @@ export const useCheckpointDetails = (pipelineId?: string, jobId?: string, epoch?
   const { data, isLoading, error } = useSWR<schemas['OperatorCheckpointGroupCollection']>(
     checkpointDetailsKey(pipelineId, jobId, epoch),
     checkpointDetailsFetcher(),
-    {}
+    { revalidateOnFocus: false, shouldRetryOnError: false }
   );
 
   return {


### PR DESCRIPTION
This PR fixes an issue introduced in #1063, where checkpoints where not correctly marked as finished in the details metadata when they included a commit step. This didn't affect the actual checkpoints, but did lead to the webui showing checkpoints failing to finish.

In addition to that fix, this also includes some improvements to the checkpoint details page in the webui, which now caches checkpoint details that the user has viewed so that they don't disappear when trimmed in history or when the leader shuts down.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->