### PR TITLE
Support updating `env_vars` and `scheduler_config` on pipelines

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -165,7 +165,7 @@ WHERE pub_id = :pub_id AND organization_id = :organization_id;
 
 ----------- jobs -----------------------
 
---! update_job(checkpoint_interval_micros?, stop?, parallelism_overrides?)
+--! update_job(checkpoint_interval_micros?, stop?, parallelism_overrides?, env_vars?, scheduler_config?)
 UPDATE job_configs
 SET
    updated_at = :updated_at,
@@ -173,7 +173,9 @@ SET
 
    stop = COALESCE(:stop, stop),
    checkpoint_interval_micros = COALESCE(:checkpoint_interval_micros, checkpoint_interval_micros),
-   parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides)
+   parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides),
+   env_vars = COALESCE(:env_vars, env_vars),
+   scheduler_config = COALESCE(:scheduler_config, scheduler_config)
 WHERE id = :job_id AND organization_id = :organization_id;
 
 --! restart_job(mode, ignore_state_before_epoch?)

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -815,6 +815,16 @@ pub async fn patch_pipeline(
         None
     };
 
+    let env_vars = pipeline_patch
+        .env_vars
+        .map(|e| serde_json::to_value(e).map_err(log_and_map))
+        .transpose()?;
+
+    let scheduler_config = pipeline_patch.scheduler_config.map(|v| match v {
+        serde_json::Value::Null => serde_json::Value::Object(Default::default()),
+        v => v,
+    });
+
     let res = api_queries::execute_update_job(
         &db,
         &OffsetDateTime::now_utc(),
@@ -822,6 +832,8 @@ pub async fn patch_pipeline(
         stop,
         &interval.map(|i| i.as_micros() as i64),
         &parallelism_overrides,
+        &env_vars,
+        &scheduler_config,
         &job_id,
         &auth_data.organization_id,
     )

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -5,6 +5,7 @@ use crate::states::leader_finishing::LeaderFinishing;
 use crate::states::leader_rescaling::LeaderRescaling;
 use crate::states::leader_restarting::LeaderRestarting;
 use crate::states::leader_stop_if_desired_running;
+use crate::types::public::RestartMode;
 use anyhow::anyhow;
 use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
@@ -107,6 +108,19 @@ impl State for LeaderRunning {
                                     *self,
                                     LeaderRestarting {
                                         mode: c.restart_mode,
+                                    },
+                                ));
+                            }
+
+                            // env_vars and scheduler_config are only applied when workers are
+                            // (re)scheduled, so a change to either while the job is running
+                            // requires a restart to take effect.
+                            if c.scheduler_config != ctx.config.scheduler_config
+                                || c.env_vars != ctx.config.env_vars {
+                                return Ok(Transition::next(
+                                    *self,
+                                    LeaderRestarting {
+                                        mode: RestartMode::safe,
                                     },
                                 ));
                             }

--- a/crates/arroyo-controller/src/states/running.rs
+++ b/crates/arroyo-controller/src/states/running.rs
@@ -11,6 +11,7 @@ use crate::states::recovering::Recovering;
 use crate::states::rescaling::Rescaling;
 use crate::states::restarting::Restarting;
 use crate::states::stop_if_desired_running;
+use crate::types::public::RestartMode;
 use crate::{job_controller::ControllerProgress, states::StateError};
 use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
@@ -56,6 +57,16 @@ impl State for Running {
                             if c.restart_nonce != ctx.status.restart_nonce {
                                 return Ok(Transition::next(*self, Restarting {
                                     mode: c.restart_mode
+                                }));
+                            }
+
+                            // env_vars and scheduler_config are only applied when workers are
+                            // (re)scheduled, so a change to either while the job is running
+                            // requires a restart to take effect.
+                            if c.scheduler_config != ctx.config.scheduler_config
+                                || c.env_vars != ctx.config.env_vars {
+                                return Ok(Transition::next(*self, Restarting {
+                                    mode: RestartMode::safe
                                 }));
                             }
 

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -56,6 +56,15 @@ pub struct PipelinePatch {
     pub parallelism: Option<u64>,
     pub checkpoint_interval_micros: Option<u64>,
     pub stop: Option<StopType>,
+    /// Per-job environment variables forwarded to workers.
+    pub env_vars: Option<HashMap<String, String>>,
+    /// Per-job scheduler configuration overlay. The shape mirrors the
+    /// controller's global scheduler config (e.g. the
+    /// `kubernetes-scheduler.*` block) and is merged on top of it at
+    /// scheduling time. An omitted field, `null`, or an empty object
+    /// all mean "use the controller's global scheduler config
+    /// unchanged".
+    pub scheduler_config: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]


### PR DESCRIPTION
In #1060 and #1064, support for specifying per-pipeline `env_vars` and `scheduler_config` was added to the pipeline creation endpoint. This commit now allows modifying these properties using `PATCH` and the assumption each pipeline only ever has one job today. The `PATCH` logic does a entire field replacement and does not attempt to merge the provided values with what may already exist for the job. Users should fetch the existing values first from the jobs API and update the value as needed before making the corresponding `PATCH`.

I'll admit this is a little awkward though given `env_vars` and `scheduler_config` belong to specific job instances and not the pipeline.

To test this, I ran `arroyo cluster`, setup connections and then created a Pipeline

```bash
curl --request POST \
--url http://localhost:5115/api/v1/pipelines \
--header 'content-type: application/json' \
--data '{
"name": "test",
"query": "select * from impulse",
"parallelism": 1
}'
```

After the Pipeline was running, I then issued PATCH requests to modify `env_vars` and watched the pipeline transition from Scheduling to Running.

```bash
curl --request PATCH \
--url http://localhost:5115/api/v1/pipelines/pl_bBwbpsJp2T \
--header 'content-type: application/json' \
--data '{
"env_vars": {
"HELLO": "WORLD"
}
}'
```
