### PR TITLE
Support checkpoint GC in leader for mode stateful operators

### DIFF
--- a/crates/arroyo-state-protocol/src/gc.rs
+++ b/crates/arroyo-state-protocol/src/gc.rs
@@ -2,18 +2,29 @@ use crate::ProtocolPaths;
 use crate::store::{ProtocolStore, StoreError, read_protobuf};
 use crate::types::{CheckpointRef, Epoch, Generation, ProtocolError};
 use arroyo_rpc::grpc::rpc::{
-    CheckpointManifest, GlobalKeyedTableTaskCheckpointMetadata, TableCheckpointMetadata, TableEnum,
+    CheckpointManifest, ExpiringKeyedTimeTableCheckpointMetadata,
+    GlobalKeyedTableTaskCheckpointMetadata, TableCheckpointMetadata, TableEnum,
 };
-use futures::future::join_all;
+use futures::{TryStreamExt, stream};
 use prost::Message;
 use std::collections::HashSet;
 use std::path::Path;
-use tracing::{debug, warn};
+use tracing::debug;
+
+const MAX_CONCURRENT_DELETES: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct CheckpointOwner {
     pub generation: Generation,
     pub epoch: Epoch,
+}
+
+/// A fully classified GC operation. Classification must complete before any deletion begins.
+struct CleanupPlan {
+    /// Checkpoints below the retention boundary, ordered newest to oldest by traversal order.
+    old_checkpoints: Vec<CheckpointOwner>,
+    /// Deduplicated files referenced only by old checkpoints.
+    data_files: Vec<CheckpointRef>,
 }
 
 pub async fn cleanup_leader_checkpoints<S>(
@@ -25,10 +36,42 @@ pub async fn cleanup_leader_checkpoints<S>(
 where
     S: ProtocolStore + ?Sized,
 {
-    let history =
-        collect_history_and_clean_checkpoint_files(store, paths, head, new_min_epoch).await?;
+    let cleanup = classify_checkpoint_history(store, head, new_min_epoch).await?;
 
-    for c in history.iter().rev() {
+    let data_directories: HashSet<_> = cleanup
+        .data_files
+        .iter()
+        .filter_map(|f| Path::new(f.as_str()).parent().and_then(|p| p.to_str()))
+        .map(|f| f.to_string())
+        .collect();
+    let checkpoint_directories: HashSet<_> = data_directories
+        .iter()
+        .filter_map(|directory| Path::new(directory).parent().and_then(|p| p.to_str()))
+        .map(|directory| directory.to_string())
+        .collect();
+
+    let mut objects = cleanup.data_files;
+    for checkpoint in &cleanup.old_checkpoints {
+        objects.push(paths.committed_marker(checkpoint.generation, checkpoint.epoch));
+        objects.push(paths.epoch_record(checkpoint.epoch));
+    }
+
+    delete_objects(store, objects).await?;
+
+    for directory in data_directories {
+        store.delete_directory(&directory).await;
+    }
+
+    // A carried-forward file may live under a checkpoint whose manifest was deleted by an earlier
+    // GC pass. Retry its checkpoint directory now that the file and its operator directory are
+    // gone. Local storage removes only empty directories; object stores treat this as a no-op.
+    for directory in checkpoint_directories {
+        store.delete_directory(&directory).await;
+    }
+
+    // Traversal records checkpoints newest-to-oldest. Delete manifests in reverse so a failed
+    // cleanup cannot create a gap that makes still-reachable older checkpoints undiscoverable.
+    for c in cleanup.old_checkpoints.iter().rev() {
         debug!(
             generation = c.generation.0,
             epoch = c.epoch.0,
@@ -45,25 +88,35 @@ where
     Ok(())
 }
 
-/// Traverses backwards through the checkpoint history, doing two things:
-/// 1. Finding and cleaning data files for GC'able checkpoints
-/// 2. Collecting a record of ownership for each checkpoint
+async fn delete_objects<S>(store: &S, objects: Vec<CheckpointRef>) -> Result<(), StoreError>
+where
+    S: ProtocolStore + ?Sized,
+{
+    stream::iter(objects.into_iter().map(Ok::<_, StoreError>))
+        .try_for_each_concurrent(MAX_CONCURRENT_DELETES, |object| async move {
+            store.delete_object(&object).await
+        })
+        .await
+}
+
+/// Traverses the reachable checkpoint history and classifies all files before deleting anything.
 ///
-/// We do it in this order because we must delete metadata files by going forward, to prevent
-/// gaps from forming in case of failure which would orphan older files. However, we do not
-/// want to re-read or retain the metadata in order to do file deletion as that could exhaust
-/// memory, so we opportunistically delete data files.
-async fn collect_history_and_clean_checkpoint_files<S>(
+/// Data files referenced by retained checkpoints are protected even if an older checkpoint also
+/// references them. This intentionally buffers deduplicated candidate and protected file refs for
+/// the reachable chain, but not full manifests. That memory cost is required to safely handle
+/// cumulative table metadata such as expiring keyed-time tables.
+async fn classify_checkpoint_history<S>(
     store: &S,
-    paths: &ProtocolPaths,
     current: CheckpointRef,
     new_min_epoch: Epoch,
-) -> Result<Vec<CheckpointOwner>, StoreError>
+) -> Result<CleanupPlan, StoreError>
 where
     S: ProtocolStore + ?Sized,
 {
     let mut head = true;
-    let mut history = vec![];
+    let mut old_checkpoints = vec![];
+    let mut candidate_files = HashSet::new();
+    let mut protected_files = HashSet::new();
     let mut seen = HashSet::new();
     let mut next = Some(current);
 
@@ -80,12 +133,20 @@ where
             break;
         };
 
-        head = false;
-
         let owner = CheckpointOwner {
             generation: Generation(manifest.generation),
             epoch: Epoch(manifest.epoch),
         };
+
+        if head && owner.epoch < new_min_epoch {
+            return Err(ProtocolError::CheckpointGcMinEpochBeyondHead {
+                head_epoch: owner.epoch,
+                new_min_epoch,
+            }
+            .into());
+        }
+
+        head = false;
 
         if !seen.insert(owner) {
             return Err(ProtocolError::CheckpointCycle {
@@ -95,15 +156,12 @@ where
             .into());
         }
 
+        let files = checkpoint_data_files(&checkpoint_ref, &manifest)?;
         if manifest.epoch < *new_min_epoch {
-            history.push(owner);
-            if let Err(e) = clean_checkpoint(store, paths, &checkpoint_ref, &manifest).await {
-                warn!(
-                    checkpoint = checkpoint_ref.as_str(),
-                    error =? e,
-                    "failed to clean checkpoint"
-                );
-            }
+            old_checkpoints.push(owner);
+            candidate_files.extend(files);
+        } else {
+            protected_files.extend(files);
         }
 
         next = manifest
@@ -112,20 +170,19 @@ where
             .transpose()?;
     }
 
-    Ok(history)
+    candidate_files.retain(|file| !protected_files.contains(file));
+
+    Ok(CleanupPlan {
+        old_checkpoints,
+        data_files: candidate_files.into_iter().collect(),
+    })
 }
 
-/// cleans a checkpoint but leaves the metadata file in place
-async fn clean_checkpoint<S>(
-    store: &S,
-    paths: &ProtocolPaths,
+fn checkpoint_data_files(
     manifest_path: &CheckpointRef,
     checkpoint: &CheckpointManifest,
-) -> Result<(), StoreError>
-where
-    S: ProtocolStore + ?Sized,
-{
-    let mut to_delete = vec![];
+) -> Result<Vec<CheckpointRef>, StoreError> {
+    let mut files = vec![];
     for operator in &checkpoint.operators {
         for (table_name, metadata) in &operator.table_checkpoint_metadata {
             let op_metadata =
@@ -142,33 +199,12 @@ where
                 table_name,
                 manifest_path,
                 metadata,
-                &mut to_delete,
+                &mut files,
             )?;
         }
     }
 
-    let directories: HashSet<_> = to_delete
-        .iter()
-        .filter_map(|f| Path::new(f.as_str()).parent().and_then(|p| p.to_str()))
-        .map(|f| f.to_string())
-        .collect();
-
-    to_delete
-        .push(paths.committed_marker(Generation(checkpoint.generation), Epoch(checkpoint.epoch)));
-
-    to_delete.push(paths.epoch_record(Epoch(checkpoint.epoch)));
-
-    for r in join_all(to_delete.iter().map(|f| store.delete_object(f))).await {
-        r?;
-    }
-
-    for d in directories {
-        // this will loop over duplicate directory when there are multiples tables per operator,
-        // but it's a no-op if the directory is already deleted
-        store.delete_directory(&d).await;
-    }
-
-    Ok(())
+    Ok(files)
 }
 
 fn table_checkpoint_data_files(
@@ -200,14 +236,16 @@ fn table_checkpoint_data_files(
             }
         }
         TableEnum::ExpiringKeyedTimeTable => {
-            return Err(StoreError::InvalidProtobuf {
-                path: metadata_path.clone(),
-                msg: format!(
-                    "table metadata for operator '{}' table '{}' has table type \
-                ExpiringKeyedTimeTable, which is not yet supported in leader mode",
-                    operator_id, table_name
-                ),
-            });
+            let metadata =
+                ExpiringKeyedTimeTableCheckpointMetadata::decode(metadata.data.as_slice())
+                    .map_err(|e| StoreError::DecodeProtobuf {
+                        path: metadata_path.clone(),
+                        source: e,
+                    })?;
+
+            for file in metadata.files {
+                files.push(CheckpointRef::new(file.file)?);
+            }
         }
     }
 

--- a/crates/arroyo-state-protocol/src/lib.rs
+++ b/crates/arroyo-state-protocol/src/lib.rs
@@ -115,8 +115,9 @@ mod tests {
         resolve_generation_manifest,
     };
     use arroyo_rpc::grpc::rpc::{
-        CheckpointManifest, GlobalKeyedTableTaskCheckpointMetadata, OperatorCheckpointMetadata,
-        OperatorMetadata, TableCheckpointMetadata, TableEnum,
+        CheckpointManifest, ExpiringKeyedTimeTableCheckpointMetadata,
+        GlobalKeyedTableTaskCheckpointMetadata, OperatorCheckpointMetadata, OperatorMetadata,
+        ParquetTimeFile, TableCheckpointMetadata, TableEnum,
     };
     use arroyo_types::{JobId, PipelineId, from_micros};
     use prost::Message;
@@ -286,6 +287,42 @@ mod tests {
         }
     }
 
+    fn expiring_operator(
+        operator_id: &str,
+        files: Vec<CheckpointRef>,
+    ) -> OperatorCheckpointMetadata {
+        OperatorCheckpointMetadata {
+            operator_metadata: Some(OperatorMetadata {
+                job_id: "J".to_string(),
+                operator_id: operator_id.to_string(),
+                epoch: 0,
+                min_watermark: None,
+                max_watermark: None,
+                parallelism: 1,
+            }),
+            start_time: 0,
+            finish_time: 0,
+            table_checkpoint_metadata: [(
+                "expiring-table".to_string(),
+                TableCheckpointMetadata {
+                    table_type: TableEnum::ExpiringKeyedTimeTable.into(),
+                    data: ExpiringKeyedTimeTableCheckpointMetadata {
+                        files: files
+                            .into_iter()
+                            .map(|file| ParquetTimeFile {
+                                file: file.to_string(),
+                                ..Default::default()
+                            })
+                            .collect(),
+                    }
+                    .encode_to_vec(),
+                },
+            )]
+            .into(),
+            table_configs: Default::default(),
+        }
+    }
+
     async fn write_gc_checkpoint(
         store: &MemoryProtocolStore,
         paths: &ProtocolPaths,
@@ -383,6 +420,246 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cleanup_preserves_expiring_files_referenced_by_retained_checkpoint() {
+        let store = MemoryProtocolStore::default();
+        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
+        let shared_file = checkpoint_ref(&format!(
+            "{}/operator-expiring-op/table-expiring-shared",
+            paths.checkpoint_dir(Generation(1), Epoch(1))
+        ));
+        let expired_file = checkpoint_ref(&format!(
+            "{}/operator-expiring-op/table-expiring-expired",
+            paths.checkpoint_dir(Generation(1), Epoch(1))
+        ));
+        let checkpoint2_ref = paths.checkpoint_manifest(Generation(1), Epoch(2));
+
+        store
+            .put_bytes(&shared_file, b"shared".to_vec())
+            .await
+            .unwrap();
+        store
+            .put_bytes(&expired_file, b"expired".to_vec())
+            .await
+            .unwrap();
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            1,
+            None,
+            vec![expiring_operator(
+                "expiring-op",
+                vec![shared_file.clone(), expired_file.clone()],
+            )],
+        )
+        .await;
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            2,
+            Some(1),
+            vec![expiring_operator("expiring-op", vec![shared_file.clone()])],
+        )
+        .await;
+
+        cleanup_leader_checkpoints(&store, &paths, checkpoint2_ref.clone(), Epoch(2))
+            .await
+            .unwrap();
+
+        assert!(exists(&store, &shared_file).await);
+        assert!(!exists(&store, &expired_file).await);
+
+        let deleted_count = store.deleted_objects().len();
+        cleanup_leader_checkpoints(&store, &paths, checkpoint2_ref, Epoch(2))
+            .await
+            .unwrap();
+        assert_eq!(deleted_count, store.deleted_objects().len());
+        assert!(exists(&store, &shared_file).await);
+    }
+
+    #[tokio::test]
+    async fn cleanup_retries_checkpoint_directory_when_carried_file_expires() {
+        let store = MemoryProtocolStore::default();
+        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
+        let checkpoint1_dir = paths.checkpoint_dir(Generation(1), Epoch(1));
+        let carried_file = checkpoint_ref(&format!(
+            "{checkpoint1_dir}/operator-expiring-op/table-expiring-carried"
+        ));
+
+        store
+            .put_bytes(&carried_file, b"carried".to_vec())
+            .await
+            .unwrap();
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            1,
+            None,
+            vec![expiring_operator("expiring-op", vec![carried_file.clone()])],
+        )
+        .await;
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            2,
+            Some(1),
+            vec![expiring_operator("expiring-op", vec![carried_file.clone()])],
+        )
+        .await;
+
+        cleanup_leader_checkpoints(
+            &store,
+            &paths,
+            paths.checkpoint_manifest(Generation(1), Epoch(2)),
+            Epoch(2),
+        )
+        .await
+        .unwrap();
+
+        assert!(exists(&store, &carried_file).await);
+        assert_eq!(
+            1,
+            store
+                .deleted_directories()
+                .iter()
+                .filter(|directory| *directory == checkpoint1_dir.as_str())
+                .count()
+        );
+
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            3,
+            Some(2),
+            vec![expiring_operator("expiring-op", vec![])],
+        )
+        .await;
+        cleanup_leader_checkpoints(
+            &store,
+            &paths,
+            paths.checkpoint_manifest(Generation(1), Epoch(3)),
+            Epoch(3),
+        )
+        .await
+        .unwrap();
+
+        assert!(!exists(&store, &carried_file).await);
+        assert_eq!(
+            2,
+            store
+                .deleted_directories()
+                .iter()
+                .filter(|directory| *directory == checkpoint1_dir.as_str())
+                .count(),
+            "the old checkpoint directory should be retried when its carried file expires"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_classifies_mixed_global_and_expiring_metadata() {
+        let store = MemoryProtocolStore::default();
+        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
+        let global_old = checkpoint_ref(&format!(
+            "{}/operator-op/table-global-old",
+            paths.checkpoint_dir(Generation(1), Epoch(1))
+        ));
+        let global_retained = data_ref(&paths, 2);
+        let expiring_old = checkpoint_ref(&format!(
+            "{}/operator-expiring-op/table-expiring-old",
+            paths.checkpoint_dir(Generation(1), Epoch(1))
+        ));
+        let expiring_shared = checkpoint_ref(&format!(
+            "{}/operator-expiring-op/table-expiring-shared",
+            paths.checkpoint_dir(Generation(1), Epoch(1))
+        ));
+
+        for file in [
+            &global_old,
+            &global_retained,
+            &expiring_old,
+            &expiring_shared,
+        ] {
+            store.put_bytes(file, b"data".to_vec()).await.unwrap();
+        }
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            1,
+            None,
+            vec![
+                global_operator(vec![global_old.clone()]),
+                expiring_operator(
+                    "expiring-op",
+                    vec![expiring_old.clone(), expiring_shared.clone()],
+                ),
+            ],
+        )
+        .await;
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            2,
+            Some(1),
+            vec![
+                global_operator(vec![global_retained.clone()]),
+                expiring_operator("expiring-op", vec![expiring_shared.clone()]),
+            ],
+        )
+        .await;
+
+        cleanup_leader_checkpoints(
+            &store,
+            &paths,
+            paths.checkpoint_manifest(Generation(1), Epoch(2)),
+            Epoch(2),
+        )
+        .await
+        .unwrap();
+
+        assert!(!exists(&store, &global_old).await);
+        assert!(!exists(&store, &expiring_old).await);
+        assert!(exists(&store, &global_retained).await);
+        assert!(exists(&store, &expiring_shared).await);
+    }
+
+    #[tokio::test]
+    async fn cleanup_malformed_expiring_metadata_is_fail_closed() {
+        let store = MemoryProtocolStore::default();
+        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
+        let old_file = data_ref(&paths, 2);
+        let mut malformed_operator = expiring_operator("expiring-op", vec![]);
+        malformed_operator
+            .table_checkpoint_metadata
+            .get_mut("expiring-table")
+            .unwrap()
+            .data = vec![0x0a];
+
+        store.put_bytes(&old_file, b"old".to_vec()).await.unwrap();
+        write_gc_checkpoint(&store, &paths, 1, None, vec![malformed_operator]).await;
+        write_gc_checkpoint(
+            &store,
+            &paths,
+            2,
+            Some(1),
+            vec![global_operator(vec![old_file.clone()])],
+        )
+        .await;
+        write_gc_checkpoint(&store, &paths, 3, Some(2), vec![global_operator(vec![])]).await;
+
+        let err = cleanup_leader_checkpoints(
+            &store,
+            &paths,
+            paths.checkpoint_manifest(Generation(1), Epoch(3)),
+            Epoch(3),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, StoreError::DecodeProtobuf { .. }));
+        assert!(store.deleted_objects().is_empty());
+        assert!(exists(&store, &old_file).await);
+    }
+
+    #[tokio::test]
     async fn cleanup_deletes_checkpoint_manifests_oldest_first() {
         let store = MemoryProtocolStore::default();
         let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
@@ -433,7 +710,7 @@ mod tests {
             &store,
             &paths,
             paths.checkpoint_manifest(Generation(1), Epoch(2)),
-            Epoch(0),
+            Epoch(2),
         )
         .await
         .unwrap_err();
@@ -443,6 +720,27 @@ mod tests {
             StoreError::Protocol(ProtocolError::CheckpointCycle {
                 generation: Generation(1),
                 epoch: Epoch(2)
+            })
+        ));
+        assert!(store.deleted_objects().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_rejects_min_epoch_newer_than_head() {
+        let store = MemoryProtocolStore::default();
+        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
+        let head = paths.checkpoint_manifest(Generation(1), Epoch(2));
+        write_gc_checkpoint(&store, &paths, 2, None, vec![global_operator(vec![])]).await;
+
+        let err = cleanup_leader_checkpoints(&store, &paths, head, Epoch(3))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            StoreError::Protocol(ProtocolError::CheckpointGcMinEpochBeyondHead {
+                head_epoch: Epoch(2),
+                new_min_epoch: Epoch(3),
             })
         ));
         assert!(store.deleted_objects().is_empty());

--- a/crates/arroyo-state-protocol/src/store.rs
+++ b/crates/arroyo-state-protocol/src/store.rs
@@ -266,11 +266,16 @@ pub(crate) mod tests {
     pub(crate) struct MemoryProtocolStore {
         objects: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
         deleted_objects: Arc<Mutex<Vec<String>>>,
+        deleted_directories: Arc<Mutex<Vec<String>>>,
     }
 
     impl MemoryProtocolStore {
         pub(crate) fn deleted_objects(&self) -> Vec<String> {
             self.deleted_objects.lock().unwrap().clone()
+        }
+
+        pub(crate) fn deleted_directories(&self) -> Vec<String> {
+            self.deleted_directories.lock().unwrap().clone()
         }
     }
 
@@ -311,6 +316,11 @@ pub(crate) mod tests {
             Ok(())
         }
 
-        async fn delete_directory(&self, _path: &str) {}
+        async fn delete_directory(&self, path: &str) {
+            self.deleted_directories
+                .lock()
+                .unwrap()
+                .push(path.to_string());
+        }
     }
 }

--- a/crates/arroyo-state-protocol/src/types.rs
+++ b/crates/arroyo-state-protocol/src/types.rs
@@ -42,6 +42,11 @@ pub enum ProtocolError {
         generation: Generation,
         epoch: Epoch,
     },
+    #[error("checkpoint GC minimum epoch {new_min_epoch} is newer than head epoch {head_epoch}")]
+    CheckpointGcMinEpochBeyondHead {
+        head_epoch: Epoch,
+        new_min_epoch: Epoch,
+    },
 }
 
 /// Monotonic identifier for a worker cluster generation of a job.


### PR DESCRIPTION
This PR follows on the initial support for checkpoint GC in leader mode for stateless operators (#1076) by adding support for stateful operators as well. Stateful operators are much more complex to GC, because their state may be stored over many checkpoints. GC thus requires reachability analysis: we must determine that a state file is no longer reachable from any active checkpoint root before it may be deleted.

We do lose some of the nicer memory bounding properties of the previous implementation, which took a streaming approach to cleaning checkpoints, but that is largely unavoidable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->