### PR TITLE
Add admin routes for pipelines/jobs scoped by org id

### DIFF
--- a/crates/arroyo-api/src/cloud.rs
+++ b/crates/arroyo-api/src/cloud.rs
@@ -1,12 +1,60 @@
-use crate::{AuthData, DEFAULT_ORG, OrgMetadata, rest_utils::ErrorResp};
+use crate::{
+    AuthData, DEFAULT_ORG, OrgMetadata,
+    rest_utils::{AuthRequest, ErrorResp},
+};
+use axum::async_trait;
+use axum::extract::{FromRequestParts, Path};
+use axum::http::request::Parts;
 use axum_extra::TypedHeader;
-use axum_extra::headers::Authorization;
+use axum_extra::headers::Authorization as HeaderAuthorization;
 use axum_extra::headers::authorization::Bearer;
 use cornucopia_async::Database;
+use std::collections::HashMap;
+use std::convert::Infallible;
+
+#[derive(Debug, Clone)]
+#[allow(unused)]
+pub struct ApiAuthorization {
+    bearer: Option<TypedHeader<HeaderAuthorization<Bearer>>>,
+    impersonated_organization_id: Option<String>,
+}
+
+pub type BearerAuth = ApiAuthorization;
+
+#[async_trait]
+impl<S> FromRequestParts<S> for ApiAuthorization
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let bearer =
+            Option::<TypedHeader<HeaderAuthorization<Bearer>>>::from_request_parts(parts, state)
+                .await
+                .unwrap_or(None);
+        let impersonated_organization_id =
+            Path::<HashMap<String, String>>::from_request_parts(parts, state)
+                .await
+                .ok()
+                .and_then(|Path(params)| params.get("organization_id").cloned());
+
+        Ok(Self {
+            bearer,
+            impersonated_organization_id,
+        })
+    }
+}
+
+impl AuthRequest for ApiAuthorization {
+    fn impersonated_organization_id(&self) -> Option<&str> {
+        self.impersonated_organization_id.as_deref()
+    }
+}
 
 pub(crate) async fn authenticate(
     _client: &Database<'_>,
-    _bearer_auth: Option<TypedHeader<Authorization<Bearer>>>,
+    _bearer_auth: BearerAuth,
 ) -> Result<AuthData, ErrorResp> {
     Ok(AuthData {
         user_id: "user".to_string(),

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -28,8 +28,8 @@ const PREVIEW_TTL: Duration = Duration::from_secs(60);
 use crate::pipelines::{query_job_by_pub_id, query_pipeline_by_pub_id};
 use crate::rest::AppState;
 use crate::rest_utils::{
-    BearerAuth, ErrorResp, authenticate, bad_request, log_and_map, not_found, paginate_results,
-    validate_pagination_params,
+    BearerAuth, ErrorResp, PipelineJobCheckpointPath, PipelineJobPath, authenticate, bad_request,
+    log_and_map, not_found, paginate_results, validate_pagination_params,
 };
 use crate::types::public::LogLevel;
 use crate::{AuthData, queries::api_queries, to_micros, types::public};
@@ -276,7 +276,10 @@ pub(crate) fn get_action(state: &str, running_desired: &bool) -> (String, Option
 pub async fn get_job_errors(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path((pipeline_pub_id, job_pub_id)): Path<(String, String)>,
+    Path(PipelineJobPath {
+        id: pipeline_pub_id,
+        job_id: job_pub_id,
+    }): Path<PipelineJobPath>,
     query_params: Query<PaginationQueryParams>,
 ) -> Result<Json<JobLogMessageCollection>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
@@ -345,7 +348,10 @@ impl From<DbLogMessage> for JobLogMessage {
 pub async fn get_job_checkpoints(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path((pipeline_pub_id, job_pub_id)): Path<(String, String)>,
+    Path(PipelineJobPath {
+        id: pipeline_pub_id,
+        job_id: job_pub_id,
+    }): Path<PipelineJobPath>,
 ) -> Result<Json<CheckpointCollection>, ErrorResp> {
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;
@@ -414,7 +420,11 @@ pub async fn get_job_checkpoints(
 pub async fn get_checkpoint_details(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path((pipeline_pub_id, job_pub_id, epoch)): Path<(String, String, u32)>,
+    Path(PipelineJobCheckpointPath {
+        id: pipeline_pub_id,
+        job_id: job_pub_id,
+        epoch,
+    }): Path<PipelineJobCheckpointPath>,
 ) -> Result<Json<OperatorCheckpointGroupCollection>, ErrorResp> {
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;
@@ -496,7 +506,10 @@ pub async fn get_checkpoint_details(
 pub async fn get_job_output(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path((pipeline_pub_id, job_pub_id)): Path<(String, String)>,
+    Path(PipelineJobPath {
+        id: pipeline_pub_id,
+        job_id: job_pub_id,
+    }): Path<PipelineJobPath>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ErrorResp> {
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;

--- a/crates/arroyo-api/src/metrics.rs
+++ b/crates/arroyo-api/src/metrics.rs
@@ -5,7 +5,8 @@ use axum::extract::{Path, State};
 use crate::queries::api_queries;
 use crate::rest::AppState;
 use crate::rest_utils::{
-    BearerAuth, ErrorResp, authenticate, log_and_map, not_found, service_unavailable,
+    BearerAuth, ErrorResp, PipelineJobPath, authenticate, log_and_map, not_found,
+    service_unavailable,
 };
 use arroyo_rpc::api_types::OperatorMetricGroupCollection;
 use arroyo_rpc::api_types::metrics::OperatorMetricGroup;
@@ -32,7 +33,10 @@ use tracing::error;
 pub async fn get_operator_metric_groups(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path((pipeline_pub_id, job_pub_id)): Path<(String, String)>,
+    Path(PipelineJobPath {
+        id: pipeline_pub_id,
+        job_id: job_pub_id,
+    }): Path<PipelineJobPath>,
 ) -> Result<Json<OperatorMetricGroupCollection>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -46,8 +46,8 @@ use crate::queries::api_queries;
 use crate::queries::api_queries::{DbPipeline, DbPipelineJob, fetch_get_udfs};
 use crate::rest::AppState;
 use crate::rest_utils::{
-    ApiError, BearerAuth, ErrorResp, authenticate, bad_request, log_and_map, not_found,
-    paginate_results, required_field, validate_pagination_params,
+    ApiError, BearerAuth, ErrorResp, PipelinePath, authenticate, bad_request, log_and_map,
+    not_found, paginate_results, required_field, validate_pagination_params,
 };
 use crate::types::public::{PipelineType, RestartMode, StopMode};
 use crate::udfs::build_udf;
@@ -631,7 +631,7 @@ pub async fn create_pipeline(
 pub async fn put_pipeline(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(id): Path<String>,
+    Path(PipelinePath { id }): Path<PipelinePath>,
     WithRejection(Json(pipeline_post), _): WithRejection<Json<PipelinePost>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     create_pipeline_inner(state, bearer_auth, Some(id), pipeline_post).await
@@ -761,7 +761,9 @@ pub async fn create_preview_pipeline(
 pub async fn patch_pipeline(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(pipeline_pub_id): Path<String>,
+    Path(PipelinePath {
+        id: pipeline_pub_id,
+    }): Path<PipelinePath>,
     WithRejection(Json(pipeline_patch), _): WithRejection<Json<PipelinePatch>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
@@ -862,7 +864,7 @@ pub async fn patch_pipeline(
 pub async fn restart_pipeline(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(id): Path<String>,
+    Path(PipelinePath { id }): Path<PipelinePath>,
     WithRejection(Json(req), _): WithRejection<Json<PipelineRestart>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
@@ -977,7 +979,9 @@ pub async fn get_pipelines(
 pub async fn get_pipeline(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(pipeline_pub_id): Path<String>,
+    Path(PipelinePath {
+        id: pipeline_pub_id,
+    }): Path<PipelinePath>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
@@ -1005,7 +1009,9 @@ pub async fn get_pipeline(
 pub async fn delete_pipeline(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(pipeline_pub_id): Path<String>,
+    Path(PipelinePath {
+        id: pipeline_pub_id,
+    }): Path<PipelinePath>,
 ) -> Result<(), ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
@@ -1058,7 +1064,9 @@ pub async fn delete_pipeline(
 pub async fn get_pipeline_jobs(
     State(state): State<AppState>,
     bearer_auth: BearerAuth,
-    Path(pipeline_pub_id): Path<String>,
+    Path(PipelinePath {
+        id: pipeline_pub_id,
+    }): Path<PipelinePath>,
 ) -> Result<Json<JobCollection>, ErrorResp> {
     let db = state.database.client().await?;
     let auth_data = authenticate(&state.database, bearer_auth).await?;

--- a/crates/arroyo-api/src/rest.rs
+++ b/crates/arroyo-api/src/rest.rs
@@ -62,6 +62,37 @@ pub async fn api_fallback() -> impl IntoResponse {
     not_found("Route")
 }
 
+fn pipeline_jobs_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_pipeline_jobs))
+        .route("/:job_id/errors", get(get_job_errors))
+        .route("/:job_id/checkpoints", get(get_job_checkpoints))
+        .route(
+            "/:job_id/checkpoints/:epoch/operator_checkpoint_groups",
+            get(get_checkpoint_details),
+        )
+        .route("/:job_id/output", get(get_job_output))
+        .route(
+            "/:job_id/operator_metric_groups",
+            get(get_operator_metric_groups),
+        )
+}
+
+fn pipeline_and_job_routes() -> Router<AppState> {
+    Router::new()
+        .route("/pipelines", post(create_pipeline))
+        .route("/pipelines/preview", post(create_preview_pipeline))
+        .route("/pipelines", get(get_pipelines))
+        .route("/jobs", get(get_jobs))
+        .route("/pipelines/validate_query", post(validate_query))
+        .route("/pipelines/:id", put(put_pipeline))
+        .route("/pipelines/:id", patch(patch_pipeline))
+        .route("/pipelines/:id", get(get_pipeline))
+        .route("/pipelines/:id/restart", post(restart_pipeline))
+        .route("/pipelines/:id", delete(delete_pipeline))
+        .nest("/pipelines/:id/jobs", pipeline_jobs_routes())
+}
+
 async fn not_found_static() -> Response {
     (StatusCode::NOT_FOUND, "404").into_response()
 }
@@ -132,20 +163,6 @@ pub fn create_rest_app(database: DatabaseSource) -> Router {
         .allow_headers(cors::Any)
         .allow_origin(cors::Any);
 
-    let jobs_routes = Router::new()
-        .route("/", get(get_pipeline_jobs))
-        .route("/:job_id/errors", get(get_job_errors))
-        .route("/:job_id/checkpoints", get(get_job_checkpoints))
-        .route(
-            "/:job_id/checkpoints/:checkpoint_id/operator_checkpoint_groups",
-            get(get_checkpoint_details),
-        )
-        .route("/:job_id/output", get(get_job_output))
-        .route(
-            "/:job_id/operator_metric_groups",
-            get(get_operator_metric_groups),
-        );
-
     let api_routes = Router::new()
         .route("/ping", get(ping))
         .route("/connectors", get(get_connectors))
@@ -169,17 +186,7 @@ pub fn create_rest_app(database: DatabaseSource) -> Router {
         .route("/udfs", get(get_udfs))
         .route("/udfs/validate", post(validate_udf))
         .route("/udfs/:id", delete(delete_udf))
-        .route("/pipelines", post(create_pipeline))
-        .route("/pipelines/preview", post(create_preview_pipeline))
-        .route("/pipelines", get(get_pipelines))
-        .route("/jobs", get(get_jobs))
-        .route("/pipelines/validate_query", post(validate_query))
-        .route("/pipelines/:id", put(put_pipeline))
-        .route("/pipelines/:id", patch(patch_pipeline))
-        .route("/pipelines/:id", get(get_pipeline))
-        .route("/pipelines/:id/restart", post(restart_pipeline))
-        .route("/pipelines/:id", delete(delete_pipeline))
-        .nest("/pipelines/:id/jobs", jobs_routes)
+        .merge(pipeline_and_job_routes())
         .fallback(api_fallback);
 
     Router::new()
@@ -188,6 +195,10 @@ pub fn create_rest_app(database: DatabaseSource) -> Router {
                 .url("/api/v1/api-docs/openapi.json", ApiDoc::openapi()),
         )
         .nest("/api/v1", api_routes)
+        .nest(
+            "/api/v1/admin/organizations/:organization_id",
+            pipeline_and_job_routes(),
+        )
         .fallback(static_handler)
         .with_state(AppState { database })
         .layer(cors)

--- a/crates/arroyo-api/src/rest_utils.rs
+++ b/crates/arroyo-api/src/rest_utils.rs
@@ -4,16 +4,34 @@ use axum::Json;
 use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum_extra::TypedHeader;
-use axum_extra::headers::Authorization;
-use axum_extra::headers::authorization::Bearer;
-use tracing::{error, warn};
-
 use cornucopia_async::{DatabaseSource, DbError};
 use serde::{Deserialize, Serialize};
+use tracing::{error, warn};
 use utoipa::ToSchema;
 
-pub type BearerAuth = Option<TypedHeader<Authorization<Bearer>>>;
+pub type BearerAuth = cloud::BearerAuth;
+
+pub(crate) trait AuthRequest {
+    fn impersonated_organization_id(&self) -> Option<&str>;
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PipelinePath {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PipelineJobPath {
+    pub id: String,
+    pub job_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PipelineJobCheckpointPath {
+    pub id: String,
+    pub job_id: String,
+    pub epoch: u32,
+}
 
 const DEFAULT_ITEMS_PER_PAGE: u32 = 10;
 
@@ -109,7 +127,38 @@ pub(crate) async fn authenticate(
     db: &DatabaseSource,
     bearer_auth: BearerAuth,
 ) -> Result<AuthData, ErrorResp> {
-    cloud::authenticate(&db.client().await?, bearer_auth).await
+    let impersonated_organization_id = bearer_auth
+        .impersonated_organization_id()
+        .map(str::to_string);
+    let mut auth_data = cloud::authenticate(&db.client().await?, bearer_auth).await?;
+    apply_impersonated_organization(&mut auth_data, impersonated_organization_id)?;
+    Ok(auth_data)
+}
+
+fn apply_impersonated_organization(
+    auth_data: &mut AuthData,
+    impersonated_organization_id: Option<String>,
+) -> Result<(), ErrorResp> {
+    let Some(organization_id) = impersonated_organization_id else {
+        return Ok(());
+    };
+
+    if organization_id.is_empty() {
+        return Err(bad_request(
+            "organization_id path parameter must not be empty",
+        ));
+    }
+
+    if auth_data.role != "admin" {
+        warn!(role = %auth_data.role, "rejecting non-admin caller on org-scoped admin route");
+        return Err(ErrorResp {
+            status_code: StatusCode::FORBIDDEN,
+            message: "Admin role required".to_string(),
+        });
+    }
+
+    auth_data.organization_id = organization_id;
+    Ok(())
 }
 
 pub(crate) fn bad_request(message: impl Into<String>) -> ErrorResp {
@@ -173,4 +222,57 @@ pub fn paginate_results<T>(results: Vec<T>, limit: u32) -> (Vec<T>, bool) {
     }
 
     (results, has_more)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrgMetadata;
+
+    fn auth(role: &str, organization_id: &str) -> AuthData {
+        AuthData {
+            user_id: "user".to_string(),
+            organization_id: organization_id.to_string(),
+            role: role.to_string(),
+            org_metadata: OrgMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn admin_can_impersonate_path_organization() {
+        let mut auth_data = auth("admin", "");
+
+        apply_impersonated_organization(&mut auth_data, Some("acct_42".to_string())).unwrap();
+
+        assert_eq!(auth_data.organization_id, "acct_42");
+    }
+
+    #[test]
+    fn tenant_cannot_impersonate_path_organization() {
+        let mut auth_data = auth("tenant", "acct_1");
+
+        let err = apply_impersonated_organization(&mut auth_data, Some("acct_2".to_string()))
+            .unwrap_err();
+
+        assert_eq!(err.status_code, StatusCode::FORBIDDEN);
+        assert_eq!(auth_data.organization_id, "acct_1");
+    }
+
+    #[test]
+    fn impersonated_organization_must_not_be_empty() {
+        let mut auth_data = auth("admin", "");
+
+        let err = apply_impersonated_organization(&mut auth_data, Some(String::new())).unwrap_err();
+
+        assert_eq!(err.status_code, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn missing_impersonation_keeps_authenticated_organization() {
+        let mut auth_data = auth("tenant", "acct_1");
+
+        apply_impersonated_organization(&mut auth_data, None).unwrap();
+
+        assert_eq!(auth_data.organization_id, "acct_1");
+    }
 }


### PR DESCRIPTION
Adds a new set of REST paths for pipeline/jobs endpoints that allow org-scoped access.

Currently, allow pipeline/job scoped endpoints use org information embedded in the auth token to determine which org the user belongs to (and therefore, which pipelines should be exposed):

`/api/v1/pipelines/{PIPELINE_ID}`

With this PR, this can also be accessed by tokens with admin-scope by

`/api/v1/admin/organizations/{ORG_ID}/pipelines/{PIPELINE_ID}`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->