### PR TITLE
fix(kafka-sink): return error instead of silent Ok on missing commit restore state

### DIFF
--- a/crates/arroyo-connectors/src/kafka/sink/mod.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::borrow::Cow;
 
+use arroyo_rpc::connector_err;
 use arroyo_rpc::errors::DataflowResult;
 use arroyo_rpc::grpc::rpc::{GlobalKeyedTableConfig, TableConfig, TableEnum};
 use arroyo_rpc::{CheckpointEvent, ControlResp};
@@ -357,10 +358,29 @@ impl ArrowOperator for KafkaSinkFunc {
         };
 
         let Some(committing_producer) = producer_to_complete.take() else {
+            // Reaching this branch means the operator was restarted mid two-phase
+            // commit: `handle_checkpoint` prepared a producer and staged
+            // `producer_to_complete`, but `handle_commit` was invoked after a restart
+            // that lost the in-memory reference. The pending Kafka transaction may
+            // have committed on the broker, aborted, or still be open — we cannot
+            // tell without querying transaction state, which is not yet implemented.
+            //
+            // Silently returning Ok(()) here would tell the checkpoint coordinator
+            // that the commit succeeded when its actual outcome is unknown, breaking
+            // the exactly-once contract. Return an error instead so the pipeline
+            // fails loudly rather than proceeding with unknown consistency.
             error!(
-                "received a commit message without a producer ready to commit. Restoring from commit phase not yet implemented"
+                "received a commit message for epoch {epoch} without a producer ready to commit; \
+                 checkpoint restore during the two-phase-commit window is not yet implemented"
             );
-            return Ok(());
+            return Err(connector_err!(
+                Internal,
+                NoRetry,
+                "kafka exactly-once sink: received commit for epoch {} without a producer ready to commit; \
+                 checkpoint restore during the two-phase-commit window is not yet implemented, \
+                 so the pipeline cannot safely proceed without risking an exactly-once violation",
+                epoch
+            ));
         };
 
         let mut commits_attempted = 0;

--- a/crates/arroyo-connectors/src/kafka/sink/test.rs
+++ b/crates/arroyo-connectors/src/kafka/sink/test.rs
@@ -178,6 +178,56 @@ async fn test_kafka_checkpoint_flushes() {
     }
 }
 
+// Regression test: without this behavior, `handle_commit` would silently
+// return `Ok(())` when `producer_to_complete` is `None` (the state after a
+// crash-restart mid two-phase-commit), telling the checkpoint coordinator the
+// commit succeeded when its actual outcome on the broker is unknown. That is
+// an exactly-once violation. This test asserts the error path is taken instead.
+// It does NOT require a live Kafka broker: the `None` branch returns before
+// any producer call.
+#[tokio::test]
+async fn test_handle_commit_returns_error_when_producer_state_missing() {
+    let mut kafka = KafkaSinkFunc {
+        topic: "unused-in-this-test".to_string(),
+        bootstrap_servers: "unused".to_string(),
+        producer: None,
+        consistency_mode: ConsistencyMode::ExactlyOnce {
+            next_transaction_index: 5,
+            producer_to_complete: None,
+        },
+        timestamp_field: None,
+        timestamp_col: None,
+        key_field: None,
+        write_futures: vec![],
+        client_config: HashMap::new(),
+        context: Context::new(None),
+        serializer: ArrowSerializer::new(Format::Json(JsonFormat::default())),
+        key_col: None,
+    };
+
+    let (command_tx, _rx) = channel(128);
+    let task_info = Arc::new(get_test_task_info());
+
+    let mut ctx = OperatorContext::new(
+        task_info,
+        None,
+        command_tx,
+        1,
+        vec![Arc::new(ArroyoSchema::new_unkeyed(schema(), 0))],
+        None,
+        HashMap::new(),
+    )
+    .await;
+
+    let result = kafka.handle_commit(42, &HashMap::new(), &mut ctx).await;
+
+    assert!(
+        result.is_err(),
+        "handle_commit must return Err when producer_to_complete is None; \
+         silently returning Ok would break the exactly-once contract"
+    );
+}
+
 #[tokio::test]
 async fn test_kafka() {
     let mut kafka_topic_tester = KafkaTopicTester {


### PR DESCRIPTION
## Problem

The exactly-once Kafka sink's `handle_commit` path silently returned `Ok(())` when `producer_to_complete` was `None` — a state that indicates the operator restarted between `handle_checkpoint` and `handle_commit` and lost the in-memory reference to the transactional producer. In that state the pending Kafka transaction may have already committed on the broker, aborted, or still be open; the sink has no way to tell without querying transaction state, and checkpoint restore during the two-phase-commit window is not yet implemented (as the pre-existing `error!("... Restoring from commit phase not yet implemented")` on that branch already noted).

Silently returning `Ok(())` told the checkpoint coordinator the commit succeeded when its outcome was in fact unknown, breaking the exactly-once contract.

## Fix

Return a `DataflowError::ConnectorError { domain: Internal, retry: NoRetry, ... }` on that branch so the pipeline fails loudly rather than proceeding with unknown consistency. Uses the existing `connector_err!` macro.

## Test

Adds `test_handle_commit_returns_error_when_producer_state_missing` in `kafka/sink/test.rs` that constructs a `KafkaSinkFunc` in `ExactlyOnce { producer_to_complete: None }` mode and asserts `handle_commit` returns `Err`. The test does not require a live Kafka broker because the `None` branch returns before any producer call.

Existing tests unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->