### PR TITLE
Expose state_url and tags in pipeline APIs

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -121,14 +121,14 @@ WHERE organization_id = :organization_id AND pub_id = :pub_id;
 
 ----------- pipelines -------------------
 
---: DbPipeline (state?, ttl_micros?)
+--: DbPipeline (state?, ttl_micros?, state_url?)
 
 --! create_pipeline(textual_repr?, state_url?)
 INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_repr, udfs, program, proto_version, state_url, tags)
 VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 
 --! get_pipelines : DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -143,7 +143,7 @@ ORDER BY pipelines.created_at DESC
 LIMIT cast(:limit as integer);
 
 --! get_pipeline: DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -512,6 +512,8 @@ impl TryInto<Pipeline> for DbPipeline {
             action_in_progress,
             preview: self.ttl_micros.is_some(),
             env_vars: self.env_vars,
+            state_url: self.state_url,
+            tags: serde_json::from_value(self.tags).map_err(log_and_map)?,
         })
     }
 }

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -81,6 +81,10 @@ pub struct Pipeline {
     pub graph: PipelineGraph,
     pub preview: bool,
     pub env_vars: serde_json::Value,
+    /// Optional URL pointing to the state the pipeline was started from.
+    pub state_url: Option<String>,
+    /// User-defined key/value tags associated with the pipeline.
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -818,7 +818,11 @@ export interface components {
             name: string;
             preview: boolean;
             query: string;
+            state_url?: string | null;
             stop: components["schemas"]["StopType"];
+            tags: {
+                [key: string]: string;
+            };
             udfs: components["schemas"]["Udf"][];
         };
         PipelineCollection: {

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -35,6 +35,8 @@ import {
   Tabs,
   Text,
   useDisclosure,
+  Wrap,
+  WrapItem,
 } from '@chakra-ui/react';
 import React, { useEffect, useRef, useState } from 'react';
 import 'reactflow/dist/style.css';
@@ -168,6 +170,30 @@ export function PipelineDetails() {
             <Text>{job.state}</Text>
           </Box>
         </Box>
+        {pipeline.state_url ? (
+          <Box className="field">
+            <Box className="fieldName">State URL</Box>
+            <Box className="fieldValue">
+              <Text wordBreak="break-all">{pipeline.state_url}</Text>
+            </Box>
+          </Box>
+        ) : null}
+        {Object.keys(pipeline.tags).length > 0 ? (
+          <Box className="field">
+            <Box className="fieldName">Tags</Box>
+            <Box className="fieldValue">
+              <Wrap spacing={1}>
+                {Object.entries(pipeline.tags).map(([k, v]) => (
+                  <WrapItem key={k}>
+                    <Badge>
+                      {k}: {v}
+                    </Badge>
+                  </WrapItem>
+                ))}
+              </Wrap>
+            </Box>
+          </Box>
+        ) : null}
         {operatorDetail}
       </Stack>
     </TabPanel>


### PR DESCRIPTION
Include the pipeline's state_url and tags on the Pipeline type returned by the list and get pipeline endpoints so API consumers can read back values that were previously only accepted on create.

- Select state_url and tags in get_pipelines and get_pipeline, and mark state_url nullable in the DbPipeline row annotation
- Add state_url and tags fields to the Pipeline API type and map them in the TryInto<Pipeline> for DbPipeline conversion
- Regenerate the corresponding webui API types
- Display state_url and tags in the pipeline details sidebar in the web UI

**Testing**

Create the pipeline with tags & state_url.
```
❯ curl -sS -X POST http://localhost:5115/api/v1/pipelines -H 'Content-Type: application/json' --data @- <<'JSON' | tee /tmp/pipeline.json | jq
{
  "name": "tags-demo",
  "parallelism": 1,
  "state_url": "/tmp/testing-arroyo-state-url/",
  "tags": { "team": "data", "env": "dev" },
  "query": "create table impulse with (connector = 'impulse', event_rate = '10');\nselect * from impulse;"
}
JSON
```

GET
```
❯ curl -sS "http://localhost:5115/api/v1/pipelines/$PIPELINE_ID" | jq '{id, name, state_url, tags}'
{
  "id": "pl_AE4CCeIyju",
  "name": "tags-demo",
  "state_url": "/tmp/testing-arroyo-state-url/",
  "tags": {
    "team": "data",
    "env": "dev"
  }
}
```
WebUI change (right side)
<img width="1251" height="426" alt="Screenshot 2026-06-16 at 4 34 22 PM" src="https://github.com/user-attachments/assets/8f82fa44-f102-440e-b660-cd92773fd518" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->