### PR TITLE
Normalize all job_id logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -85,11 +85,11 @@ jobs:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Kafka
         run: |
-          wget --progress=dot --show-progress https://archive.apache.org/dist/kafka/3.9.2/kafka_2.13-3.9.2.tgz
-          tar xvfz kafka*.tgz
+          wget --progress=dot --show-progress -O kafka.tgz 'https://www.apache.org/dyn/closer.lua/kafka/4.3.1/kafka_2.13-4.3.1.tgz?action=download'
+          tar xvfz kafka.tgz
           mkdir /tmp/kraft-combined-logs
-          kafka_*/bin/kafka-storage.sh format -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/kraft/server.properties
-          kafka_*/bin/kafka-server-start.sh -daemon kafka_*/config/kraft/server.properties
+          kafka_*/bin/kafka-storage.sh format --standalone -t 9v5PspiySuWU2l5NjTgRuA -c kafka_*/config/server.properties
+          kafka_*/bin/kafka-server-start.sh -daemon kafka_*/config/server.properties
       - name: Install mosquitto
         run: |
           sudo apt-get install -y mosquitto

--- a/crates/arroyo-controller/src/job_controller/leader_manager.rs
+++ b/crates/arroyo-controller/src/job_controller/leader_manager.rs
@@ -46,7 +46,7 @@ impl LeaderManager {
             Duration::from_millis(100),
             Duration::from_secs(2),
             |e| warn!(
-                job_id = *job_id.0,
+                job_id = %job_id,
                 pipeline_id = *pipeline_id.0,
                 message = "failed to connect to worker leader",
                 error = ?e
@@ -74,7 +74,7 @@ impl LeaderManager {
             Duration::from_millis(100),
             Duration::from_secs(2),
             |e| warn!(
-                job_id = *self.job_id.0,
+                job_id = %self.job_id,
                 pipeline_id = *self.pipeline_id.0,
                 message = "failed to poll for job status",
                 error = ?e
@@ -110,7 +110,7 @@ impl LeaderManager {
     pub async fn stop_leader(&mut self, stop_mode: JobStopMode) -> anyhow::Result<()> {
         info!(
             message = "sending stop request to leader",
-            job_id = *self.job_id.0,
+            job_id = %self.job_id,
             pipeline_id = *self.pipeline_id.0,
             stop_mode = ?stop_mode,
         );
@@ -208,7 +208,7 @@ where
                     }
                     Some(msg) => {
                         warn!(
-                            job_id = *ctx.config.id,
+                            job_id = %ctx.config.id,
                             pipeline_id = *ctx.pipeline_info.pipeline_id,
                             ?msg,
                             "unexpected job message in leader leader mode"

--- a/crates/arroyo-controller/src/job_controller/mod.rs
+++ b/crates/arroyo-controller/src/job_controller/mod.rs
@@ -183,7 +183,7 @@ impl JobController {
                     info!(
                         message = "setting new min epoch",
                         min_epoch = *min_epoch,
-                        job_id = *self.config.id,
+                        job_id = %self.config.id,
                         pipeline_id = *self.model.pipeline_id
                     );
                     self.model.min_epoch = min_epoch;
@@ -191,7 +191,7 @@ impl JobController {
                 Ok(Err(e)) => {
                     error!(
                         message = "cleanup failed",
-                        job_id = *self.config.id,
+                        job_id = %self.config.id,
                         pipeline_id = *self.model.pipeline_id,
                         error = format!("{:?}", e)
                     );
@@ -202,7 +202,7 @@ impl JobController {
                 Err(e) => {
                     error!(
                         message = "cleanup panicked",
-                        job_id = *self.config.id,
+                        job_id = %self.config.id,
                         pipeline_id = *self.model.pipeline_id,
                         error = format!("{:?}", e)
                     );
@@ -314,7 +314,7 @@ impl JobController {
                 JobMessage::ConfigUpdate(c) if c.stop_mode == SqlStopMode::immediate => {
                     info!(
                         message = "stopping job immediately",
-                        job_id = *self.config.id,
+                        job_id = %self.config.id,
                         pipeline_id = *self.model.pipeline_id
                     );
                     self.stop_job(StopMode::Immediate).await?;
@@ -339,7 +339,7 @@ impl JobController {
 
         info!(
             message = "Starting cleaning",
-            job_id = *job_id,
+            job_id = %job_id,
             pipeline_id = *pipeline_id,
             min_epoch = *min_epoch,
             new_min = *new_min
@@ -376,7 +376,7 @@ impl JobController {
 
             info!(
                 message = "Finished cleaning",
-                job_id = *job_id,
+                job_id = %job_id,
                 pipeline_id = *pipeline_id,
                 min_epoch = *min_epoch,
                 new_min = *new_min,

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -240,7 +240,7 @@ impl ControllerGrpc for ControllerServer {
             .worker_context
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
         info!(
-            job_id = worker.job_id,
+            job_id = %worker.job_id,
             pipeline_id = worker.pipeline_id,
             "Worker registered: {:?} -- {:?}",
             worker,
@@ -272,7 +272,7 @@ impl ControllerGrpc for ControllerServer {
             .worker_context
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
         info!(
-            job_id = ctx.job_id,
+            job_id = %ctx.job_id,
             pipeline_id = ctx.pipeline_id,
             worker_id = ctx.worker_id,
             task_id = req.task_id,
@@ -403,7 +403,7 @@ impl ControllerGrpc for ControllerServer {
             .worker_context
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
         info!(
-            job_id = ctx.job_id,
+            job_id = %ctx.job_id,
             pipeline_id = ctx.pipeline_id,
             "Worker {} initialization completed: success={}, error={:?}",
             ctx.worker_id,
@@ -438,7 +438,7 @@ impl JobControllerGrpc for ControllerServer {
             .as_ref()
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
         debug!(
-            job_id = ctx.job_id,
+            job_id = %ctx.job_id,
             pipeline_id = ctx.pipeline_id,
             "received task checkpoint event {:?}",
             req
@@ -465,7 +465,7 @@ impl JobControllerGrpc for ControllerServer {
             .as_ref()
             .ok_or_else(|| Status::invalid_argument("missing worker_context"))?;
         debug!(
-            job_id = ctx.job_id,
+            job_id = %ctx.job_id,
             pipeline_id = ctx.pipeline_id,
             "received task checkpoint completed {:?}",
             req
@@ -568,7 +568,7 @@ impl JobControllerGrpc for ControllerServer {
             .ok_or_else(|| Status::invalid_argument("NonfatalErrorReq missing error"))?;
 
         info!(
-            job_id = ctx.job_id,
+            job_id = %ctx.job_id,
             pipeline_id = ctx.pipeline_id,
             operator_id = err.operator_id,
             message = "operator error",
@@ -662,7 +662,7 @@ impl ControllerServer {
                 Ok(())
             }
         } else {
-            warn!(message = "Received message for unknown job id", job_id);
+            warn!(message = "Received message for unknown job id", %job_id);
             Err(Status::failed_precondition(format!(
                 "No job with id {job_id}"
             )))
@@ -722,7 +722,7 @@ impl ControllerServer {
 
                     let state_context: StateContext =
                         serde_json::from_value(p.state_context.clone()).unwrap_or_else(|e| {
-                            warn!(job_id = *id, original =? p.state_context, error =? e,
+                            warn!(job_id = %id, original =? p.state_context, error =? e,
                                 "failed to deserialize state context");
                             StateContext {
                                 version: 1,

--- a/crates/arroyo-controller/src/schedulers/embedded.rs
+++ b/crates/arroyo-controller/src/schedulers/embedded.rs
@@ -69,7 +69,7 @@ impl Scheduler for EmbeddedScheduler {
             match tokio::task::spawn(async move {
                 if let Err(e) = server.start_async().await {
                     error!(
-                        job_id = *worker_job_id,
+                        job_id = %worker_job_id,
                         pipeline_id = *worker_pipeline_id,
                         "Failed to start worker {:?}: {:?}",
                         worker_id,
@@ -81,7 +81,7 @@ impl Scheduler for EmbeddedScheduler {
             {
                 Ok(_) => {
                     info!(
-                        job_id = *log_job_id,
+                        job_id = %log_job_id,
                         pipeline_id = *pipeline_id,
                         "Worker {:?} finished",
                         worker_id
@@ -89,7 +89,7 @@ impl Scheduler for EmbeddedScheduler {
                 }
                 Err(err) => {
                     error!(
-                        job_id = *log_job_id,
+                        job_id = %log_job_id,
                         pipeline_id = *pipeline_id,
                         "Worker {:?} panicked: {:?}",
                         worker_id,

--- a/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/kubernetes/mod.rs
@@ -252,7 +252,7 @@ impl Scheduler for KubernetesScheduler {
         }
 
         info!(
-            job_id = *req.job_id,
+            job_id = %req.job_id,
             pipeline_id = *req.pipeline_id,
             message = "starting workers on k8s",
             replicas = pods.len(),
@@ -261,7 +261,7 @@ impl Scheduler for KubernetesScheduler {
 
         for pod in pods {
             info!(
-                job_id = *req.job_id,
+                job_id = %req.job_id,
                 pipeline_id = *req.pipeline_id,
                 message = "starting worker",
                 pod = pod.metadata.name

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -233,7 +233,7 @@ impl Scheduler for ProcessScheduler {
                             info!(
                                 message = "Killing child",
                                 worker_id,
-                                job_id = *job_id,
+                                job_id = %job_id,
                                 pipeline_id = *pipeline_id
                             );
                             if let Err(e) = child.kill().await {
@@ -331,7 +331,7 @@ impl Scheduler for ProcessScheduler {
                         warn!(
                             message = "process scheduler worker exited without completion signal",
                             worker_id = worker_id.0,
-                            job_id = *job_id,
+                            job_id = %job_id,
                             pipeline_id = *pipeline_id,
                         );
                     }
@@ -627,7 +627,7 @@ impl NodeScheduler {
             warn!(
                 message = "node not found for stop worker",
                 node_id = *worker.node_id.0,
-                job_id = *worker.job_id,
+                job_id = %worker.job_id,
                 pipeline_id = *worker.pipeline_id
             );
             return Ok(Some(worker_id));
@@ -639,7 +639,7 @@ impl NodeScheduler {
 
         info!(
             message = "stopping worker",
-            job_id = *worker.job_id,
+            job_id = %worker.job_id,
             pipeline_id = *worker.pipeline_id,
             node_id = *worker.node_id.0,
             node_addr = node.addr,
@@ -648,7 +648,7 @@ impl NodeScheduler {
 
         let Ok(mut client) = Self::client(&node).await else {
             warn!(
-                job_id = *worker.job_id,
+                job_id = %worker.job_id,
                 pipeline_id = *worker.pipeline_id,
                 "Failed to connect to worker to stop; this likely means it is dead"
             );
@@ -664,7 +664,7 @@ impl NodeScheduler {
             .await
         else {
             warn!(
-                job_id = *worker.job_id,
+                job_id = %worker.job_id,
                 pipeline_id = *worker.pipeline_id,
                 "Failed to connect to worker to stop; this likely means it is dead"
             );
@@ -732,14 +732,14 @@ impl Scheduler for NodeScheduler {
             node.release_slots(worker_id, req.slots as usize);
         } else {
             warn!(
-                job_id,
+                %job_id,
                 pipeline_id, "Got worker finished message for unknown node {}", machine_id
             );
         }
 
         if state.workers.remove(&worker_id).is_none() {
             warn!(
-                job_id,
+                %job_id,
                 pipeline_id, "Got worker finished message for unknown worker {}", worker_id.0
             );
         }
@@ -803,7 +803,7 @@ impl Scheduler for NodeScheduler {
 
             let slots_for_this_one = node.free_slots.min(to_schedule);
             info!(
-                job_id = *start_pipeline_req.job_id,
+                job_id = %start_pipeline_req.job_id,
                 pipeline_id = *start_pipeline_req.pipeline_id,
                 "Scheduling {} slots on node {}",
                 slots_for_this_one,

--- a/crates/arroyo-controller/src/states/checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/checkpoint_stopping.rs
@@ -28,7 +28,7 @@ impl State for CheckpointStopping {
             match job_controller.checkpoint_finished().await {
                 Ok(done) => {
                     debug!(
-                        job_id = *job_id,
+                        job_id = %job_id,
                         pipeline_id = *pipeline_id,
                         "checked checkpoint, got {}, job_controller.finished(): {}, final_checkpoint_started: {}",
                         done,

--- a/crates/arroyo-controller/src/states/failing.rs
+++ b/crates/arroyo-controller/src/states/failing.rs
@@ -18,7 +18,7 @@ impl State for Failing {
             warn!(
                 message = "failed to gracefully tear down cluster during failure",
                 error = format!("{:?}", e),
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id
             );
         }

--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -58,7 +58,7 @@ impl State for LeaderRestarting {
                                 }
                                 Some(msg) => {
                                     warn!(
-                                        job_id = *ctx.config.id,
+                                        job_id = %ctx.config.id,
                                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                                         ?msg,
                                         "unexpected job message in leader mode"
@@ -91,7 +91,7 @@ impl State for LeaderRestarting {
             }
             RestartMode::force => {
                 info!(
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id,
                     "force restarting job, tearing down cluster"
                 );

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -138,7 +138,7 @@ impl State for LeaderRunning {
                         }
                         Some(msg) => {
                             warn!(
-                                job_id = *ctx.config.id,
+                                job_id = %ctx.config.id,
                                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                                 msg =? msg,
                                 "unexpected job message in leader mode"
@@ -157,7 +157,7 @@ impl State for LeaderRunning {
                             error!(
                                 message = "Failed to update status",
                                 error = format!("{:?}", e),
-                                job_id = *ctx.config.id,
+                                job_id = %ctx.config.id,
                                 pipeline_id = *ctx.pipeline_info.pipeline_id
                             );
                             ctx.status.restarts = restarts;
@@ -232,7 +232,7 @@ impl State for LeaderRunning {
                             warn!(
                                 message = "error while polling leader status",
                                 error = format!("{:?}", err),
-                                job_id = *ctx.config.id,
+                                job_id = %ctx.config.id,
                                 pipeline_id = *ctx.pipeline_info.pipeline_id
                             );
                             tokio::time::sleep(Duration::from_secs(2)).await;

--- a/crates/arroyo-controller/src/states/leader_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_stopping.rs
@@ -49,7 +49,7 @@ impl State for LeaderStopping {
 
                 info!(
                     msg = "waiting for workers to terminate",
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id
                 );
                 // TODO: we should watch the config queue and move immediately to force stop if requested
@@ -64,7 +64,7 @@ impl State for LeaderStopping {
                     Ok(Err(e)) => {
                         error!(
                             msg = "encountered error while waiting for job to stop gracefully; will try force-stopping",
-                            job_id = *ctx.config.id,
+                            job_id = %ctx.config.id,
                             pipeline_id = *ctx.pipeline_info.pipeline_id,
                             error = e.to_string(),
                         );
@@ -79,7 +79,7 @@ impl State for LeaderStopping {
                     Err(_e) => {
                         error!(
                             msg = "timed out waiting for job to stop",
-                            job_id = *ctx.config.id,
+                            job_id = %ctx.config.id,
                             pipeline_id = *ctx.pipeline_info.pipeline_id,
                         );
 

--- a/crates/arroyo-controller/src/states/mod.rs
+++ b/crates/arroyo-controller/src/states/mod.rs
@@ -117,7 +117,7 @@ async fn handle_terminal<'a>(ctx: &mut JobContext<'a>) {
         warn!(
             message = "Failed to clean up cluster",
             error = format!("{:?}", e),
-            job_id = *ctx.config.id,
+            job_id = %ctx.config.id,
             pipeline_id = *ctx.pipeline_info.pipeline_id
         );
     }
@@ -553,7 +553,7 @@ impl JobContext<'_> {
             JobMessage::RunningMessage(RunningMessage::WorkerHeartbeat { .. })
         ) {
             warn!(
-                job_id = *self.config.id,
+                job_id = %self.config.id,
                 pipeline_id = *self.pipeline_info.pipeline_id,
                 "unhandled job message {:?}",
                 msg
@@ -584,7 +584,7 @@ impl JobContext<'_> {
         event: TaskFailedEvent,
     ) -> Result<Transition, StateError> {
         error!(
-            job_id = self.config.id.as_str(),
+            job_id = %self.config.id.as_str(),
             pipeline_id = *self.pipeline_info.pipeline_id,
             task_id = event.task_id,
             operator_subtask = event.subtask_idx,
@@ -611,7 +611,7 @@ impl JobContext<'_> {
         .await
         {
             warn!(
-                job_id = *self.config.id,
+                job_id = %self.config.id,
                 pipeline_id = *self.pipeline_info.pipeline_id,
                 "Failed to log task failure to database: {:?}",
                 db_err
@@ -650,7 +650,7 @@ impl JobContext<'_> {
         let reason = failure.message.clone();
 
         error!(
-            job_id = self.config.id.as_str(),
+            job_id = %self.config.id.as_str(),
             pipeline_id = *self.pipeline_info.pipeline_id,
             task_id = format!("{:?}", failure.task_id),
             operator_subtask = subtask_index,
@@ -680,7 +680,7 @@ impl JobContext<'_> {
             .await
             {
                 warn!(
-                    job_id = *self.config.id,
+                    job_id = %self.config.id,
                     pipeline_id = *self.pipeline_info.pipeline_id,
                     "Failed to log job failure to database: {:?}",
                     db_err
@@ -759,7 +759,7 @@ async fn execute_state<'a>(
 
     debug!(
         message = "executing state",
-        job_id = *ctx.config.id,
+        job_id = %ctx.config.id,
         pipeline_id = *ctx.pipeline_info.pipeline_id,
         state = state_name,
         config = format!("{:?}", ctx.config)
@@ -769,7 +769,7 @@ async fn execute_state<'a>(
         Ok(Transition::Advance(s)) => {
             info!(
                 message = "state transition",
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 from = state_name,
                 to = s.state.name(),
@@ -802,7 +802,7 @@ async fn execute_state<'a>(
         }) => {
             error!(
                 message = "fatal state error",
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 state = state_name,
                 error_message = message,
@@ -836,7 +836,7 @@ async fn execute_state<'a>(
         }) => {
             error!(
                 message = "exhausted in-state retries, moving to recovering",
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 state = state_name,
                 error_message = message,
@@ -860,7 +860,7 @@ async fn execute_state<'a>(
         }) => {
             error!(
                 message = "retryable state error",
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 state = state_name,
                 error_message = message,
@@ -917,7 +917,7 @@ pub(crate) async fn state_backoff(retries_attempted: usize, job_id: &str, pipeli
         ));
 
     debug!(
-        job_id,
+        %job_id,
         pipeline_id,
         "waiting {}ms to retry",
         backoff.as_millis()
@@ -950,7 +950,7 @@ async fn run_to_completion(
         .await
         .map(Some)
         .unwrap_or_else(|e| {
-            warn!(job_id = *job_config.id,
+            warn!(job_id = %job_config.id,
                     pipeline_id = *pipeline_info.pipeline_id,
                     leader_ctx =? ctx,
                     error =? e,
@@ -1065,7 +1065,7 @@ impl StateMachine {
                 Ok(p) => Some((p, info)),
                 Err(e) => {
                     warn!(
-                        job_id,
+                        %job_id,
                         pipeline_id = *info.pipeline_id,
                         "Failed to start job: {}",
                         e
@@ -1139,7 +1139,7 @@ impl StateMachine {
                             let id = { config.read().unwrap().0.id.clone() };
                             info!(
                                 message = "starting state machine",
-                                job_id = *id,
+                                job_id = %id,
                                 pipeline_id = *pipeline_id
                             );
                             run_to_completion(
@@ -1156,7 +1156,7 @@ impl StateMachine {
                             .await;
                             info!(
                                 message = "finished state machine",
-                                job_id = *id,
+                                job_id = %id,
                                 pipeline_id = *pipeline_id
                             );
                             Ok(())
@@ -1167,7 +1167,7 @@ impl StateMachine {
                     }
                     Err(e) => {
                         // something went wrong, we'll retry on the next go around
-                        warn!(job_id = *status.id, "Failed to start job: {:?}", e);
+                        warn!(job_id = %status.id, "Failed to start job: {:?}", e);
                     }
                 }
             }

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -34,7 +34,7 @@ impl Recovering {
         }
 
         // stop the job
-        info!(message = "stopping job", job_id, pipeline_id);
+        info!(message = "stopping job", %job_id, pipeline_id);
         let start = Instant::now();
         match job_controller.stop_job(StopMode::Immediate).await {
             Ok(_) => {
@@ -43,7 +43,7 @@ impl Recovering {
                 {
                     info!(
                         message = "job stopped",
-                        job_id,
+                        %job_id,
                         pipeline_id,
                         duration = start.elapsed().as_secs_f32()
                     );
@@ -53,7 +53,7 @@ impl Recovering {
                 warn!(
                     message = "failed to stop job",
                     error = format!("{:?}", e),
-                    job_id,
+                    %job_id,
                     pipeline_id,
                 );
             }
@@ -70,7 +70,7 @@ impl Recovering {
                 Ok(Ok(status)) => status,
                 Ok(Err(e)) => {
                     warn!(
-                        job_id,
+                        %job_id,
                         pipeline_id,
                         error =? e,
                         "failed to get leader status while recovering"
@@ -79,7 +79,7 @@ impl Recovering {
                 }
                 Err(e) => {
                     warn!(
-                        job_id,
+                        %job_id,
                         pipeline_id,
                         error =? e,
                         "timed out polling leader status while recovering"
@@ -94,7 +94,7 @@ impl Recovering {
             }
             Ok(JobState::JobUnknown) | Err(_) => {
                 warn!(
-                    job_id,
+                    %job_id,
                     pipeline_id,
                     "received unknown job state {} while cleaning job",
                     status.job_state
@@ -102,20 +102,20 @@ impl Recovering {
                 return;
             }
             Ok(JobState::JobInitializing) => {
-                warn!(job_id, pipeline_id, "job is in initializing while cleaning");
+                warn!(%job_id, pipeline_id, "job is in initializing while cleaning");
                 return;
             }
             Ok(JobState::JobRunning) => {
                 // shutdown
                 info!(
-                    job_id,
+                    %job_id,
                     pipeline_id, "job is still running in recovering, shutting down"
                 );
                 if let Err(e) = leader_manager
                     .stop_leader(JobStopMode::JobStopImmediate)
                     .await
                 {
-                    warn!(job_id, pipeline_id, error =? e, "failed to stop leader");
+                    warn!(%job_id, pipeline_id, error =? e, "failed to stop leader");
                     return;
                 }
                 JobState::JobStopped
@@ -136,14 +136,14 @@ impl Recovering {
             }
             Ok(JobState::JobFailing) => {
                 info!(
-                    job_id,
+                    %job_id,
                     pipeline_id, "job is failing in recovering, shutting down"
                 );
                 if let Err(e) = leader_manager
                     .stop_leader(JobStopMode::JobStopImmediate)
                     .await
                 {
-                    warn!(job_id, pipeline_id, error =? e, "failed to stop leader");
+                    warn!(%job_id, pipeline_id, error =? e, "failed to stop leader");
                     return;
                 }
                 JobState::JobFailed
@@ -157,7 +157,7 @@ impl Recovering {
         .await
         {
             warn!(
-                job_id,
+                %job_id,
                 pipeline_id,
                 error = ?e,
                 ?expected_state,
@@ -178,7 +178,7 @@ impl Recovering {
 
         info!(
             message = "tearing down workers",
-            job_id = *ctx.config.id,
+            job_id = %ctx.config.id,
             pipeline_id = *ctx.pipeline_info.pipeline_id
         );
 
@@ -220,7 +220,7 @@ impl Recovering {
             Duration::from_millis(200),
             Duration::from_secs(10),
             |e| warn!(
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 error =? e,
                 "failed to tear down cluster"
@@ -267,7 +267,7 @@ impl State for Recovering {
         .await;
 
         info!(
-            job_id = *ctx.config.id,
+            job_id = %ctx.config.id,
             pipeline_id = *ctx.pipeline_info.pipeline_id,
             retries_remaining = pipeline_config.allowed_restarts - ctx.status.restarts,
             "recovering pipeline"

--- a/crates/arroyo-controller/src/states/running.rs
+++ b/crates/arroyo-controller/src/states/running.rs
@@ -105,7 +105,7 @@ impl State for Running {
                             error!(
                                 message = "Failed to update status",
                                 error = format!("{:?}", e),
-                                job_id = *ctx.config.id,
+                                job_id = %ctx.config.id,
                                 pipeline_id = *ctx.pipeline_info.pipeline_id
                             );
                             ctx.status.restarts = restarts;
@@ -140,7 +140,7 @@ impl State for Running {
                             error!(
                                 message = "error while running",
                                 error = format!("{:?}", err),
-                                job_id = *ctx.config.id,
+                                job_id = %ctx.config.id,
                                 pipeline_id = *ctx.pipeline_info.pipeline_id
                             );
                             log_event!("running_error", {

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -122,7 +122,7 @@ async fn handle_worker_connect<'a>(
             if ctx.status.generation != run_id {
                 info!(
                     message = "worker connect from wrong run; ignoring",
-                    job_id = *job_id,
+                    job_id = %job_id,
                     pipeline_id = *pipeline_id,
                     worker_id = worker_id.0,
                     machine_id = *machine_id.0,
@@ -147,7 +147,7 @@ async fn handle_worker_connect<'a>(
             handles.push(tokio::spawn(async move {
                 info!(
                     message = "connecting to worker",
-                    job_id = *job_id,
+                    job_id = %job_id,
                     pipeline_id = *pipeline_id,
                     worker_id = worker_id.0,
                     machine_id = *machine_id.0,
@@ -177,7 +177,7 @@ async fn handle_worker_connect<'a>(
                         Err(e) => {
                             error!(
                                 message = "Failed to connect to worker",
-                                job_id = *job_id,
+                                job_id = %job_id,
                                 pipeline_id = *pipeline_id,
                                 worker_id = worker_id.0,
                                 machine_id = *machine_id.0,
@@ -253,7 +253,7 @@ async fn get_checkpoint_info_legacy<'a>(
             if should_restore {
                 info!(
                     message = "restoring checkpoint",
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id,
                     epoch = r.epoch,
                     min_epoch = r.min_epoch
@@ -268,7 +268,7 @@ async fn get_checkpoint_info_legacy<'a>(
             } else {
                 info!(
                     message = "skipping checkpoint due to ignore_state_before_epoch threshold",
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id,
                     checkpoint_epoch = r.epoch,
                     threshold = ctx.config.ignore_state_before_epoch.unwrap()
@@ -459,7 +459,7 @@ async fn get_and_register_checkpoint_info_leader<'a>(
     if ignore_state {
         info!(
             message = "starting leader generation without state",
-            job_id = *ctx.config.id,
+            job_id = %ctx.config.id,
             generation = ctx.status.generation,
         );
     }
@@ -549,7 +549,7 @@ impl Scheduling {
             .insert("ARROYO__CHECKPOINT_URL".to_string(), checkpoint_url)
             .inspect(|_| {
                 warn!(
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id,
                     key = "ARROYO__CHECKPOINT_URL",
                     "job env_vars contained a reserved infrastructure key; \
@@ -562,7 +562,7 @@ impl Scheduling {
             .insert(CLUSTER_ID_ENV.to_string(), cluster_id)
             .inspect(|_| {
                 warn!(
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id,
                     key = CLUSTER_ID_ENV,
                     "job env_vars contained a reserved infrastructure key; \
@@ -593,7 +593,7 @@ impl Scheduling {
                 Err(SchedulerError::NotEnoughSlots { slots_needed: s }) => {
                     warn!(
                         message = "not enough slots for job",
-                        job_id = *ctx.config.id,
+                        job_id = %ctx.config.id,
                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                         slots_for_job = slots_needed,
                         slots_needed = s
@@ -654,7 +654,7 @@ impl State for Scheduling {
         if let Err(e) = ctx.scheduler.stop_workers(&ctx.config.id, None, true).await {
             warn!(
                 message = "failed to clean cluster prior to scheduling",
-                job_id = *ctx.config.id,
+                job_id = %ctx.config.id,
                 pipeline_id = *ctx.pipeline_info.pipeline_id,
                 error = format!("{:?}", e)
             )
@@ -753,7 +753,7 @@ impl State for Scheduling {
                     let epoch = (t - 1) as u64;
                     info!(
                         message = "starting from ignore_state_before_epoch threshold",
-                        job_id = *ctx.config.id,
+                        job_id = %ctx.config.id,
                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                         default_epoch = epoch,
                     );
@@ -797,7 +797,7 @@ impl State for Scheduling {
                 tokio::spawn(async move {
                     info!(
                         message = "starting execution on worker",
-                        job_id = *job_id,
+                        job_id = %job_id,
                         pipeline_id = *pipeline_id,
                         worker_id = id.0,
                         machine_id = *machine_id.0,
@@ -821,7 +821,7 @@ impl State for Scheduling {
                         Ok(_) => {
                             debug!(
                                 message = "worker entered initialization phase",
-                                job_id = *job_id,
+                                job_id = %job_id,
                                 pipeline_id = *pipeline_id,
                                 worker_id = id.0,
                                 machine_id = *machine_id.0,
@@ -831,7 +831,7 @@ impl State for Scheduling {
                         Err(e) => {
                             error!(
                                 message = "failed to start execution on worker",
-                                job_id = *job_id,
+                                job_id = %job_id,
                                 pipeline_id = *pipeline_id,
                                 worker_id = id.0,
                                 machine_id = *machine_id.0,
@@ -882,7 +882,7 @@ impl State for Scheduling {
                                     worker.state = WorkerState::Ready;
                                     info!(
                                         message = "worker initialization completed successfully",
-                                        job_id = *ctx.config.id,
+                                        job_id = %ctx.config.id,
                                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                                         worker_id = worker_id.0,
                                         machine_id = *worker.machine_id.0,
@@ -892,7 +892,7 @@ impl State for Scheduling {
                                     worker.state = WorkerState::Failed;
                                     error!(
                                         message = "worker initialization failed",
-                                        job_id = *ctx.config.id,
+                                        job_id = %ctx.config.id,
                                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                                         worker_id = worker_id.0,
                                         machine_id = *worker.machine_id.0,
@@ -954,7 +954,7 @@ impl State for Scheduling {
                                         warn!(
                                             message = "leader returned invalid job state before task startup timeout",
                                             error = format!("{:?}", e),
-                                            job_id = *ctx.config.id,
+                                            job_id = %ctx.config.id,
                                             pipeline_id = *ctx.pipeline_info.pipeline_id,
                                         );
                                     }
@@ -1009,7 +1009,7 @@ impl State for Scheduling {
                 );
                 if needs_commit {
                     info!(
-                        job_id = *ctx.config.id,
+                        job_id = %ctx.config.id,
                         pipeline_id = *ctx.pipeline_info.pipeline_id,
                         "restored checkpoint was in committing phase, sending commits"
                     );

--- a/crates/arroyo-controller/src/states/stopping.rs
+++ b/crates/arroyo-controller/src/states/stopping.rs
@@ -35,7 +35,7 @@ impl State for Stopping {
 
                 info!(
                     msg = "waiting for workers to terminate",
-                    job_id = *ctx.config.id,
+                    job_id = %ctx.config.id,
                     pipeline_id = *ctx.pipeline_info.pipeline_id
                 );
                 match timeout(FINISH_TIMEOUT, job_controller.wait_for_finish(ctx.rx)).await {
@@ -43,7 +43,7 @@ impl State for Stopping {
                     Ok(Err(e)) => {
                         error!(
                             msg = "encountered error while waiting for job to stop gracefully; will try force-stopping",
-                            job_id = *ctx.config.id,
+                            job_id = %ctx.config.id,
                             pipeline_id = *ctx.pipeline_info.pipeline_id,
                             error = e.to_string(),
                         );
@@ -54,7 +54,7 @@ impl State for Stopping {
                         error!(
                             msg =
                                 "timed out while waiting for job to stop; will try force-stopping",
-                            job_id = *ctx.config.id,
+                            job_id = %ctx.config.id,
                             pipeline_id = *ctx.pipeline_info.pipeline_id
                         );
                         self.stop_mode = StopBehavior::StopWorkers;


### PR DESCRIPTION
We have a mix of debug formatting and dereferencing for job_id logs in the controller. This PR normalizes everything to use display formatting, which will end up with the raw job_id (`job_vd3KIPZu4W`) being logged, matching the behavior of the worker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->