### PR TITLE
Don't fail in leader mode if job is stopping

### DIFF
--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -1,10 +1,10 @@
 use super::{JobContext, State, Transition, controller_job_failure};
 use crate::JobMessage;
+use crate::states::StateError;
 use crate::states::leader_finishing::LeaderFinishing;
 use crate::states::leader_rescaling::LeaderRescaling;
 use crate::states::leader_restarting::LeaderRestarting;
 use crate::states::leader_stop_if_desired_running;
-use crate::states::{StateError, fatal};
 use anyhow::anyhow;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
@@ -169,11 +169,11 @@ impl State for LeaderRunning {
                                     // in progress
                                 }
                                 rpc::JobState::JobStopping | rpc::JobState::JobStopped => {
-                                    // the job somehow is stopping without us telling it to
-                                    // we may want to automatically handle this in the future, but
-                                    // initially I'm being conservative about automation
-                                    return Err(fatal("job unexpectedly stopped",
-                                        anyhow!("job unexpectedly entered {:?} state", state)));
+                                    return ctx.handle_job_failure(*self, controller_job_failure(
+                                        format!("job unexpectedly in {:?} state, should be running", state),
+                                        rpc::ErrorDomain::Internal,
+                                        rpc::RetryHint::WithBackoff,
+                                    )).await;
                                 }
                                 rpc::JobState::JobFinishing | rpc::JobState::JobFinished => {
                                     // finishing is initiated by the workers themselves (via the

--- a/crates/arroyo-rpc/src/identity.rs
+++ b/crates/arroyo-rpc/src/identity.rs
@@ -53,11 +53,19 @@ impl Interceptor for InjectWorkerId {
 /// Server interceptor: rejects requests whose `x-target-worker-id` header
 /// does not match the server's own worker_id.
 #[derive(Clone, Debug)]
-pub struct VerifyWorkerId(pub u64);
+pub struct VerifyWorkerId {
+    pub service: &'static str,
+    pub worker_id: WorkerId,
+}
 
 impl Interceptor for VerifyWorkerId {
     fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
         let Some(header) = req.metadata().get(WORKER_ID_HEADER) else {
+            warn!(
+                service = self.service,
+                caller =? req.remote_addr(),
+                "x-target-worker-id header is missing"
+            );
             return Ok(req);
         };
 
@@ -67,9 +75,11 @@ impl Interceptor for VerifyWorkerId {
             .parse()
             .map_err(|_| Status::permission_denied("x-target-worker-id mismatch"))?;
 
-        if received != self.0 {
+        if received != *self.worker_id {
             warn!(
-                expected = self.0,
+                service = self.service,
+                caller =? req.remote_addr(),
+                expected = *self.worker_id,
                 received, "rejecting request with mismatched target worker_id"
             );
             return Err(Status::permission_denied("x-target-worker-id mismatch"));
@@ -121,7 +131,11 @@ mod tests {
                 req.metadata_mut()
                     .insert(WORKER_ID_HEADER, h.parse().unwrap());
             }
-            let result = VerifyWorkerId(expected).call(req);
+            let result = VerifyWorkerId {
+                service: "test",
+                worker_id: WorkerId(expected),
+            }
+            .call(req);
             assert_eq!(
                 result.is_ok(),
                 should_pass,
@@ -138,6 +152,11 @@ mod tests {
         let req = InjectWorkerId::new(WorkerId(1234567890))
             .call(Request::new(()))
             .unwrap();
-        VerifyWorkerId(1234567890).call(req).unwrap();
+        VerifyWorkerId {
+            service: "test",
+            worker_id: WorkerId(1234567890),
+        }
+        .call(req)
+        .unwrap();
     }
 }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -740,7 +740,10 @@ impl WorkerServer {
             JobStatusGrpcServer::new(leader)
                 .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd),
-            VerifyWorkerId(*context.worker_id),
+            VerifyWorkerId {
+                service: "job-status",
+                worker_id: context.worker_id,
+            },
         );
 
         self.shutdown_guard
@@ -754,7 +757,10 @@ impl WorkerServer {
                         .await?
                         .add_service(WorkerGrpcServer::with_interceptor(
                             self,
-                            VerifyWorkerId(*context.worker_id),
+                            VerifyWorkerId {
+                                service: "worker-grpc",
+                                worker_id: context.worker_id,
+                            },
                         ))
                         .add_service(job_controller)
                         .add_service(leader)
@@ -764,7 +770,10 @@ impl WorkerServer {
                     arroyo_server_common::grpc_server()
                         .add_service(WorkerGrpcServer::with_interceptor(
                             self,
-                            VerifyWorkerId(*context.worker_id),
+                            VerifyWorkerId {
+                                service: "worker-grpc",
+                                worker_id: context.worker_id,
+                            },
                         ))
                         .add_service(job_controller)
                         .add_service(leader)


### PR DESCRIPTION
We've seen several cases now where jobs in leader mode unexpectedly get a stop command, without a log from the controller (or any controller) indicating that it sent such a command. It's not clear how this is happening—the worker id verification should prevent other controllers from talking to the wrong worker.

Currently, this causes the pipeline to fail as we were being intentionally conservative about unexpected cases.

This PR makes two changes:
* This case is now a retryable error, rather than a fatal error
* We've added additional logging in the worker id verification interceptor to try to shed a better light on what's happening 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->