### PR TITLE
Keep leader alive after checkpoint stopping

### DIFF
--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -1,7 +1,9 @@
 use crate::JobMessage;
 use crate::states::leader_stopping::{LeaderStopBehavior, LeaderStopping};
 use crate::states::recovering::Recovering;
-use crate::states::{JobContext, State, StateError, Transition, TransitionTo, fatal};
+use crate::states::{
+    JobContext, State, StateError, Transition, TransitionTo, controller_job_failure,
+};
 use crate::types::public::StopMode as SqlStopMode;
 use anyhow::{anyhow, bail};
 use arroyo_rpc::config::config;
@@ -197,7 +199,11 @@ where
             }
             resp = ctx.leader_manager.as_mut().expect("leader manager not initialized").wait_for_state(expected_state) => {
                 if let Err(e) = resp {
-                    return Err(fatal("failed while waiting for final checkpoint", e));
+                return ctx.handle_job_failure(state, controller_job_failure(
+                    format!("failed while taking final checkpoint: {:?}", e),
+                    rpc::ErrorDomain::Internal,
+                    rpc::RetryHint::WithBackoff,
+                )).await;
                 }
                 return Ok(Transition::next(
                     state,
@@ -205,14 +211,11 @@ where
                 ));
             }
             _ = tokio::time::sleep(timeout) => {
-                return ctx.handle_job_failure(state, JobFailure {
-                    operator_id: None,
-                    task_id: None,
-                    subtask_index: None,
-                    message: "timed out while taking final checkpoint".to_string(),
-                    error_domain: rpc::ErrorDomain::Internal as i32,
-                    retry_hint: rpc::RetryHint::WithBackoff as i32,
-                }).await;
+                return ctx.handle_job_failure(state, controller_job_failure(
+                    "timed out while taking final checkpoint".to_string(),
+                    rpc::ErrorDomain::Internal,
+                    rpc::RetryHint::WithBackoff,
+                )).await;
             }
         }
     }

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, bail};
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::job_status_grpc_client::JobStatusGrpcClient;
-use arroyo_rpc::grpc::rpc::{JobFailure, JobState, JobStatusReq, JobStopMode, StopJobReq};
+use arroyo_rpc::grpc::rpc::{JobState, JobStatusReq, JobStopMode, StopJobReq};
 use arroyo_rpc::identity::InjectWorkerId;
 use arroyo_rpc::{job_status_client, retry};
 use arroyo_types::{JobId, WorkerId};

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -54,7 +54,7 @@ const TTL_PIPELINE_CLEANUP_TIME: Duration = Duration::from_secs(60 * 60);
 include!(concat!(env!("OUT_DIR"), "/controller-sql.rs"));
 
 use crate::job_controller::job_metrics::JobMetrics;
-use crate::schedulers::{NodeScheduler, ProcessScheduler, Scheduler};
+use crate::schedulers::{ManualScheduler, NodeScheduler, ProcessScheduler, Scheduler};
 use types::public::LogLevel;
 use types::public::{RestartMode, StopMode};
 
@@ -562,6 +562,10 @@ impl ControllerServer {
             config::Scheduler::Process => {
                 info!("Using process scheduler");
                 Arc::new(ProcessScheduler::new())
+            }
+            config::Scheduler::Manual => {
+                info!("Using manual scheduler");
+                Arc::new(ManualScheduler::new())
             }
         };
 

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -328,11 +328,9 @@ impl Scheduler for ProcessScheduler {
     }
 }
 
-
 /// A "manual" scheduler that relies on the user to manage worker processes by executing commands
 /// printed out to the terminal. This is mostly useful for testing scheduling behavior.
-pub struct ManualScheduler {
-}
+pub struct ManualScheduler {}
 
 impl ManualScheduler {
     pub fn new() -> Self {
@@ -455,10 +453,7 @@ impl Scheduler for ManualScheduler {
         _run_id: Option<u64>,
         _force: bool,
     ) -> anyhow::Result<()> {
-        println!(
-            "[manual scheduler] Stop workers for job {}",
-            job_id
-        );
+        println!("[manual scheduler] Stop workers for job {}", job_id);
 
         Ok(())
     }

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -407,7 +407,7 @@ impl Scheduler for ManualScheduler {
             cmdline.push_str(&exe.to_string_lossy());
             for arg in &args {
                 cmdline.push(' ');
-                cmdline.push_str(&arg);
+                cmdline.push_str(arg);
             }
 
             println!();

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -328,24 +328,15 @@ impl Scheduler for ProcessScheduler {
     }
 }
 
-struct ManualWorker {
-    job_id: JobId,
-    generation: u64,
-}
 
 /// A "manual" scheduler that relies on the user to manage worker processes by executing commands
 /// printed out to the terminal. This is mostly useful for testing scheduling behavior.
 pub struct ManualScheduler {
-    workers: Arc<Mutex<HashMap<WorkerId, ManualWorker>>>,
-    worker_counter: AtomicU64,
 }
 
 impl ManualScheduler {
     pub fn new() -> Self {
-        Self {
-            workers: Arc::new(Mutex::new(HashMap::new())),
-            worker_counter: AtomicU64::new(100),
-        }
+        Self {}
     }
 }
 
@@ -370,15 +361,12 @@ impl Scheduler for ManualScheduler {
             let slots_here = (start_pipeline_req.slots - slots_scheduled).min(slots_per_process);
             slots_scheduled += slots_here;
 
-            let worker_id = self.worker_counter.fetch_add(1, Ordering::SeqCst);
-
             let mut envs: Vec<(String, String)> = vec![
                 ("ARROYO__ADMIN__HTTP_PORT".to_string(), "0".to_string()),
                 (
                     "ARROYO__WORKER__TASK_SLOTS".to_string(),
                     slots_here.to_string(),
                 ),
-                ("ARROYO__WORKER__ID".to_string(), worker_id.to_string()),
                 (
                     "ARROYO__CONTROLLER_ENDPOINT".to_string(),
                     config.controller_endpoint(),
@@ -424,27 +412,15 @@ impl Scheduler for ManualScheduler {
                 cmdline.push_str(&arg);
             }
 
-            {
-                let mut workers = self.workers.lock().await;
-                workers.insert(
-                    WorkerId(worker_id),
-                    ManualWorker {
-                        job_id: start_pipeline_req.job_id.clone(),
-                        generation: start_pipeline_req.generation,
-                    },
-                );
-            }
-
             println!();
             println!(
                 "════════════════════════════════════════════════════════════════════════════════"
             );
             println!(
-                "[manual scheduler] Run worker {} of {} (worker id {}, {} slots) for job {} in a \
+                "[manual scheduler] Run worker {} of {} (worker id {} slots) for job {} in a \
                  separate terminal:",
                 slots_scheduled / slots_per_process.max(1),
                 workers,
-                worker_id,
                 slots_here,
                 start_pipeline_req.job_id,
             );
@@ -467,55 +443,24 @@ impl Scheduler for ManualScheduler {
 
     async fn workers_for_job(
         &self,
-        job_id: &str,
-        run_id: Option<u64>,
+        _job_id: &str,
+        _run_id: Option<u64>,
     ) -> anyhow::Result<Vec<WorkerId>> {
-        Ok(self
-            .workers
-            .lock()
-            .await
-            .iter()
-            .filter(|(_, w)| {
-                *w.job_id == job_id && (run_id.is_none() || w.generation == run_id.unwrap())
-            })
-            .map(|(k, _)| *k)
-            .collect())
+        Ok(vec![])
     }
 
     async fn stop_workers(
         &self,
         job_id: &str,
-        run_id: Option<u64>,
+        _run_id: Option<u64>,
         _force: bool,
     ) -> anyhow::Result<()> {
-        for worker_id in self.workers_for_job(job_id, run_id).await? {
-            let removed = self.workers.lock().await.remove(&worker_id).is_some();
-            if removed {
-                println!(
-                    "[manual scheduler] Stop worker {} for job {} (Ctrl-C its terminal)",
-                    worker_id.0, job_id
-                );
-            }
-        }
+        println!(
+            "[manual scheduler] Stop workers for job {}",
+            job_id
+        );
 
         Ok(())
-    }
-
-    async fn shutdown(&self) {
-        let workers: Vec<_> = self.workers.lock().await.drain().collect();
-        if workers.is_empty() {
-            return;
-        }
-
-        println!(
-            "[manual scheduler] Controller shutting down; stop the following manually-run workers \
-             (Ctrl-C their terminals): {}",
-            workers
-                .iter()
-                .map(|(id, _)| id.0.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
     }
 }
 

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -328,6 +328,197 @@ impl Scheduler for ProcessScheduler {
     }
 }
 
+struct ManualWorker {
+    job_id: JobId,
+    generation: u64,
+}
+
+/// A "manual" scheduler that relies on the user to manage worker processes by executing commands
+/// printed out to the terminal. This is mostly useful for testing scheduling behavior.
+pub struct ManualScheduler {
+    workers: Arc<Mutex<HashMap<WorkerId, ManualWorker>>>,
+    worker_counter: AtomicU64,
+}
+
+impl ManualScheduler {
+    pub fn new() -> Self {
+        Self {
+            workers: Arc::new(Mutex::new(HashMap::new())),
+            worker_counter: AtomicU64::new(100),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Scheduler for ManualScheduler {
+    async fn start_workers(
+        &self,
+        start_pipeline_req: StartPipelineReq,
+    ) -> Result<(), SchedulerError> {
+        let config = config();
+        let slots_per_process = config.manual_scheduler.slots_per_process as usize;
+
+        let workers = (start_pipeline_req.slots as f32 / slots_per_process as f32).ceil() as usize;
+
+        let exe = current_exe().map_err(|e| {
+            SchedulerError::Other(format!("Could not get path of worker binary: {e:?}"))
+        })?;
+
+        let mut slots_scheduled = 0;
+
+        for _ in 0..workers {
+            let slots_here = (start_pipeline_req.slots - slots_scheduled).min(slots_per_process);
+            slots_scheduled += slots_here;
+
+            let worker_id = self.worker_counter.fetch_add(1, Ordering::SeqCst);
+
+            let mut envs: Vec<(String, String)> = vec![
+                ("ARROYO__ADMIN__HTTP_PORT".to_string(), "0".to_string()),
+                (
+                    "ARROYO__WORKER__TASK_SLOTS".to_string(),
+                    slots_here.to_string(),
+                ),
+                ("ARROYO__WORKER__ID".to_string(), worker_id.to_string()),
+                (
+                    "ARROYO__CONTROLLER_ENDPOINT".to_string(),
+                    config.controller_endpoint(),
+                ),
+                (
+                    PIPELINE_ID_ENV.to_string(),
+                    start_pipeline_req.pipeline_id.to_string(),
+                ),
+                (
+                    JOB_ID_ENV.to_string(),
+                    start_pipeline_req.job_id.to_string(),
+                ),
+                (
+                    GENERATION_ENV.to_string(),
+                    start_pipeline_req.generation.to_string(),
+                ),
+            ];
+
+            for (env, value) in &start_pipeline_req.env_vars {
+                envs.push((env.clone(), value.clone()));
+            }
+
+            // Build the command-line arguments, mirroring the process scheduler.
+            let mut args: Vec<String> = vec![];
+            if let Some(path) = &config.config_path {
+                args.push("-c".to_string());
+                args.push(path.to_string_lossy().to_string());
+            }
+            if let Some(path) = &config.config_dir {
+                args.push("--config-dir".to_string());
+                args.push(path.to_string_lossy().to_string());
+            }
+            args.push("worker".to_string());
+
+            // Assemble the copy-pasteable command line.
+            let mut cmdline = String::new();
+            for (env, value) in &envs {
+                cmdline.push_str(&format!("{}={} ", env, value));
+            }
+            cmdline.push_str(&exe.to_string_lossy());
+            for arg in &args {
+                cmdline.push(' ');
+                cmdline.push_str(&arg);
+            }
+
+            {
+                let mut workers = self.workers.lock().await;
+                workers.insert(
+                    WorkerId(worker_id),
+                    ManualWorker {
+                        job_id: start_pipeline_req.job_id.clone(),
+                        generation: start_pipeline_req.generation,
+                    },
+                );
+            }
+
+            println!();
+            println!(
+                "════════════════════════════════════════════════════════════════════════════════"
+            );
+            println!(
+                "[manual scheduler] Run worker {} of {} (worker id {}, {} slots) for job {} in a \
+                 separate terminal:",
+                slots_scheduled / slots_per_process.max(1),
+                workers,
+                worker_id,
+                slots_here,
+                start_pipeline_req.job_id,
+            );
+            println!();
+            println!("{cmdline}");
+            println!(
+                "════════════════════════════════════════════════════════════════════════════════"
+            );
+            println!();
+        }
+
+        Ok(())
+    }
+
+    async fn register_node(&self, _: RegisterNodeReq) {}
+    async fn heartbeat_node(&self, _: HeartbeatNodeReq) -> Result<(), Status> {
+        Ok(())
+    }
+    async fn worker_finished(&self, _: WorkerFinishedReq) {}
+
+    async fn workers_for_job(
+        &self,
+        job_id: &str,
+        run_id: Option<u64>,
+    ) -> anyhow::Result<Vec<WorkerId>> {
+        Ok(self
+            .workers
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, w)| {
+                *w.job_id == job_id && (run_id.is_none() || w.generation == run_id.unwrap())
+            })
+            .map(|(k, _)| *k)
+            .collect())
+    }
+
+    async fn stop_workers(
+        &self,
+        job_id: &str,
+        run_id: Option<u64>,
+        _force: bool,
+    ) -> anyhow::Result<()> {
+        for worker_id in self.workers_for_job(job_id, run_id).await? {
+            let removed = self.workers.lock().await.remove(&worker_id).is_some();
+            if removed {
+                println!(
+                    "[manual scheduler] Stop worker {} for job {} (Ctrl-C its terminal)",
+                    worker_id.0, job_id
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn shutdown(&self) {
+        let workers: Vec<_> = self.workers.lock().await.drain().collect();
+        if workers.is_empty() {
+            return;
+        }
+
+        println!(
+            "[manual scheduler] Controller shutting down; stop the following manually-run workers \
+             (Ctrl-C their terminals): {}",
+            workers
+                .iter()
+                .map(|(id, _)| id.0.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+}
+
 #[derive(Debug, Clone)]
 struct NodeStatus {
     id: MachineId,

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use super::{JobContext, State, Stopped, Transition};
 use crate::job_controller::leader_manager::handle_leader_stopping;
 use crate::states::StateError;
@@ -24,6 +25,9 @@ impl State for LeaderCheckpointStopping {
 
         let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
 
+        println!("sleeping...");
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        println!("continuing...");
         handle_leader_stopping(*self, ctx, JobState::JobStopped, Stopped {}, timeout).await
     }
 }

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -3,7 +3,6 @@ use crate::job_controller::leader_manager::handle_leader_stopping;
 use crate::states::StateError;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
-use std::time::Duration;
 
 #[derive(Debug)]
 pub struct LeaderCheckpointStopping {}

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
 use super::{JobContext, State, Stopped, Transition};
 use crate::job_controller::leader_manager::handle_leader_stopping;
 use crate::states::StateError;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
+use std::time::Duration;
 
 #[derive(Debug)]
 pub struct LeaderCheckpointStopping {}
@@ -25,9 +25,6 @@ impl State for LeaderCheckpointStopping {
 
         let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
 
-        println!("sleeping...");
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        println!("continuing...");
         handle_leader_stopping(*self, ctx, JobState::JobStopped, Stopped {}, timeout).await
     }
 }

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -271,6 +271,8 @@ impl TransitionTo<Failed> for Failing {}
 fn done_transition(ctx: &mut JobContext) {
     ctx.status.finish_time = Some(OffsetDateTime::now_utc());
     ctx.job_controller = None;
+    ctx.leader_manager = None;
+    ctx.status.state_context.leader = None;
 }
 
 impl TransitionTo<Stopped> for Stopping {

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -66,6 +66,9 @@ http-port = 5114
 slots-per-process = 16
 shutdown-with-controller = true
 
+[manual-scheduler]
+slots-per-process = 16
+
 [kubernetes-scheduler]
 namespace = "default"
 resource-mode = "per-slot"

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -224,6 +224,9 @@ pub struct Config {
     /// Process scheduler configuration
     pub process_scheduler: ProcessSchedulerConfig,
 
+    /// Manual scheduler configuration
+    pub manual_scheduler: ManualSchedulerConfig,
+
     // Kubernetes scheduler configuration
     pub kubernetes_scheduler: KubernetesSchedulerConfig,
 
@@ -699,6 +702,7 @@ impl Default for SqliteConfig {
 pub enum Scheduler {
     Embedded,
     Process,
+    Manual,
     Node,
     Kubernetes,
 }
@@ -711,6 +715,14 @@ pub struct ProcessSchedulerConfig {
     /// shuts down. Note if disabled, this may orphan workers -- this is primarily used for testing
     /// state machine recovery.
     pub shutdown_with_controller: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ManualSchedulerConfig {
+    /// The number of task slots assigned to each worker process. The scheduler will print a command
+    /// line for `ceil(slots / slots_per_process)` workers.
+    pub slots_per_process: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -554,13 +554,22 @@ impl WorkerJobController {
             return Ok(ControllerProgress::Stopped);
         }
 
+        if !self.stopping && self.model.all_tasks_finished() {
+            let state = self.status.job_status.lock().unwrap().job_state();
+            return Ok(match state {
+                rpc::JobState::JobFinishing | rpc::JobState::JobFinished => {
+                    ControllerProgress::Finished
+                }
+                rpc::JobState::JobFailing | rpc::JobState::JobFailed => {
+                    ControllerProgress::Continue
+                }
+                _ => ControllerProgress::Finishing,
+            });
+        }
+
         // have any of our tasks finished?
         if !self.stopping && self.model.any_finished_sources() {
             return Ok(ControllerProgress::Finishing);
-        }
-
-        if !self.stopping && self.model.all_tasks_finished() {
-            return Ok(ControllerProgress::Finished);
         }
 
         if matches!(

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -1015,17 +1015,32 @@ impl WorkerGrpc for WorkerServer {
         &self,
         _request: Request<JobFinishedReq>,
     ) -> Result<Response<JobFinishedResp>, Status> {
+        let is_worker_leader = self.state.job_controller_tx.get().is_some();
+
         let mut phase = self.state.phase.lock().unwrap();
         if let WorkerExecutionPhase::Running(engine_state) = &*phase {
             engine_state.shutdown_guard.cancel();
         }
         *phase = WorkerExecutionPhase::Idle;
+        drop(phase);
 
-        let token = self.shutdown_guard.token();
-        tokio::task::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            token.cancel();
-        });
+        if is_worker_leader {
+            // Keep the worker leader reachable so the controller can observe the
+            // terminal job status before explicitly stopping the worker process.
+            info!(
+                message =
+                    "job finished on worker leader; waiting for controller to stop worker process",
+                worker_id = self.state.worker_context.worker_id.0,
+                job_id = *self.state.worker_context.job_id,
+                generation = self.state.worker_context.generation,
+            );
+        } else {
+            let token = self.shutdown_guard.token();
+            tokio::task::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                token.cancel();
+            });
+        }
 
         Ok(Response::new(JobFinishedResp {}))
     }
@@ -1256,15 +1271,24 @@ impl JobControllerGrpc for LeaderServer {
         self.validate_req(req.worker_context.as_ref())?;
 
         debug!(
-            "[{:?}] Received heartbeat {:?}",
-            self.state.worker_context.worker_id, req
+            worker_id =? self.state.worker_context.worker_id,
+            ?req,
+            "received heartbeat",
         );
 
-        self.send_job_message(RunningMessage::WorkerHeartbeat {
-            worker_id: WorkerId(req.worker_context.as_ref().unwrap().worker_id),
-            time: Instant::now(),
-        })
-        .await?;
+        if self
+            .send_job_message(RunningMessage::WorkerHeartbeat {
+                worker_id: WorkerId(req.worker_context.as_ref().unwrap().worker_id),
+                time: Instant::now(),
+            })
+            .await
+            .is_err()
+        {
+            debug!(
+                worker_id =? self.state.worker_context.worker_id,
+                "received heartbeat while shutting down"
+            )
+        };
 
         Ok(Response::new(HeartbeatResp {}))
     }

--- a/crates/arroyo/src/run.rs
+++ b/crates/arroyo/src/run.rs
@@ -446,7 +446,10 @@ pub async fn run(args: RunArgs) {
         }
         c.controller.rpc_port = 0;
 
-        if c.controller.scheduler != Scheduler::Embedded {
+        if !matches!(
+            c.controller.scheduler,
+            Scheduler::Embedded | Scheduler::Manual
+        ) {
             c.controller.scheduler = Scheduler::Process;
         }
 


### PR DESCRIPTION
There is currently a race condition for checkpoint stopping in leader mode:
1. The controller sends `CheckpointReq { then_stop: true, ... }` to the leader
2. The leader initiates final checkpoint then monitors progress
3. The checkpoint completes and the leader shuts down
4. The controller polls for leader status (waiting for JobStopped) but this fails, because the leader has already shut down

The fix in this PR is to not have the leader shut down on final checkpoint; it hangs around until it gets an actual stop request from the controller. We're also no longer triggering a fatal error if final checkpointing fails, so that we are able to recover the pipeline from the last successful checkpoint.

Also includes a new "manual" scheduler which is useful for testing these sorts of scenarios. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->