### PR TITLE
When retrying individual states fails, still go through the state machine recovery process

### DIFF
--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -779,20 +779,6 @@ async fn execute_state<'a>(
             message,
             source,
             domain,
-        })
-        | Err(StateError::RetryableError {
-            message,
-            source,
-            domain,
-            retries: 1,
-            ..
-        })
-        | Err(StateError::RetryableError {
-            message,
-            source,
-            domain,
-            retries: 0,
-            ..
         }) => {
             error!(
                 message = "fatal state error",
@@ -818,6 +804,29 @@ async fn execute_state<'a>(
             ctx.status.finish_time = Some(OffsetDateTime::now_utc());
             // Transition to Failing state for graceful shutdown before Failed
             let s: Box<dyn State> = Box::new(Failing {});
+            Some(s)
+        }
+        Err(StateError::RetryableError {
+            message,
+            source,
+            domain,
+            retries: 0 | 1,
+            ..
+        }) => {
+            error!(
+                message = "exhausted in-state retries, moving to recovering",
+                job_id = *ctx.config.id,
+                state = state_name,
+                error_message = message,
+                error = format!("{:?}", source)
+            );
+            ctx.status.restarts += 1;
+            ctx.retries_attempted = 0;
+            let s: Box<dyn State> = Box::new(Recovering {
+                source,
+                reason: message,
+                domain,
+            });
             Some(s)
         }
         Err(StateError::RetryableError {


### PR DESCRIPTION
In the controller state machine, we have two kinds of retries: local retries of the individual state that failed, and global retries of the entire scheduling loop, via the Recovering state. These have different tradeoffs: local retries are faster and cheaper, but may not be able to recover from all failures. Recovery is much more expensive (involving tearing down the entire cluster and recreating it) but is more powerful.

Currently, if a state attempts a local retry, it will do so until it exhausts its budget and then transition to Failed. This means that if we try to do a local recovery for a particular issue and fail, we are not bringing our full recovery power to the problem, and in practice has lead t o a number of pipelines transitioning fully to Failed.

This PR changes that behavior: we now first try local retries, then transition to Recovering instead of Failed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->