### PR TITLE
Optimize AND TRUE expressions

### DIFF
--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -823,7 +823,10 @@ mod tests {
         let rewritten = and(predicate.clone(), lit(true))
             .rewrite(&mut TimeWindowNullCheckRemover {})
             .unwrap();
-        assert!(rewritten.transformed, "expected `expr AND true` to be rewritten");
+        assert!(
+            rewritten.transformed,
+            "expected `expr AND true` to be rewritten"
+        );
         assert_eq!(
             rewritten.data, predicate,
             "`expr AND true` should collapse to `expr`"
@@ -833,7 +836,10 @@ mod tests {
         let rewritten = and(lit(true), predicate.clone())
             .rewrite(&mut TimeWindowNullCheckRemover {})
             .unwrap();
-        assert!(rewritten.transformed, "expected `true AND expr` to be rewritten");
+        assert!(
+            rewritten.transformed,
+            "expected `true AND expr` to be rewritten"
+        );
         assert_eq!(
             rewritten.data, predicate,
             "`true AND expr` should collapse to `expr`"

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -791,3 +791,65 @@ impl TreeNodeRewriter for SinkInputRewriter<'_> {
         Ok(Transformed::no(node))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::{col, lit};
+
+    fn and(left: Expr, right: Expr) -> Expr {
+        Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left),
+            logical_expr::Operator::And,
+            Box::new(right),
+        ))
+    }
+
+    /// `f_down` rewrites a time-window `IS NOT NULL` guard to the literal `true`, leaving a
+    /// trivial `predicate AND true` behind; `f_up` must collapse that back to `predicate`.
+    ///
+    /// `lit(true)` is the exact node `f_down` emits
+    /// (`Expr::Literal(ScalarValue::Boolean(Some(true)), None)`), so rewriting `predicate AND true`
+    /// reproduces the real post-`f_down` shape that reaches `f_up` in `plan::mod`'s `Filter` arm.
+    ///
+    /// Without the `f_up` collapse this fails: the predicate stays `a = 1 AND true` and
+    /// `transformed` is false. On vanilla DataFusion that residual `AND true` triggers the
+    /// `pre_selection_scatter` row-leak when the left side is < 20% selective.
+    #[test]
+    fn collapses_and_true() {
+        let predicate = col("a").eq(lit(1i64));
+
+        // `a = 1 AND true`  ->  `a = 1`
+        let rewritten = and(predicate.clone(), lit(true))
+            .rewrite(&mut TimeWindowNullCheckRemover {})
+            .unwrap();
+        assert!(rewritten.transformed, "expected `expr AND true` to be rewritten");
+        assert_eq!(
+            rewritten.data, predicate,
+            "`expr AND true` should collapse to `expr`"
+        );
+
+        // `true AND a = 1`  ->  `a = 1`  (the literal may sit on either side)
+        let rewritten = and(lit(true), predicate.clone())
+            .rewrite(&mut TimeWindowNullCheckRemover {})
+            .unwrap();
+        assert!(rewritten.transformed, "expected `true AND expr` to be rewritten");
+        assert_eq!(
+            rewritten.data, predicate,
+            "`true AND expr` should collapse to `expr`"
+        );
+    }
+
+    /// Guard: only literal `true` under `AND` is collapsed. A genuine two-sided conjunction must
+    /// be left untouched so we never drop a real predicate.
+    #[test]
+    fn preserves_real_conjunction() {
+        let conjunction = and(col("a").eq(lit(1i64)), col("b").eq(lit(2i64)));
+        let rewritten = conjunction
+            .clone()
+            .rewrite(&mut TimeWindowNullCheckRemover {})
+            .unwrap();
+        assert!(!rewritten.transformed);
+        assert_eq!(rewritten.data, conjunction);
+    }
+}

--- a/crates/arroyo-planner/src/rewriters.rs
+++ b/crates/arroyo-planner/src/rewriters.rs
@@ -703,6 +703,36 @@ impl TreeNodeRewriter for TimeWindowNullCheckRemover {
 
         Ok(Transformed::no(node))
     }
+
+    fn f_up(&mut self, node: Self::Node) -> DFResult<Transformed<Self::Node>> {
+        // Collapse the trivial `expr AND true` / `true AND expr` left behind when an
+        // `IS NOT NULL` time-window check is rewritten to `true` in `f_down`. Beyond being a
+        // useless predicate, a literal-scalar RHS under `AND` triggers a row-leak bug in
+        // DataFusion's short-circuit `pre_selection_scatter`: when the left side is less than
+        // 20% selective, it returns the bare scalar instead of scattering it across the
+        // selection, so the entire batch passes the filter. Collapsing it is therefore also a
+        // correctness fix against upstream DataFusion.
+        if let Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: logical_expr::Operator::And,
+            right,
+        }) = &node
+        {
+            if matches!(
+                right.as_ref(),
+                Expr::Literal(ScalarValue::Boolean(Some(true)), _)
+            ) {
+                return Ok(Transformed::yes(left.as_ref().clone()));
+            }
+            if matches!(
+                left.as_ref(),
+                Expr::Literal(ScalarValue::Boolean(Some(true)), _)
+            ) {
+                return Ok(Transformed::yes(right.as_ref().clone()));
+            }
+        }
+        Ok(Transformed::no(node))
+    }
 }
 
 pub struct RowTimeRewriter {}


### PR DESCRIPTION
There's a latent row-correctness bug in datafusion 48 (https://github.com/apache/datafusion/issues/16928, fixed by @mwylde) in the short-circuit `AND` that `expr AND true` triggers. The solution we currently have in arroyo is to patch a fix into arroyo-datafusion. As part of the work in https://github.com/ArroyoSystems/arroyo/issues/1088 I'm trying to remove our dependency on the internal fork so that we can bump DF versions more easily. This PR 