### PR TITLE
Update Kafka URL for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Kafka
         run: |
-          wget --progress=dot --show-progress  https://dlcdn.apache.org/kafka/3.9.2/kafka_2.13-3.9.2.tgz
+          wget --progress=dot --show-progress https://archive.apache.org/dist/kafka/3.9.2/kafka_2.13-3.9.2.tgz
           tar xvfz kafka*.tgz
           mkdir /tmp/kraft-combined-logs
           kafka_*/bin/kafka-storage.sh format -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/kraft/server.properties


### PR DESCRIPTION
Version 3.9.2 is no longer available at the previous URL: https://downloads.apache.org/kafka/

Example of failed CI: https://github.com/ArroyoSystems/arroyo/actions/runs/29264240277/job/86865187255?pr=1105
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->