### PR TITLE
Fix checkpoint cleaning feailures in leader mode that could starve out checkpointing

### DIFF
--- a/crates/arroyo-state-protocol/src/gc.rs
+++ b/crates/arroyo-state-protocol/src/gc.rs
@@ -71,11 +71,7 @@ where
         let Some(manifest): Option<CheckpointManifest> =
             read_protobuf(store, &checkpoint_ref).await?
         else {
-            if history.is_empty() {
-                return Err(StoreError::ExistingObjectMissing {
-                    path: checkpoint_ref,
-                });
-            }
+            // this was already deleted in a prior cleaning run
             break;
         };
 

--- a/crates/arroyo-state-protocol/src/gc.rs
+++ b/crates/arroyo-state-protocol/src/gc.rs
@@ -62,7 +62,8 @@ async fn collect_history_and_clean_checkpoint_files<S>(
 where
     S: ProtocolStore + ?Sized,
 {
-    let mut history = Vec::new();
+    let mut head = true;
+    let mut history = vec![];
     let mut seen = HashSet::new();
     let mut next = Some(current);
 
@@ -71,9 +72,15 @@ where
         let Some(manifest): Option<CheckpointManifest> =
             read_protobuf(store, &checkpoint_ref).await?
         else {
-            // this was already deleted in a prior cleaning run
+            if head {
+                return Err(StoreError::ExpectedObjectMissing {
+                    path: checkpoint_ref,
+                });
+            }
             break;
         };
+
+        head = false;
 
         let owner = CheckpointOwner {
             generation: Generation(manifest.generation),

--- a/crates/arroyo-state-protocol/src/store.rs
+++ b/crates/arroyo-state-protocol/src/store.rs
@@ -39,6 +39,8 @@ pub enum StoreError {
     InvalidProtobuf { path: CheckpointRef, msg: String },
     #[error("conditional create for {path} reported an existing object, but it could not be read")]
     ExistingObjectMissing { path: CheckpointRef },
+    #[error("expected {path} to exist but it was missing")]
+    ExpectedObjectMissing { path: CheckpointRef },
     #[error("protocol error: {0}")]
     Protocol(#[from] ProtocolError),
 }

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -48,6 +48,7 @@ pub struct WorkerJobController {
     status: JobControllerStatus,
     model: RunningJobModel,
     cleanup_task: Option<JoinHandle<anyhow::Result<Epoch>>>,
+    cleanup_backoff: Option<SystemTime>,
     rx: Receiver<RunningMessage>,
     stopping: bool,
     failing: bool,
@@ -275,6 +276,7 @@ impl WorkerJobController {
             status,
             worker_context,
             cleanup_task: None,
+            cleanup_backoff: None,
             rx,
             stopping: false,
             failing: false,
@@ -607,8 +609,7 @@ impl WorkerJobController {
                         error = format!("{:?}", e)
                     );
 
-                    // wait a bit before trying again
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    self.cleanup_backoff = Some(SystemTime::now() + Duration::from_secs(10));
                 }
                 Err(e) => {
                     error!(
@@ -616,15 +617,9 @@ impl WorkerJobController {
                         job_id = *self.worker_context.job_id,
                         error = format!("{:?}", e)
                     );
-
-                    // wait a bit before trying again
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    self.cleanup_backoff = Some(SystemTime::now() + Duration::from_secs(10));
                 }
             }
-        }
-
-        if !self.stopping && self.cleanup_task.is_none() && self.model.checkpoint_state.is_none() {
-            self.cleanup_task = self.start_cleanup();
         }
 
         if self.stopping && !self.final_checkpoint_started && self.model.checkpoint_state.is_none()
@@ -646,6 +641,16 @@ impl WorkerJobController {
         {
             // or do we need to start checkpointing?
             self.checkpoint(false).await?;
+        }
+
+        // do we need to start cleaning?
+        let now = SystemTime::now();
+        if !self.stopping
+            && self.cleanup_task.is_none()
+            && self.model.checkpoint_state.is_none()
+            && self.cleanup_backoff.unwrap_or(now) <= now
+        {
+            self.cleanup_task = self.start_cleanup();
         }
 
         // update metrics

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -28,7 +28,7 @@ pub use arroyo_rpc::worker_types::{RunningMessage, TaskFailedEvent, WorkerContex
 pub mod job_metrics;
 
 pub const CHECKPOINTS_TO_KEEP: u64 = 10;
-pub const COMPACT_EVERY: u64 = 2;
+pub const COMPACT_EVERY: u64 = 10;
 
 #[derive(Debug, Clone)]
 pub struct StoredCheckpointMetadata {


### PR DESCRIPTION
Fixes an error we saw that looked likes this:

* Worker successfully cleans a generation set of generations
* Then, before it can write a new checkpoint (with the updated min_epoch) worker is killed
* On startup it re-attempts to clean that generation
* This fails, because we're treating the case where the root manifest is already deleted as an error
* Because we didn't successfully clean, on our job manager loop that's always the first thing we try to do, starving out checkpointing
* This means we never commit to timber and never advance our offset

There are two fixes here:

* We no longer error if the manifest is already deleted during GC, as it may have been correctly deleted by a prior run that wasn't checkpointed
* We now have a backoff for failed cleanings, and check for cleaning start after checkpointing so it can't be starved out
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->