### PR TITLE
Preserve full catalog error message when it contains quotes

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/iceberg/mod.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/iceberg/mod.rs
@@ -88,7 +88,8 @@ fn extract_catalog_status(display: &str) -> Option<u16> {
 }
 
 fn extract_catalog_message(display: &str) -> Option<String> {
-    let re = Regex::new(r#""message"\s*:\s*"([^"]+)""#).unwrap();
+    // Capture the full JSON string value, such as `NoSuchBucket`
+    let re = Regex::new(r#""message"\s*:\s*"((?:[^"\\]|\\.)*)""#).unwrap();
     re.captures(display).map(|c| c[1].to_string())
 }
 


### PR DESCRIPTION
The regex that extracts the `message` field from Iceberg REST catalog errors. stopped at the first inner double-quote. When a catalog error wraps a quoted cause, the message was truncated and the actual root cause was dropped, sometimes making distinct failures look identical.
Users now see the complete, accurate catalog error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->