### PR TITLE
Move env_vars from the Pipeline API to the Job API

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -128,7 +128,7 @@ INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_
 VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 
 --! get_pipelines : DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars, state_url, tags
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -143,7 +143,7 @@ ORDER BY pipelines.created_at DESC
 LIMIT cast(:limit as integer);
 
 --! get_pipeline: DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, env_vars, state_url, tags
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -203,7 +203,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
 --! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -211,7 +211,7 @@ WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pub
 ORDER BY job_configs.created_at DESC;
 
 --! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -219,7 +219,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY job_configs.created_at DESC;
 
 --! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -511,7 +511,6 @@ impl TryInto<Pipeline> for DbPipeline {
             action_text,
             action_in_progress,
             preview: self.ttl_micros.is_some(),
-            env_vars: self.env_vars,
             state_url: self.state_url,
             tags: serde_json::from_value(self.tags).map_err(log_and_map)?,
         })
@@ -538,6 +537,7 @@ impl From<DbPipelineJob> for Job {
             }),
             created_at: to_micros(val.created_at),
             scheduler_config: val.scheduler_config,
+            env_vars: val.env_vars,
         }
     }
 }

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -80,7 +80,6 @@ pub struct Pipeline {
     pub action_in_progress: bool,
     pub graph: PipelineGraph,
     pub preview: bool,
-    pub env_vars: serde_json::Value,
     /// Optional URL pointing to the state the pipeline was started from.
     pub state_url: Option<String>,
     /// User-defined key/value tags associated with the pipeline.
@@ -148,6 +147,8 @@ pub struct Job {
     /// An empty object means "no overrides, use the controller's
     /// global scheduler config unchanged".
     pub scheduler_config: serde_json::Value,
+    /// Per-job environment variables forwarded to workers.
+    pub env_vars: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -699,6 +699,10 @@ export interface components {
             /** Format: int64 */
             run_id: number;
             running_desired: boolean;
+            /** @description Per-job scheduler configuration overlay (see `PipelinePost`).
+             *     An empty object means "no overrides, use the controller's
+             *     global scheduler config unchanged". */
+            scheduler_config: unknown;
             /** Format: int64 */
             start_time?: number | null;
             state: string;
@@ -864,10 +868,21 @@ export interface components {
         PipelinePost: {
             /** Format: int64 */
             checkpoint_interval_micros?: number | null;
+            /** @description Per-job environment variables forwarded to workers. */
+            env_vars?: {
+                [key: string]: string;
+            } | null;
             name: string;
             /** Format: int64 */
             parallelism: number;
             query: string;
+            /** @description Per-job scheduler configuration overlay. The shape mirrors the
+             *     controller's global scheduler config (e.g. the
+             *     `kubernetes-scheduler.*` block) and is merged on top of it at
+             *     scheduling time. An omitted field, `null`, or an empty object
+             *     all mean "use the controller's global scheduler config
+             *     unchanged". */
+            scheduler_config?: unknown;
             state_url?: string | null;
             tags?: {
                 [key: string]: string;

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -471,7 +471,7 @@ export interface components {
         Checkpoint: {
             backend: string;
             checkpoint_type: components["schemas"]["CheckpointType"];
-            /** Format: int32 */
+            /** Format: int64 */
             epoch: number;
             events: components["schemas"]["CheckpointEventSpan"][];
             /** Format: int64 */
@@ -688,6 +688,8 @@ export interface components {
         Job: {
             /** Format: int64 */
             created_at: number;
+            /** @description Per-job environment variables forwarded to workers. */
+            env_vars: unknown;
             failure_reason?: components["schemas"]["FailureReason"] | null;
             /** Format: int64 */
             finish_time?: number | null;
@@ -818,8 +820,10 @@ export interface components {
             name: string;
             preview: boolean;
             query: string;
+            /** @description Optional URL pointing to the state the pipeline was started from. */
             state_url?: string | null;
             stop: components["schemas"]["StopType"];
+            /** @description User-defined key/value tags associated with the pipeline. */
             tags: {
                 [key: string]: string;
             };

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -20,6 +20,12 @@ import {
   Grid,
   Heading,
   Icon,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
   Popover,
   PopoverArrow,
   PopoverBody,
@@ -65,6 +71,20 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { useNavbar } from '../../App';
 
+function flattenConfig(value: unknown, prefix = ''): [string, string][] {
+  if (value === null || typeof value !== 'object') {
+    return [[prefix, String(value)]];
+  }
+  if (Array.isArray(value)) {
+    return [[prefix, JSON.stringify(value)]];
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) {
+    return prefix ? [[prefix, '{}']] : [];
+  }
+  return entries.flatMap(([key, v]) => flattenConfig(v, prefix ? `${prefix}.${key}` : key));
+}
+
 export function PipelineDetails() {
   const [activeOperator, setActiveOperator] = useState<number | undefined>(undefined);
   const {
@@ -76,6 +96,11 @@ export function PipelineDetails() {
     isOpen: restartWithoutStateModalIsOpen,
     onOpen: onRestartWithoutStateModalOpen,
     onClose: onRestartWithoutStateModalClose,
+  } = useDisclosure();
+  const {
+    isOpen: schedulerConfigModalIsOpen,
+    onOpen: onSchedulerConfigModalOpen,
+    onClose: onSchedulerConfigModalClose,
   } = useDisclosure();
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -214,13 +239,9 @@ export function PipelineDetails() {
           <Box className="field">
             <Box className="fieldName">Scheduler Config</Box>
             <Box className="fieldValue">
-              <SyntaxHighlighter
-                language="json"
-                style={vs2015}
-                customStyle={{ borderRadius: '5px' }}
-              >
-                {JSON.stringify(job.scheduler_config, null, 2)}
-              </SyntaxHighlighter>
+              <Button size="sm" onClick={onSchedulerConfigModalOpen}>
+                View
+              </Button>
             </Box>
           </Box>
         ) : null}
@@ -429,6 +450,27 @@ export function PipelineDetails() {
           </AlertDialogContent>
         </AlertDialogOverlay>
       </AlertDialog>
+      <Modal
+        isOpen={schedulerConfigModalIsOpen}
+        onClose={onSchedulerConfigModalClose}
+        isCentered
+        size="xl"
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Scheduler Config</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <Stack spacing={1}>
+              {flattenConfig(job.scheduler_config).map(([k, v]) => (
+                <Text key={k} fontFamily="mono" fontSize="sm" wordBreak="break-all">
+                  {k}: {v}
+                </Text>
+              ))}
+            </Stack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -194,6 +194,36 @@ export function PipelineDetails() {
             </Box>
           </Box>
         ) : null}
+        {job.env_vars && Object.keys(job.env_vars as Record<string, string>).length > 0 ? (
+          <Box className="field">
+            <Box className="fieldName">Env Vars</Box>
+            <Box className="fieldValue">
+              <Wrap spacing={1}>
+                {Object.entries(job.env_vars as Record<string, string>).map(([k, v]) => (
+                  <WrapItem key={k}>
+                    <Badge>
+                      {k}: {v}
+                    </Badge>
+                  </WrapItem>
+                ))}
+              </Wrap>
+            </Box>
+          </Box>
+        ) : null}
+        {job.scheduler_config && Object.keys(job.scheduler_config as object).length > 0 ? (
+          <Box className="field">
+            <Box className="fieldName">Scheduler Config</Box>
+            <Box className="fieldValue">
+              <SyntaxHighlighter
+                language="json"
+                style={vs2015}
+                customStyle={{ borderRadius: '5px' }}
+              >
+                {JSON.stringify(job.scheduler_config, null, 2)}
+              </SyntaxHighlighter>
+            </Box>
+          </Box>
+        ) : null}
         {operatorDetail}
       </Stack>
     </TabPanel>

--- a/webui/src/routes/pipelines/pipelines.css
+++ b/webui/src/routes/pipelines/pipelines.css
@@ -35,6 +35,7 @@
 .pipelineInfo .fieldName,
 .pipelineInfo .fieldValue {
   display: inline-block;
+  vertical-align: middle;
 }
 
 .pipelineInfo .fieldName {


### PR DESCRIPTION
env_vars is a per-job value stored on job_configs (like scheduler_config), not a pipeline-level field like tags/state_url. Move it to the Job type to match scheduler_config and reflect where the data actually lives.

**Testing**

```
❯ curl -sS -X POST http://localhost:5115/api/v1/pipelines -H 'Content-Type: application/json' --data @- <<'JSON' | tee /tmp/pipeline.json | jq
{
  "name": "env-sched-demo",
  "parallelism": 1,
  "tags": { "team": "data" },
  "state_url": "/tmp/arroyo-testing/",
  "env_vars": { "MY_FLAG": "true", "LOG_LEVEL": "debug" },
  "scheduler_config": { "kubernetes-scheduler": { "worker": { "resources": { "requests": { "memory": "512Mi" } } } } },
  "query": "create table impulse with (connector = 'impulse', event_rate = '10');\nselect * from impulse;"
}
JSON

```
```
❯ curl -sS "http://localhost:5115/api/v1/pipelines/$PIPELINE_ID/jobs" | jq '.data[] | {id, pipeline_id, state, run_id, env_vars, scheduler_config}'
{
  "id": "job_RGE8zrKCux",
  "pipeline_id": "pl_hrR0MNXLSI",
  "state": "Running",
  "run_id": 2,
  "env_vars": {
    "LOG_LEVEL": "debug",
    "MY_FLAG": "true"
  },
  "scheduler_config": {
    "kubernetes-scheduler": {
      "worker": {
        "resources": {
          "requests": {
            "memory": "512Mi"
          }
        }
      }
    }
  }
}
```
WebUI:
<img width="570" height="546" alt="Screenshot 2026-06-18 at 1 32 11 PM" src="https://github.com/user-attachments/assets/aeafe8d0-b3a0-44e4-897b-a6a1bc53474d" />

Modal: 
<img width="1042" height="489" alt="Screenshot 2026-06-18 at 1 32 42 PM" src="https://github.com/user-attachments/assets/ae1f0730-bb8b-448e-92e4-5c4aa4ba18dc" />



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->