### PR TITLE
Add checkpoint_type to /checkpoints response

### DIFF
--- a/crates/arroyo-api/migrations/V32__add_checkpoint_type.sql
+++ b/crates/arroyo-api/migrations/V32__add_checkpoint_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE checkpoints ADD COLUMN is_stopping BOOLEAN DEFAULT false NOT NULL;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -243,7 +243,7 @@ FROM checkpoints
 WHERE job_id = :job_id AND organization_id = :organization_id;
 
 --! get_job_checkpoints: DbCheckpoint
-SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints
+SELECT epoch, state_backend, start_time, finish_time, event_spans, operators, is_stopping FROM checkpoints
 JOIN job_configs ON checkpoints.job_id = job_configs.id
 WHERE job_configs.id = :job_id
     AND checkpoints.organization_id = :organization_id
@@ -252,7 +252,7 @@ WHERE job_configs.id = :job_id
 ORDER BY epoch;
 
 --! get_job_checkpoint: DbCheckpoint
-SELECT epoch, state_backend, start_time, finish_time, event_spans, operators FROM checkpoints
+SELECT epoch, state_backend, start_time, finish_time, event_spans, operators, is_stopping FROM checkpoints
 JOIN job_configs ON checkpoints.job_id = job_configs.id
 WHERE job_configs.id = :job_id
     AND checkpoints.organization_id = :organization_id

--- a/crates/arroyo-api/sqlite_migrations/V10__add_checkpoint_type.sql
+++ b/crates/arroyo-api/sqlite_migrations/V10__add_checkpoint_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE checkpoints ADD COLUMN is_stopping INTEGER DEFAULT 0 NOT NULL;

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -1,7 +1,7 @@
 use crate::queries::api_queries::{DbCheckpoint, DbLogMessage, DbPipelineJob};
 use anyhow::Context;
 use arroyo_rpc::api_types::checkpoints::{
-    Checkpoint, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
+    Checkpoint, CheckpointType, JobCheckpointSpan, OperatorCheckpointGroup, SubtaskCheckpointGroup,
 };
 use arroyo_rpc::api_types::pipelines::{JobLogLevel, JobLogMessage, OutputData, StopType};
 use arroyo_rpc::api_types::{
@@ -602,6 +602,7 @@ impl TryFrom<DbCheckpoint> for Checkpoint {
         Ok(Checkpoint {
             epoch: val.epoch as u64,
             backend: val.state_backend,
+            checkpoint_type: CheckpointType::from_is_stopping(val.is_stopping),
             start_time: to_micros(val.start_time),
             finish_time: val.finish_time.map(to_micros),
             events: events.into_iter().map(|e| e.into()).collect(),

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -298,6 +298,7 @@ impl IntoResponse for HttpError {
         JobLogMessageCollection,
         JobLogLevel,
         Checkpoint,
+        CheckpointType,
         CheckpointCollection,
         OutputData,
         MetricName,

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -58,8 +58,8 @@ WHERE job_id = :job_id AND epoch < :epoch;
 
 --! create_checkpoint
 INSERT INTO checkpoints
-(pub_id, organization_id, job_id, state_backend, epoch, min_epoch, start_time)
-VALUES (:pub_id, :organization_id, :job_id, :state_backend, :epoch, :min_epoch, :start_time);
+(pub_id, organization_id, job_id, state_backend, epoch, min_epoch, start_time, is_stopping)
+VALUES (:pub_id, :organization_id, :job_id, :state_backend, :epoch, :min_epoch, :start_time, :is_stopping);
 
 --! update_checkpoint (finish_time?)
 UPDATE checkpoints

--- a/crates/arroyo-controller/src/job_controller/checkpoint_store.rs
+++ b/crates/arroyo-controller/src/job_controller/checkpoint_store.rs
@@ -42,6 +42,7 @@ impl CheckpointMetadataStore for DbCheckpointMetadataStore {
             &(req.epoch as i32),
             &(req.min_epoch as i32),
             &OffsetDateTime::from(req.start_time),
+            &req.is_stopping,
         )
         .await?;
         Ok(())

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -273,6 +273,7 @@ message JobCheckpointMetadata {
   uint64 start_time = 3;
   optional uint64 finish_time = 4;
   repeated JobCheckpointEventSpan event_spans = 5;
+  bool is_stopping = 6;
 }
 
 enum JobState {

--- a/crates/arroyo-rpc/src/api_types/checkpoints.rs
+++ b/crates/arroyo-rpc/src/api_types/checkpoints.rs
@@ -9,9 +9,27 @@ use utoipa::ToSchema;
 pub struct Checkpoint {
     pub epoch: u64,
     pub backend: String,
+    pub checkpoint_type: CheckpointType,
     pub start_time: u64,
     pub finish_time: Option<u64>,
     pub events: Vec<CheckpointEventSpan>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointType {
+    Scheduled,
+    Stopping,
+}
+
+impl CheckpointType {
+    pub fn from_is_stopping(is_stopping: bool) -> Self {
+        if is_stopping {
+            Self::Stopping
+        } else {
+            Self::Scheduled
+        }
+    }
 }
 
 impl From<grpc::rpc::JobCheckpointMetadata> for Checkpoint {
@@ -19,6 +37,7 @@ impl From<grpc::rpc::JobCheckpointMetadata> for Checkpoint {
         Self {
             epoch: value.epoch,
             backend: value.state_backend,
+            checkpoint_type: CheckpointType::from_is_stopping(value.is_stopping),
             start_time: value.start_time,
             finish_time: value.finish_time,
             events: value
@@ -115,5 +134,22 @@ impl From<JobCheckpointSpan> for CheckpointEventSpan {
             event: format!("{:?}", value.event),
             description,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoint_type_maps_from_stopping_flag() {
+        assert_eq!(
+            CheckpointType::from_is_stopping(false),
+            CheckpointType::Scheduled
+        );
+        assert_eq!(
+            CheckpointType::from_is_stopping(true),
+            CheckpointType::Stopping
+        );
     }
 }

--- a/crates/arroyo-rpc/src/checkpoints.rs
+++ b/crates/arroyo-rpc/src/checkpoints.rs
@@ -18,6 +18,7 @@ pub struct CreateCheckpointReq {
     pub epoch: u64,
     pub min_epoch: u64,
     pub start_time: SystemTime,
+    pub is_stopping: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -39,6 +39,7 @@ pub struct StoredCheckpointMetadata {
     finish_time: Option<SystemTime>,
     event_spans: Vec<JobCheckpointSpan>,
     operator_details: HashMap<String, OperatorCheckpointDetail>,
+    is_stopping: bool,
     status: arroyo_rpc::checkpoints::CheckpointStatus,
 }
 
@@ -86,6 +87,7 @@ impl CheckpointHistory {
             finish_time: None,
             event_spans: vec![],
             operator_details: HashMap::new(),
+            is_stopping: req.is_stopping,
             status: arroyo_rpc::checkpoints::CheckpointStatus::InProgress,
         };
 
@@ -164,6 +166,7 @@ impl CheckpointHistory {
                     .cloned()
                     .map(checkpoint_span_to_rpc)
                     .collect(),
+                is_stopping: c.is_stopping,
             })
             .collect()
     }
@@ -186,6 +189,42 @@ pub mod checkpoint_state;
 pub mod committing_state;
 pub mod controller;
 pub mod model;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arroyo_rpc::checkpoints::CreateCheckpointReq;
+
+    fn create_req(epoch: u64, is_stopping: bool) -> CreateCheckpointReq {
+        CreateCheckpointReq {
+            checkpoint_id: format!("checkpoint-{epoch}"),
+            epoch,
+            min_epoch: 0,
+            start_time: SystemTime::now(),
+            is_stopping,
+        }
+    }
+
+    #[test]
+    fn checkpoint_history_marks_scheduled_checkpoints() {
+        let mut history = CheckpointHistory::default();
+        history.create_checkpoint(&create_req(1, false));
+
+        let checkpoints = history.checkpoints();
+        assert_eq!(checkpoints.len(), 1);
+        assert!(!checkpoints[0].is_stopping);
+    }
+
+    #[test]
+    fn checkpoint_history_marks_stopping_checkpoints() {
+        let mut history = CheckpointHistory::default();
+        history.create_checkpoint(&create_req(1, true));
+
+        let checkpoints = history.checkpoints();
+        assert_eq!(checkpoints.len(), 1);
+        assert!(checkpoints[0].is_stopping);
+    }
+}
 
 #[derive(Debug)]
 pub struct RetireWorkerLeader {

--- a/crates/arroyo-worker/src/job_controller/model.rs
+++ b/crates/arroyo-worker/src/job_controller/model.rs
@@ -362,6 +362,7 @@ impl RunningJobModel {
                 epoch: *self.epoch,
                 min_epoch: *self.min_epoch,
                 start_time: SystemTime::now(),
+                is_stopping: then_stop,
             })
             .await?;
 

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -470,6 +470,7 @@ export interface components {
         };
         Checkpoint: {
             backend: string;
+            checkpoint_type: components["schemas"]["CheckpointType"];
             /** Format: int32 */
             epoch: number;
             events: components["schemas"]["CheckpointEventSpan"][];
@@ -489,6 +490,8 @@ export interface components {
             /** Format: int64 */
             start_time: number;
         };
+        /** @enum {string} */
+        CheckpointType: "scheduled" | "stopping";
         ConnectionAutocompleteResp: {
             values: {
                 [key: string]: string[];


### PR DESCRIPTION
Requests to the /checkpoints endpoint will now return a new field, `checkpoint_type` which can be one of `scheduled` or `stopping`. This allows clients to distinguish between checkpoints that were triggered by the regular checkpointing process and those triggered by a stop request.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->