### PR TITLE
Expose pipeline_id in job APIs

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -203,7 +203,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
 --! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -211,7 +211,7 @@ WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pub
 ORDER BY job_configs.created_at DESC;
 
 --! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -219,7 +219,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY job_configs.created_at DESC;
 
 --! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -520,6 +520,7 @@ impl From<DbPipelineJob> for Job {
     fn from(val: DbPipelineJob) -> Self {
         Job {
             id: val.id,
+            pipeline_id: val.pipeline_id,
             running_desired: val.stop == StopMode::none,
             state: val.state.unwrap_or_else(|| "Created".to_string()),
             run_id: val.run_id.unwrap_or(0) as u64,

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -130,6 +130,8 @@ pub struct FailureReason {
 #[serde(rename_all = "snake_case")]
 pub struct Job {
     pub id: String,
+    /// The `pub_id` of the pipeline this job belongs to.
+    pub pipeline_id: String,
     pub running_desired: bool,
     pub state: String,
     pub run_id: u64,

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -692,6 +692,8 @@ export interface components {
             /** Format: int64 */
             finish_time?: number | null;
             id: string;
+            /** @description The `pub_id` of the pipeline this job belongs to. */
+            pipeline_id: string;
             /** Format: int64 */
             run_id: number;
             running_desired: boolean;


### PR DESCRIPTION
Include the owning pipeline's pub_id on the Job type returned by the job endpoints so API consumers can correlate a job with its pipeline.

- Select pipelines.pub_id as pipeline_id in get_pipeline_jobs, get_all_jobs, and get_pipeline_job
- Add the pipeline_id field to the Job API type and map it in the From<DbPipelineJob> conversion
- Regenerate the corresponding webui API types
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->