### PR TITLE
Add support for starting/restarting without state in leader mode

### DIFF
--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -183,7 +183,6 @@ UPDATE job_configs
 SET
    updated_at = :updated_at,
    updated_by = :updated_by,
-   stop = 'none',
    restart_nonce = restart_nonce + 1,
    restart_mode = :mode,
    ignore_state_before_epoch = :ignore_state_before_epoch

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -29,7 +29,8 @@ use crate::pipelines::{query_job_by_pub_id, query_pipeline_by_pub_id};
 use crate::rest::AppState;
 use crate::rest_utils::{
     BearerAuth, ErrorResp, PipelineJobCheckpointPath, PipelineJobPath, authenticate, bad_request,
-    log_and_map, not_found, paginate_results, validate_pagination_params,
+    conflict, internal_server_error, log_and_map, not_found, paginate_results,
+    validate_pagination_params,
 };
 use crate::types::public::LogLevel;
 use crate::{AuthData, queries::api_queries, to_micros, types::public};
@@ -193,6 +194,216 @@ pub(crate) async fn create_job(
     .await?;
 
     Ok(job_id)
+}
+
+fn replaceable_job(jobs: Vec<(String, String)>) -> Result<String, ErrorResp> {
+    let count = jobs.len();
+    let Some((job_id, state)) = jobs.into_iter().next() else {
+        return Err(not_found("Job for pipeline"));
+    };
+
+    if count != 1 {
+        return Err(internal_server_error(format!(
+            "expected one job for pipeline, found {count}"
+        )));
+    }
+
+    if state != "Stopped" && state != "Failed" {
+        return Err(conflict(format!(
+            "cannot restart job {job_id} without state while it is in state {state}; stop the job first"
+        )));
+    }
+
+    Ok(job_id)
+}
+
+/// Replaces a pipeline's single terminal job with a fresh job.
+///
+/// This is used for restart-without-state in leader mode. Keeping the replacement in a single
+/// transaction preserves the current one-job-per-pipeline assumption for all other API queries.
+pub(crate) async fn replace_job_without_state(
+    db: &DatabaseSource,
+    pipeline_pub_id: &str,
+    auth: &AuthData,
+) -> Result<String, ErrorResp> {
+    let new_job_id = generate_id(IdTypes::JobConfig);
+    let new_status_id = generate_id(IdTypes::JobStatus);
+
+    match db {
+        DatabaseSource::Postgres(pool) => {
+            let mut client = pool.get().await.map_err(log_and_map)?;
+            let transaction = client.transaction().await.map_err(log_and_map)?;
+
+            // Lock the pipeline first. This serializes concurrent replacement requests before
+            // either request resolves the pipeline's current singleton job.
+            let pipeline = transaction
+                .query_opt(
+                    "SELECT id FROM pipelines \
+                     WHERE pub_id = $1 AND organization_id = $2 \
+                     FOR UPDATE",
+                    &[&pipeline_pub_id, &auth.organization_id],
+                )
+                .await
+                .map_err(log_and_map)?
+                .ok_or_else(|| not_found("Pipeline"))?;
+            let pipeline_id: i64 = pipeline.get(0);
+
+            let jobs = transaction
+                .query(
+                    "SELECT c.id, COALESCE(s.state, 'Created') \
+                     FROM job_configs c \
+                     INNER JOIN job_statuses s ON c.id = s.id \
+                     WHERE c.pipeline_id = $1 AND c.organization_id = $2 \
+                     FOR UPDATE OF c, s",
+                    &[&pipeline_id, &auth.organization_id],
+                )
+                .await
+                .map_err(log_and_map)?
+                .into_iter()
+                .map(|row| (row.get(0), row.get(1)))
+                .collect();
+            let old_job_id = replaceable_job(jobs)?;
+
+            let inserted = transaction
+                .execute(
+                    "INSERT INTO job_configs \
+                     (id, organization_id, pipeline_name, created_by, updated_by, updated_at, \
+                      ttl_micros, stop, pipeline_id, parallelism_overrides, \
+                      checkpoint_interval_micros, env_vars, scheduler_config) \
+                     SELECT $1, organization_id, pipeline_name, created_by, $2, CURRENT_TIMESTAMP, \
+                            ttl_micros, 'none', pipeline_id, parallelism_overrides, \
+                            checkpoint_interval_micros, env_vars, scheduler_config \
+                     FROM job_configs WHERE id = $3",
+                    &[&new_job_id, &auth.user_id, &old_job_id],
+                )
+                .await
+                .map_err(log_and_map)?;
+            if inserted != 1 {
+                return Err(internal_server_error("failed to clone job configuration"));
+            }
+
+            transaction
+                .execute(
+                    "INSERT INTO job_statuses (pub_id, id, organization_id) VALUES ($1, $2, $3)",
+                    &[&new_status_id, &new_job_id, &auth.organization_id],
+                )
+                .await
+                .map_err(log_and_map)?;
+
+            // Delete children explicitly because the SQLite checkpoints table does not have the
+            // same foreign-key cascade as PostgreSQL.
+            transaction
+                .execute("DELETE FROM checkpoints WHERE job_id = $1", &[&old_job_id])
+                .await
+                .map_err(log_and_map)?;
+            transaction
+                .execute(
+                    "DELETE FROM job_log_messages WHERE job_id = $1",
+                    &[&old_job_id],
+                )
+                .await
+                .map_err(log_and_map)?;
+            transaction
+                .execute("DELETE FROM job_statuses WHERE id = $1", &[&old_job_id])
+                .await
+                .map_err(log_and_map)?;
+            transaction
+                .execute("DELETE FROM job_configs WHERE id = $1", &[&old_job_id])
+                .await
+                .map_err(log_and_map)?;
+
+            transaction.commit().await.map_err(log_and_map)?;
+        }
+        DatabaseSource::Sqlite(connection) => {
+            let mut connection = connection.lock().map_err(log_and_map)?;
+            let transaction = connection.transaction().map_err(log_and_map)?;
+
+            // Beginning a SQLite transaction acquires the connection mutex for this entire block,
+            // so resolving and replacing the singleton job cannot interleave with another request.
+            let pipeline_id = transaction
+                .query_row(
+                    "SELECT id FROM pipelines WHERE pub_id = ?1 AND organization_id = ?2",
+                    rusqlite::params![pipeline_pub_id, auth.organization_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| match error {
+                    rusqlite::Error::QueryReturnedNoRows => not_found("Pipeline"),
+                    error => log_and_map(error),
+                })?;
+
+            let jobs = {
+                let mut statement = transaction
+                    .prepare(
+                        "SELECT c.id, COALESCE(s.state, 'Created') \
+                         FROM job_configs c \
+                         INNER JOIN job_statuses s ON c.id = s.id \
+                         WHERE c.pipeline_id = ?1 AND c.organization_id = ?2",
+                    )
+                    .map_err(log_and_map)?;
+                statement
+                    .query_map(
+                        rusqlite::params![pipeline_id, auth.organization_id],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(log_and_map)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(log_and_map)?
+            };
+            let old_job_id = replaceable_job(jobs)?;
+
+            let inserted = transaction
+                .execute(
+                    "INSERT INTO job_configs \
+                     (id, organization_id, pipeline_name, created_by, updated_by, updated_at, \
+                      ttl_micros, stop, pipeline_id, parallelism_overrides, \
+                      checkpoint_interval_micros, env_vars, scheduler_config) \
+                     SELECT ?1, organization_id, pipeline_name, created_by, ?2, CURRENT_TIMESTAMP, \
+                            ttl_micros, 'none', pipeline_id, parallelism_overrides, \
+                            checkpoint_interval_micros, env_vars, scheduler_config \
+                     FROM job_configs WHERE id = ?3",
+                    rusqlite::params![new_job_id, auth.user_id, old_job_id],
+                )
+                .map_err(log_and_map)?;
+            if inserted != 1 {
+                return Err(internal_server_error("failed to clone job configuration"));
+            }
+
+            transaction
+                .execute(
+                    "INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![new_status_id, new_job_id, auth.organization_id],
+                )
+                .map_err(log_and_map)?;
+            transaction
+                .execute(
+                    "DELETE FROM checkpoints WHERE job_id = ?1",
+                    rusqlite::params![old_job_id],
+                )
+                .map_err(log_and_map)?;
+            transaction
+                .execute(
+                    "DELETE FROM job_log_messages WHERE job_id = ?1",
+                    rusqlite::params![old_job_id],
+                )
+                .map_err(log_and_map)?;
+            transaction
+                .execute(
+                    "DELETE FROM job_statuses WHERE id = ?1",
+                    rusqlite::params![old_job_id],
+                )
+                .map_err(log_and_map)?;
+            transaction
+                .execute(
+                    "DELETE FROM job_configs WHERE id = ?1",
+                    rusqlite::params![old_job_id],
+                )
+                .map_err(log_and_map)?;
+
+            transaction.commit().map_err(log_and_map)?;
+        }
+    }
+
+    Ok(new_job_id)
 }
 
 pub(crate) fn get_action(state: &str, running_desired: &bool) -> (String, Option<StopType>, bool) {
@@ -621,5 +832,176 @@ impl TryFrom<DbCheckpoint> for Checkpoint {
             finish_time: val.finish_time.map(to_micros),
             events: events.into_iter().map(|e| e.into()).collect(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrgMetadata;
+    use std::sync::{Arc, Mutex};
+
+    fn auth() -> AuthData {
+        AuthData {
+            user_id: "user_2".to_string(),
+            organization_id: "org_1".to_string(),
+            role: "user".to_string(),
+            org_metadata: OrgMetadata::default(),
+        }
+    }
+
+    fn sqlite_job(state: &str) -> DatabaseSource {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE pipelines (
+                    id INTEGER PRIMARY KEY,
+                    pub_id TEXT NOT NULL,
+                    organization_id TEXT NOT NULL
+                );
+                CREATE TABLE job_configs (
+                    id TEXT PRIMARY KEY,
+                    organization_id TEXT,
+                    pipeline_name TEXT NOT NULL,
+                    created_by TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_by TEXT,
+                    updated_at TIMESTAMP,
+                    ttl_micros INTEGER,
+                    stop TEXT DEFAULT 'none' NOT NULL,
+                    parallelism_overrides TEXT DEFAULT '{}' NOT NULL,
+                    checkpoint_interval_micros INTEGER DEFAULT 10000000 NOT NULL,
+                    pipeline_id INTEGER NOT NULL,
+                    restart_nonce INTEGER DEFAULT 0 NOT NULL,
+                    restart_mode TEXT DEFAULT 'safe' NOT NULL,
+                    ignore_state_before_epoch INTEGER,
+                    env_vars TEXT DEFAULT '{}' NOT NULL,
+                    scheduler_config TEXT DEFAULT '{}' NOT NULL
+                );
+                CREATE TABLE job_statuses (
+                    pub_id TEXT NOT NULL UNIQUE,
+                    id TEXT PRIMARY KEY,
+                    organization_id TEXT,
+                    run_id INTEGER DEFAULT 0 NOT NULL,
+                    state TEXT DEFAULT 'Created' NOT NULL
+                );
+                CREATE TABLE checkpoints (job_id TEXT NOT NULL);
+                CREATE TABLE job_log_messages (job_id TEXT NOT NULL);
+                INSERT INTO pipelines (id, pub_id, organization_id)
+                    VALUES (1, 'pl_1', 'org_1');
+                INSERT INTO job_configs
+                    (id, organization_id, pipeline_name, created_by, updated_by, ttl_micros, stop,
+                     parallelism_overrides, checkpoint_interval_micros, pipeline_id, restart_nonce,
+                     restart_mode, ignore_state_before_epoch, env_vars, scheduler_config)
+                    VALUES
+                    ('job_old', 'org_1', 'pipeline', 'user_1', 'user_1', 123, 'immediate',
+                     '{\"1\": 4}', 5000000, 1, 3, 'force', 42,
+                     '{\"ENV\": \"value\"}', '{\"scheduler\": true}');
+                INSERT INTO checkpoints (job_id) VALUES ('job_old');
+                INSERT INTO job_log_messages (job_id) VALUES ('job_old');",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO job_statuses (pub_id, id, organization_id, run_id, state)
+                 VALUES ('js_old', 'job_old', 'org_1', 7, ?1)",
+                [state],
+            )
+            .unwrap();
+
+        DatabaseSource::Sqlite(Arc::new(Mutex::new(connection)))
+    }
+
+    #[tokio::test]
+    async fn replace_job_without_state_replaces_terminal_job_and_deletes_history() {
+        let database = sqlite_job("Stopped");
+
+        let new_job_id = replace_job_without_state(&database, "pl_1", &auth())
+            .await
+            .unwrap();
+
+        assert_ne!(new_job_id, "job_old");
+        let DatabaseSource::Sqlite(connection) = &database else {
+            unreachable!()
+        };
+        let connection = connection.lock().unwrap();
+
+        let job: (
+            String,
+            String,
+            i64,
+            String,
+            String,
+            Option<i64>,
+            String,
+            String,
+        ) = connection
+            .query_row(
+                "SELECT id, stop, restart_nonce, restart_mode, updated_by,
+                        ignore_state_before_epoch, env_vars, scheduler_config
+                 FROM job_configs",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            job,
+            (
+                new_job_id.clone(),
+                "none".to_string(),
+                0,
+                "safe".to_string(),
+                "user_2".to_string(),
+                None,
+                "{\"ENV\": \"value\"}".to_string(),
+                "{\"scheduler\": true}".to_string(),
+            )
+        );
+
+        let status: (String, i64, String) = connection
+            .query_row("SELECT id, run_id, state FROM job_statuses", [], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(status, (new_job_id, 0, "Created".to_string()));
+
+        for table in ["checkpoints", "job_log_messages"] {
+            let count: i64 = connection
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, 0, "{table} should be cleared");
+        }
+    }
+
+    #[tokio::test]
+    async fn replace_job_without_state_rejects_non_terminal_job() {
+        let database = sqlite_job("Running");
+
+        let error = replace_job_without_state(&database, "pl_1", &auth())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.status_code, StatusCode::CONFLICT);
+        let DatabaseSource::Sqlite(connection) = &database else {
+            unreachable!()
+        };
+        let connection = connection.lock().unwrap();
+        let job_id: String = connection
+            .query_row("SELECT id FROM job_configs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(job_id, "job_old");
     }
 }

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -52,7 +52,7 @@ use crate::rest_utils::{
 use crate::types::public::{PipelineType, RestartMode, StopMode};
 use crate::udfs::build_udf;
 use crate::{connection_tables, to_micros};
-use arroyo_rpc::config::{JobControllerMode, config};
+use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_types::to_millis;
 use cornucopia_async::{Database, DatabaseSource};
@@ -868,14 +868,14 @@ pub async fn restart_pipeline(
     WithRejection(Json(req), _): WithRejection<Json<PipelineRestart>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
-
     let db = state.database.client().await?;
 
-    let job = api_queries::fetch_get_pipeline_jobs(&db, &auth_data.organization_id, &id)
+    let job_id = api_queries::fetch_get_pipeline_jobs(&db, &auth_data.organization_id, &id)
         .await?
         .into_iter()
         .next()
-        .ok_or_else(|| bad_request("No jobs for pipeline"))?;
+        .ok_or_else(|| bad_request("No jobs for pipeline"))?
+        .id;
 
     let mode = if req.force == Some(true) {
         RestartMode::force
@@ -883,29 +883,14 @@ pub async fn restart_pipeline(
         RestartMode::safe
     };
 
+    // If user wants to ignore state, query max checkpoint epoch and compute threshold
     let ignore_before_epoch = if req.ignore_state.unwrap_or(false) {
-        match config().job_controller {
-            JobControllerMode::Controller => {
-                // Controller mode uses this as an epoch threshold.
-                api_queries::fetch_max_checkpoint_epoch(&db, &job.id, &auth_data.organization_id)
-                    .await?
-                    .into_iter()
-                    .next()
-                    .and_then(|r| r.max_epoch)
-                    .map(|max_epoch| max_epoch + 1)
-            }
-            JobControllerMode::Worker => {
-                // Leader mode uses this as the generation that should start without state.
-                Some(
-                    job.run_id
-                        .unwrap_or(0)
-                        .max(0)
-                        .checked_add(1)
-                        .and_then(|generation| generation.try_into().ok())
-                        .ok_or_else(|| bad_request("Job generation is too large to restart"))?,
-                )
-            }
-        }
+        api_queries::fetch_max_checkpoint_epoch(&db, &job_id, &auth_data.organization_id)
+            .await?
+            .into_iter()
+            .next()
+            .and_then(|r| r.max_epoch)
+            .map(|max_epoch| max_epoch + 1)
     } else {
         None
     };
@@ -916,7 +901,7 @@ pub async fn restart_pipeline(
         &auth_data.user_id,
         &mode,
         &ignore_before_epoch,
-        &job.id,
+        &job_id,
         &auth_data.organization_id,
     )
     .await?;

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -52,7 +52,7 @@ use crate::rest_utils::{
 use crate::types::public::{PipelineType, RestartMode, StopMode};
 use crate::udfs::build_udf;
 use crate::{connection_tables, to_micros};
-use arroyo_rpc::config::config;
+use arroyo_rpc::config::{JobControllerMode, config};
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_types::to_millis;
 use cornucopia_async::{Database, DatabaseSource};
@@ -868,6 +868,17 @@ pub async fn restart_pipeline(
     WithRejection(Json(req), _): WithRejection<Json<PipelineRestart>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
+
+    if req.ignore_state.unwrap_or(false)
+        && matches!(config().job_controller, JobControllerMode::Worker)
+    {
+        jobs::replace_job_without_state(&state.database, &id, &auth_data).await?;
+
+        let db = state.database.client().await?;
+        let pipeline = query_pipeline_by_pub_id(&id, &db, &auth_data).await?;
+        return Ok(Json(pipeline));
+    }
+
     let db = state.database.client().await?;
 
     let job_id = api_queries::fetch_get_pipeline_jobs(&db, &auth_data.organization_id, &id)

--- a/crates/arroyo-api/src/rest_utils.rs
+++ b/crates/arroyo-api/src/rest_utils.rs
@@ -168,6 +168,13 @@ pub(crate) fn bad_request(message: impl Into<String>) -> ErrorResp {
     }
 }
 
+pub(crate) fn conflict(message: impl Into<String>) -> ErrorResp {
+    ErrorResp {
+        status_code: StatusCode::CONFLICT,
+        message: message.into(),
+    }
+}
+
 pub(crate) fn service_unavailable(object: &str) -> ErrorResp {
     ErrorResp {
         status_code: StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -111,8 +111,6 @@ pub struct JobConfig {
     parallelism_overrides: HashMap<u32, usize>,
     restart_nonce: i32,
     restart_mode: RestartMode,
-    /// Minimum checkpoint epoch in controller mode; generation to start without state in leader
-    /// mode.
     ignore_state_before_epoch: Option<i32>,
     /// Per-job environment variables forwarded to workers at scheduling time.
     env_vars: serde_json::Value,

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -472,7 +472,6 @@ async fn get_and_register_checkpoint_info_leader<'a>(
             job_id: JobId(ctx.config.id.clone()),
             generation: Generation(ctx.status.generation),
             updated_at: SystemTime::now(),
-            ignore_state,
         },
         true,
     )

--- a/crates/arroyo-state-protocol/src/lib.rs
+++ b/crates/arroyo-state-protocol/src/lib.rs
@@ -759,7 +759,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(1),
                 updated_at: from_micros(123),
-                ignore_state: false,
             },
             false,
         )
@@ -815,7 +814,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(2),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )
@@ -836,62 +834,6 @@ mod tests {
                 recovery: GenerationRecovery::Ready {
                     checkpoint_ref: checkpoint_ref.clone()
                 }
-            }
-        );
-
-        let written_manifest: GenerationManifest =
-            read_json(&store, &paths.generation_manifest(Generation(2)))
-                .await
-                .unwrap()
-                .expect("new generation manifest should be written");
-        assert_eq!(written_manifest, expected_manifest);
-    }
-
-    #[tokio::test]
-    async fn initialize_generation_can_ignore_previous_checkpoint() {
-        let store = MemoryProtocolStore::default();
-        let paths = ProtocolPaths::new(PipelineId::new("P"), JobId::new("J"));
-        write_current_generation(&store, &paths, Generation(2)).await;
-
-        let checkpoint_ref = paths.checkpoint_manifest(Generation(1), Epoch(1));
-        let checkpoint = checkpoint_for_generation(Generation(1), 1, None, false);
-        write_canonical_checkpoint(&store, &paths, &checkpoint_ref, &checkpoint).await;
-        let previous_manifest =
-            generation_manifest_for_generation(Generation(1), None, Some(checkpoint_ref));
-        put_json(
-            &store,
-            &paths.generation_manifest(Generation(1)),
-            &previous_manifest,
-        )
-        .await
-        .unwrap();
-
-        let initialization = initialize_generation(
-            &store,
-            InitializeGenerationRequest {
-                pipeline_id: PipelineId::new("P"),
-                job_id: JobId::new("J"),
-                generation: Generation(2),
-                updated_at: from_micros(456),
-                ignore_state: true,
-            },
-            false,
-        )
-        .await
-        .unwrap();
-
-        let expected_manifest = GenerationManifest::new(
-            PipelineId::new("P"),
-            JobId::new("J"),
-            Generation(2),
-            None,
-            456,
-        );
-        assert_eq!(
-            initialization,
-            GenerationInitialization::Initialized {
-                generation_manifest: expected_manifest.clone(),
-                recovery: GenerationRecovery::NoCheckpoint,
             }
         );
 
@@ -929,7 +871,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(2),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )
@@ -978,7 +919,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(3),
                 updated_at: from_micros(789),
-                ignore_state: false,
             },
             false,
         )
@@ -1026,7 +966,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(2),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )
@@ -1083,7 +1022,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(3),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )
@@ -1149,7 +1087,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(3),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )
@@ -1187,7 +1124,6 @@ mod tests {
                 job_id: JobId::new("J"),
                 generation: Generation(2),
                 updated_at: from_micros(456),
-                ignore_state: false,
             },
             false,
         )

--- a/crates/arroyo-state-protocol/src/workflow.rs
+++ b/crates/arroyo-state-protocol/src/workflow.rs
@@ -71,8 +71,6 @@ pub struct InitializeGenerationRequest {
     pub job_id: JobId,
     pub generation: Generation,
     pub updated_at: SystemTime,
-    /// Start this generation without restoring a checkpoint from an earlier generation.
-    pub ignore_state: bool,
 }
 
 /// Checkpoint, if any, that a newly initialized generation should restore from.
@@ -261,11 +259,7 @@ where
         });
     }
 
-    let recovery = if request.ignore_state {
-        RecoverySearch::Found(GenerationRecovery::NoCheckpoint)
-    } else {
-        find_recovery_checkpoint(store, &paths, request.generation).await?
-    };
+    let recovery = find_recovery_checkpoint(store, &paths, request.generation).await?;
     let base_checkpoint_ref = match &recovery {
         RecoverySearch::Found(recovery) => match recovery {
             GenerationRecovery::NoCheckpoint => None,

--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -160,9 +160,6 @@ impl WorkerJobController {
                 job_id: worker_context.job_id.clone(),
                 generation: Generation(worker_context.generation),
                 updated_at: SystemTime::now(),
-                // The controller passes no parent checkpoint when this generation should start
-                // without state (or when there is no state available).
-                ignore_state: parent_ref.is_none(),
             },
             false,
         )

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -524,7 +524,7 @@ export const usePipeline = (pipelineId?: string, refresh: boolean = false) => {
       params: { path: { id: pipelineId } },
       body: { ignore_state: ignoreState ?? false },
     });
-    await mutate();
+    await Promise.all([mutate(), globalMutate(pipelineJobsKey(pipelineId))]);
   };
 
   const deletePipeline = async () => {

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -138,7 +138,7 @@ export function PipelineDetails() {
 
   async function updateJobState(stop: StopType) {
     console.log(`Setting pipeline stop_mode=${stop}`);
-    await updatePipeline({ stop });
+    updatePipeline({ stop });
   }
 
   async function updateJobParallelism(parallelism: number) {
@@ -352,29 +352,23 @@ export function PipelineDetails() {
   let actionButton = <></>;
   if (pipeline) {
     editPipelineButton = <Button onClick={onConfigModalOpen}>Edit</Button>;
-    const isStopped = job.state === 'Stopped' && pipeline.action != null;
-    if (job.state === 'Failed' || isStopped) {
-      const actionText = isStopped ? 'Start' : 'Restart';
+    if (job.state == 'Failed') {
       actionButton = (
         <Popover trigger="hover" placement="bottom-start">
           <PopoverTrigger>
             <Button
               onClick={async () => {
-                if (isStopped) {
-                  await updateJobState(pipeline.action!);
-                } else {
-                  await restartPipeline(false);
-                }
+                await restartPipeline(false);
               }}
             >
-              {actionText}
+              Restart
             </Button>
           </PopoverTrigger>
           <PopoverContent width="auto">
             <PopoverArrow />
             <PopoverBody p={4}>
               <Button size="sm" colorScheme="red" onClick={onRestartWithoutStateModalOpen}>
-                {actionText} Without State
+                Restart Without State
               </Button>
             </PopoverBody>
           </PopoverContent>
@@ -394,10 +388,6 @@ export function PipelineDetails() {
       );
     }
   }
-
-  const startingWithoutState = job.state === 'Stopped';
-  const withoutStateAction = startingWithoutState ? 'Start' : 'Restart';
-  const withoutStateActionPresentParticiple = startingWithoutState ? 'Starting' : 'Restarting';
 
   const headerArea = (
     <Flex>
@@ -432,13 +422,13 @@ export function PipelineDetails() {
         <AlertDialogOverlay>
           <AlertDialogContent>
             <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              {withoutStateAction} Without State
+              Restart Without State
             </AlertDialogHeader>
 
             <AlertDialogBody>
               <Text>
-                {withoutStateActionPresentParticiple} without state could lead to data loss,
-                duplication, and incorrect results. Are you sure you want to continue?
+                Restarting without state could lead to data loss, duplication, and incorrect
+                results. Are you sure you want to continue?
               </Text>
             </AlertDialogBody>
 
@@ -454,7 +444,7 @@ export function PipelineDetails() {
                 }}
                 ml={3}
               >
-                {withoutStateAction} Without State
+                Restart Without State
               </Button>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -138,7 +138,7 @@ export function PipelineDetails() {
 
   async function updateJobState(stop: StopType) {
     console.log(`Setting pipeline stop_mode=${stop}`);
-    updatePipeline({ stop });
+    await updatePipeline({ stop });
   }
 
   async function updateJobParallelism(parallelism: number) {
@@ -352,23 +352,29 @@ export function PipelineDetails() {
   let actionButton = <></>;
   if (pipeline) {
     editPipelineButton = <Button onClick={onConfigModalOpen}>Edit</Button>;
-    if (job.state == 'Failed') {
+    const isStopped = job.state === 'Stopped' && pipeline.action != null;
+    if (job.state === 'Failed' || isStopped) {
+      const actionText = isStopped ? 'Start' : 'Restart';
       actionButton = (
         <Popover trigger="hover" placement="bottom-start">
           <PopoverTrigger>
             <Button
               onClick={async () => {
-                await restartPipeline(false);
+                if (isStopped) {
+                  await updateJobState(pipeline.action!);
+                } else {
+                  await restartPipeline(false);
+                }
               }}
             >
-              Restart
+              {actionText}
             </Button>
           </PopoverTrigger>
           <PopoverContent width="auto">
             <PopoverArrow />
             <PopoverBody p={4}>
               <Button size="sm" colorScheme="red" onClick={onRestartWithoutStateModalOpen}>
-                Restart Without State
+                {actionText} Without State
               </Button>
             </PopoverBody>
           </PopoverContent>
@@ -388,6 +394,10 @@ export function PipelineDetails() {
       );
     }
   }
+
+  const startingWithoutState = job.state === 'Stopped';
+  const withoutStateAction = startingWithoutState ? 'Start' : 'Restart';
+  const withoutStateActionPresentParticiple = startingWithoutState ? 'Starting' : 'Restarting';
 
   const headerArea = (
     <Flex>
@@ -422,13 +432,13 @@ export function PipelineDetails() {
         <AlertDialogOverlay>
           <AlertDialogContent>
             <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              Restart Without State
+              {withoutStateAction} Without State
             </AlertDialogHeader>
 
             <AlertDialogBody>
               <Text>
-                Restarting without state could lead to data loss, duplication, and incorrect
-                results. Are you sure you want to continue?
+                {withoutStateActionPresentParticiple} without state could lead to data loss,
+                duplication, and incorrect results. Are you sure you want to continue?
               </Text>
             </AlertDialogBody>
 
@@ -444,7 +454,7 @@ export function PipelineDetails() {
                 }}
                 ml={3}
               >
-                Restart Without State
+                {withoutStateAction} Without State
               </Button>
             </AlertDialogFooter>
           </AlertDialogContent>


### PR DESCRIPTION
This is the second attempt at #1111, which accidentally merged the wrong version of this code. This PR reverts that change, and adds the intended version. 

The existing implementation of skipping state for controller mode relies on querying the most recent epoch for the job from the checkpoints table, and then setting that as the "ignore_before_epoch" field in the config. This approach is awkward for leader mode though, as we don't have a checkpoints table, and determining the latest epoch involves going to object storage.

There are several principled approaches we could take here—for example, introducing a "state version" field, which could be bumped to start a new state lineage for the pipeline, which would require a number of changes throughout the controller, worker, and state system. However, long-term this will be solved by a more sophisticated system of pipelines and jobs, where we create a new job for a new state lineage.

While that redesign remains in the future, this PR implements the same idea in a somewhat hacky way: when restarting a leader-mode pipeline without state, we simply replace the existing job with a new one. As checkpoints are stored by job_id, this addresses the need here without any worker or state specific code. There is some risk of introducing multiple running jobs as there is no explicit synchronization with the controller, however we mitigate by restricting these operations to pipelines in Failed or Stopped.

This PR also adds a "start without state" option and button the UI, so this is not just limited to failed pipelines.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->