### PR TITLE
Add detailed diagnostics for validate_sql API

### DIFF
--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -356,6 +356,9 @@ impl IntoResponse for HttpError {
         GlobalUdf,
         GlobalUdfCollection,
         BadData,
+        SqlDiagnostic,
+        SqlSpan,
+        SqlLocation
     )),
     tags(
         (name = "ping", description = "Ping endpoint"),

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -28,7 +28,7 @@ use arroyo_datastream::logical::{
     ChainedLogicalOperator, LogicalNode, LogicalProgram, OperatorChain, OperatorName,
 };
 use arroyo_formats::ser::ArrowSerializer;
-use arroyo_planner::{ArroyoSchemaProvider, CompiledSql, SqlConfig};
+use arroyo_planner::{ArroyoSchemaProvider, CompiledSql, PlannerError, SqlConfig};
 use arroyo_rpc::formats::Format;
 use arroyo_rpc::grpc::rpc::compiler_grpc_client::CompilerGrpcClient;
 use arroyo_rpc::public_ids::{IdTypes, generate_id};
@@ -65,7 +65,7 @@ async fn compile_sql(
     auth_data: &AuthData,
     validate_only: bool,
     db: &DatabaseSource,
-) -> Result<CompiledSql, ErrorResp> {
+) -> Result<Result<CompiledSql, PlannerError>, ErrorResp> {
     let mut schema_provider = ArroyoSchemaProvider::new();
 
     let global_udfs = fetch_get_udfs(&db.client().await?, &auth_data.organization_id)
@@ -174,15 +174,14 @@ async fn compile_sql(
         schema_provider.add_connection_profile(profile);
     }
 
-    arroyo_planner::parse_and_get_program(
+    Ok(arroyo_planner::parse_and_get_program(
         &query,
         schema_provider,
         SqlConfig {
             default_parallelism: parallelism,
         },
     )
-    .await
-    .map_err(|err| bad_request(err.to_string()))
+    .await)
 }
 
 fn set_parallelism(program: &mut LogicalProgram, parallelism: usize) {
@@ -569,7 +568,7 @@ pub async fn validate_query(
         true,
         &state.database,
     )
-    .await
+    .await?
     {
         Ok(CompiledSql { program, .. }) => QueryValidationResult {
             graph: Some(program.try_into().map_err(log_and_map)?),
@@ -577,7 +576,7 @@ pub async fn validate_query(
         },
         Err(e) => QueryValidationResult {
             graph: None,
-            errors: vec![e.message],
+            errors: e.diagnostics,
         },
     };
 
@@ -660,7 +659,7 @@ async fn create_pipeline_inner(
         false,
         &state.database,
     )
-    .await?;
+    .await??;
 
     let pipeline_id = create_pipeline_int(
         pipeline_post.name,
@@ -718,7 +717,7 @@ pub async fn create_preview_pipeline(
         false,
         &state.database,
     )
-    .await?;
+    .await??;
 
     let pipeline_id = create_pipeline_int(
         format!("preview_{}", to_millis(SystemTime::now())),

--- a/crates/arroyo-api/src/rest_utils.rs
+++ b/crates/arroyo-api/src/rest_utils.rs
@@ -1,4 +1,5 @@
 use crate::{AuthData, cloud};
+use arroyo_planner::PlannerError;
 use arroyo_rpc::log_event;
 use axum::Json;
 use axum::extract::rejection::JsonRejection;
@@ -64,6 +65,20 @@ pub fn map_delete_err(name: &str, user: &str, error: DbError) -> ErrorResp {
         ))
     } else {
         error.into()
+    }
+}
+
+impl From<PlannerError> for ErrorResp {
+    fn from(value: PlannerError) -> Self {
+        let mut message = "Failed to plan query:".to_string();
+        for d in &value.diagnostics {
+            message.push_str(&format!("\n * {}", d.message));
+        }
+
+        ErrorResp {
+            status_code: StatusCode::BAD_REQUEST,
+            message,
+        }
     }
 }
 

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -64,6 +64,7 @@ use arroyo_connectors::connectors;
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_datastream::optimizers::ChainingOptimizer;
 use arroyo_operator::connector::Connection;
+use arroyo_rpc::api_types::pipelines::{SqlDiagnostic, SqlLocation, SqlSpan};
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::{TIMESTAMP_FIELD, duration_from_sql};
 use arroyo_udf_host::ParsedUdfFile;
@@ -548,17 +549,52 @@ impl Default for SqlConfig {
     }
 }
 
+#[derive(Debug)]
+pub struct PlannerError {
+    pub diagnostics: Vec<SqlDiagnostic>,
+}
+
 pub async fn parse_and_get_program(
     query: &str,
     schema_provider: ArroyoSchemaProvider,
     config: SqlConfig,
-) -> Result<CompiledSql> {
+) -> Result<CompiledSql, PlannerError> {
     let query = query.to_string();
 
     if query.trim().is_empty() {
-        return plan_err!("Query is empty");
+        return Err(PlannerError {
+            diagnostics: vec![SqlDiagnostic::message("Query is empty!")],
+        });
     }
-    parse_and_get_arrow_program(query, schema_provider, config).await
+    parse_and_get_arrow_program(query, schema_provider, config)
+        .await
+        .map_err(|e| {
+            let diagnostics = e
+                .iter()
+                .map(|error| {
+                    let diagnostic = error.diagnostic();
+                    SqlDiagnostic {
+                        message: diagnostic
+                            .map(|diagnostic| diagnostic.message.clone())
+                            .unwrap_or_else(|| error.to_string()),
+                        span: diagnostic.and_then(|diagnostic| {
+                            diagnostic.span.map(|span| SqlSpan {
+                                start: SqlLocation {
+                                    line: span.start.line,
+                                    column: span.start.column,
+                                },
+                                end: SqlLocation {
+                                    line: span.end.line,
+                                    column: span.end.column,
+                                },
+                            })
+                        }),
+                    }
+                })
+                .collect();
+
+            PlannerError { diagnostics }
+        })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -57,8 +57,7 @@ use datafusion::{
     },
 };
 use itertools::Itertools;
-use sqlparser::ast;
-use sqlparser::ast::TableConstraint;
+use sqlparser::ast::{self, TableConstraint};
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 use tracing::warn;
@@ -140,7 +139,10 @@ fn produce_optimized_plan(
     statement: &Statement,
     schema_provider: &ArroyoSchemaProvider,
 ) -> Result<LogicalPlan> {
-    let sql_to_rel = SqlToRel::new(schema_provider);
+    let sql_to_rel = SqlToRel::new_with_options(
+        schema_provider,
+        datafusion::sql::planner::ParserOptions::new().with_collect_spans(true),
+    );
 
     let plan = sql_to_rel.sql_statement_to_plan(statement.clone())?;
 

--- a/crates/arroyo-planner/src/test/plan_tests.rs
+++ b/crates/arroyo-planner/src/test/plan_tests.rs
@@ -47,7 +47,13 @@ async fn validate_query(path: &Path) {
     if fail {
         let err = result.unwrap_err();
         if let Some(error_message) = error_message {
-            let err: Vec<_> = err.error.split_whitespace().collect();
+            let err: Vec<_> = err
+                .diagnostics
+                .first()
+                .unwrap()
+                .message
+                .split_whitespace()
+                .collect();
             let err = err.join(" ");
             assert!(
                 err.contains(error_message),

--- a/crates/arroyo-planner/src/test/plan_tests.rs
+++ b/crates/arroyo-planner/src/test/plan_tests.rs
@@ -47,8 +47,7 @@ async fn validate_query(path: &Path) {
     if fail {
         let err = result.unwrap_err();
         if let Some(error_message) = error_message {
-            let err_s = err.to_string();
-            let err: Vec<_> = err_s.split_whitespace().collect();
+            let err: Vec<_> = err.error.split_whitespace().collect();
             let err = err.join(" ");
             assert!(
                 err.contains(error_message),
@@ -56,7 +55,7 @@ async fn validate_query(path: &Path) {
             );
         }
     } else if let Err(e) = result {
-        println!("{e}");
-        panic!("{}", e);
+        println!("{e:?}");
+        panic!("{e:?}");
     }
 }

--- a/crates/arroyo-planner/src/test/queries/virtual_bad_schema.sql
+++ b/crates/arroyo-planner/src/test/queries/virtual_bad_schema.sql
@@ -1,4 +1,4 @@
---fail=Schema error: No field named notfield. Valid fields are input.length.
+--fail='notfield' not found
 create table input (
     length JSON,
     diff INT GENERATED ALWAYS AS (notfield) STORED

--- a/crates/arroyo-planner/src/types.rs
+++ b/crates/arroyo-planner/src/types.rs
@@ -1,15 +1,14 @@
-use std::{sync::Arc, time::SystemTime};
-
 use arrow::datatypes::{DataType, Field};
-use datafusion::common::{Result, plan_datafusion_err, plan_err};
-
 use arrow_schema::{DECIMAL_DEFAULT_SCALE, DECIMAL128_MAX_PRECISION, IntervalUnit, TimeUnit};
 use arroyo_types::ArroyoExtensionType;
-use datafusion::error::DataFusionError;
+use datafusion::common::{
+    DataFusionError, Diagnostic, Result, Span, plan_datafusion_err, plan_err,
+};
 use datafusion::sql::sqlparser::ast::{
-    ArrayElemTypeDef, DataType as SQLDataType, ExactNumberInfo, TimezoneInfo,
+    ArrayElemTypeDef, DataType as SQLDataType, ExactNumberInfo, Spanned, TimezoneInfo,
 };
 use itertools::Itertools;
+use std::{sync::Arc, time::SystemTime};
 // Pulled from DataFusion
 
 pub(crate) fn convert_data_type(
@@ -117,7 +116,13 @@ fn convert_simple_data_type(
 
             Ok(DataType::Struct(fields.into()))
         }
-        _ => return plan_err!("Unsupported SQL type {sql_type:?}"),
+        SQLDataType::Custom(name, _) => {
+            let message = format!("Unsupported SQL type '{name}'");
+            let diagnostic =
+                Diagnostic::new_error(message.clone(), Span::try_from_sqlparser_span(name.span()));
+            return plan_err!("{message}"; diagnostic = diagnostic);
+        }
+        _ => return plan_err!("Unsupported SQL type '{sql_type}'"),
     };
 
     Ok((dt?, None))

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-
 use crate::api_types::udfs::Udf;
 use crate::errors::ErrorDomain;
 use crate::grpc as grpc_proto;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -17,7 +16,34 @@ pub struct ValidateQueryPost {
 #[serde(rename_all = "snake_case")]
 pub struct QueryValidationResult {
     pub graph: Option<PipelineGraph>,
-    pub errors: Vec<String>,
+    pub errors: Vec<SqlDiagnostic>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
+pub struct SqlLocation {
+    pub line: u64,
+    pub column: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
+pub struct SqlSpan {
+    pub start: SqlLocation,
+    pub end: SqlLocation,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
+pub struct SqlDiagnostic {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<SqlSpan>,
+}
+impl SqlDiagnostic {
+    pub fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            span: None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/arroyo/src/run.rs
+++ b/crates/arroyo/src/run.rs
@@ -167,7 +167,7 @@ async fn run_pipeline(
     if !errors.errors.is_empty() {
         eprintln!("There were some issues with the provided query");
         for error in errors.errors {
-            eprintln!("  * {error}");
+            eprintln!("  * {}", error.message);
         }
         exit(1);
     }

--- a/crates/integ/tests/api_tests.rs
+++ b/crates/integ/tests/api_tests.rs
@@ -223,7 +223,7 @@ async fn basic_pipeline() {
         .unwrap()
         .into_inner();
 
-    assert_eq!(valid.errors, Vec::<String>::new());
+    assert!(valid.errors.is_empty());
     assert!(valid.graph.is_some());
 
     let (pipeline_id, job_id, _) = start_and_monitor(test_id, &query, &[], 10).await.unwrap();

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -907,7 +907,7 @@ export interface components {
             message_name?: string | null;
         };
         QueryValidationResult: {
-            errors: string[];
+            errors: components["schemas"]["SqlDiagnostic"][];
             graph?: components["schemas"]["PipelineGraph"] | null;
         };
         RawBytesFormat: Record<string, never>;
@@ -936,6 +936,20 @@ export interface components {
             required?: boolean;
             readonly sql_name?: string | null;
         });
+        SqlDiagnostic: {
+            message: string;
+            span?: components["schemas"]["SqlSpan"] | null;
+        };
+        SqlLocation: {
+            /** Format: int64 */
+            column: number;
+            /** Format: int64 */
+            line: number;
+        };
+        SqlSpan: {
+            end: components["schemas"]["SqlLocation"];
+            start: components["schemas"]["SqlLocation"];
+        };
         /** @enum {string} */
         StopType: "none" | "checkpoint" | "graceful" | "immediate" | "force";
         StructField: {

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -33,6 +33,7 @@ export type SubtaskCheckpointGroup = schemas['SubtaskCheckpointGroup'];
 export type GlobalUdf = schemas['GlobalUdf'];
 export type PipelineLocalUdf = schemas['Udf'];
 export type UdfValidationResult = schemas['UdfValidationResult'];
+export type SqlDiagnostic = schemas['SqlDiagnostic'];
 
 const base = window.__ARROYO_BASENAME.replace(/\/$/, '') || '';
 const BASE_URL = `${base}/api`;

--- a/webui/src/routes/pipelines/CodeEditor.tsx
+++ b/webui/src/routes/pipelines/CodeEditor.tsx
@@ -1,29 +1,119 @@
-import Editor from '@monaco-editor/react';
-import React, { Dispatch } from 'react';
+import Editor, { Monaco, OnMount } from '@monaco-editor/react';
+import React, { Dispatch, useCallback, useEffect, useRef } from 'react';
 import { Flex } from '@chakra-ui/react';
+import { editor } from 'monaco-editor';
+import { SqlDiagnostic } from '../../lib/data_fetching';
+
+const SQL_DIAGNOSTIC_OWNER = 'arroyo-sql-diagnostics';
+
+function diagnosticRange(model: editor.ITextModel, diagnostic: SqlDiagnostic) {
+  if (!diagnostic.span) {
+    return undefined;
+  }
+
+  return model.validateRange({
+    startLineNumber: diagnostic.span.start.line,
+    startColumn: diagnostic.span.start.column,
+    endLineNumber: diagnostic.span.end.line,
+    endColumn: diagnostic.span.end.column,
+  });
+}
 
 export function CodeEditor({
   code,
   setCode,
   readOnly,
   language,
+  diagnostics = [],
+  selectedDiagnostic,
 }: {
   code: string;
   setCode?: Dispatch<string>;
   readOnly?: boolean;
   language?: string;
+  diagnostics?: SqlDiagnostic[];
+  selectedDiagnostic?: SqlDiagnostic;
 }) {
+  const editorRef = useRef<editor.IStandaloneCodeEditor>();
+  const monacoRef = useRef<Monaco>();
+
   const onChange = (value: string | undefined) => {
     if (setCode != null) {
       setCode(value || '');
     }
   };
 
+  const updateMarkers = useCallback(
+    (mountedEditor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
+      const model = mountedEditor.getModel();
+      if (!model) {
+        return;
+      }
+
+      const markers = diagnostics.flatMap(diagnostic => {
+        const range = diagnosticRange(model, diagnostic);
+        if (!range) {
+          return [];
+        }
+
+        return [
+          {
+            ...range,
+            message: diagnostic.message,
+            severity: monaco.MarkerSeverity.Error,
+            source: 'Arroyo SQL',
+          },
+        ];
+      });
+
+      monaco.editor.setModelMarkers(model, SQL_DIAGNOSTIC_OWNER, markers);
+    },
+    [diagnostics]
+  );
+
+  const onMount: OnMount = (mountedEditor, monaco) => {
+    editorRef.current = mountedEditor;
+    monacoRef.current = monaco;
+    updateMarkers(mountedEditor, monaco);
+  };
+
+  useEffect(() => {
+    if (editorRef.current && monacoRef.current) {
+      updateMarkers(editorRef.current, monacoRef.current);
+    }
+  }, [updateMarkers]);
+
+  useEffect(() => {
+    const mountedEditor = editorRef.current;
+    const monaco = monacoRef.current;
+    const model = mountedEditor?.getModel();
+    if (!mountedEditor || !monaco || !model || !selectedDiagnostic) {
+      return;
+    }
+
+    const range = diagnosticRange(model, selectedDiagnostic);
+    if (range) {
+      mountedEditor.setSelection(range);
+      mountedEditor.revealRangeInCenter(range, monaco.editor.ScrollType.Smooth);
+      mountedEditor.focus();
+    }
+  }, [selectedDiagnostic]);
+
+  useEffect(() => {
+    return () => {
+      const model = editorRef.current?.getModel();
+      if (model && monacoRef.current) {
+        monacoRef.current.editor.setModelMarkers(model, SQL_DIAGNOSTIC_OWNER, []);
+      }
+    };
+  }, []);
+
   return (
     <Flex py={5} pr={5} flex={1}>
       <Editor
         defaultLanguage={language || 'sql'}
         onChange={onChange}
+        onMount={onMount}
         theme="vs-dark"
         options={{ minimap: { enabled: false }, wordWrap: 'on', readOnly: readOnly || false }}
         value={code}

--- a/webui/src/routes/pipelines/CreatePipeline.tsx
+++ b/webui/src/routes/pipelines/CreatePipeline.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   HStack,
   Icon,
+  Link,
   Spinner,
   Stack,
   Tab,
@@ -25,6 +26,7 @@ import { SqlOptions } from '../../lib/types';
 import {
   JobLogMessage,
   PipelineLocalUdf,
+  SqlDiagnostic,
   post,
   useOperatorErrors,
   usePipeline,
@@ -54,6 +56,7 @@ import UdfLabel from '../udfs/UdfLabel';
 import { PiFileSqlDuotone, PiFunction, PiGraph } from 'react-icons/pi';
 import { BiTable } from 'react-icons/bi';
 import { IoWarningOutline } from 'react-icons/io5';
+import { VscError } from 'react-icons/vsc';
 import { useNavbar } from '../../App';
 import { FiDatabase } from 'react-icons/fi';
 import CatalogTab from './CatalogTab';
@@ -101,6 +104,9 @@ export function CreatePipeline() {
   const [udfValidationApiError, setUdfValidationApiError] = useState<any | undefined>(undefined);
   const [validationInProgress, setValidationInProgress] = useState<boolean>(false);
   const [startingPreview, setStartingPreview] = useState<boolean>(false);
+  const [selectedQueryDiagnostic, setSelectedQueryDiagnostic] = useState<
+    SqlDiagnostic | undefined
+  >();
 
   const { tourActive, tourStep, setTourStep, disableTour } = useContext(TourContext);
 
@@ -109,7 +115,8 @@ export function CreatePipeline() {
 
   const { setMenuItems } = useNavbar();
 
-  const hasValidationErrors = queryValidation?.errors?.length || hasUdfValidationErrors;
+  const queryDiagnostics = queryInput === queryInputToCheck ? queryValidation?.errors ?? [] : [];
+  const hasValidationErrors = queryDiagnostics.length > 0 || hasUdfValidationErrors;
 
   useEffect(() => {
     setMenuItems([
@@ -444,16 +451,55 @@ export function CreatePipeline() {
     let queryErrors = <></>;
     let udfErrors = <></>;
 
-    if (queryValidation?.errors) {
+    if (queryDiagnostics.length > 0) {
       queryErrors = (
         <Flex flexDirection={'column'} py={3} gap={2}>
-          <Flex gap={1} onClick={() => openTab('query')} cursor={'pointer'} w={'min-content'}>
+          <Flex gap={1} alignItems={'center'}>
             <Icon as={PiFileSqlDuotone} boxSize={5} />
             <Text>Query</Text>
+            <Text color={'gray.500'} fontSize={'sm'}>
+              {queryDiagnostics.length} {queryDiagnostics.length === 1 ? 'error' : 'errors'}
+            </Text>
           </Flex>
-          <SyntaxHighlighter language="text" style={vs2015} customStyle={{ borderRadius: '5px' }}>
-            {queryValidation.errors[0]}
-          </SyntaxHighlighter>
+          <Flex flexDirection={'column'} borderY={'1px solid'} borderColor={'gray.700'}>
+            {queryDiagnostics.map((diagnostic, index) => {
+              const location = diagnostic.span?.start;
+              return (
+                <Flex
+                  key={`${diagnostic.message}-${location?.line}-${location?.column}-${index}`}
+                  alignItems={'flex-start'}
+                  gap={2}
+                  px={2}
+                  py={1.5}
+                  textAlign={'left'}
+                  borderBottom={index < queryDiagnostics.length - 1 ? '1px solid' : undefined}
+                  borderColor={'gray.700'}
+                  backgroundColor={'#1e1e1e'}
+                >
+                  <Icon as={VscError} color={'red.400'} boxSize={4} mt={0.5} flexShrink={0} />
+                  <Text fontFamily={'monospace'} fontSize={'sm'} flex={1} userSelect={'text'}>
+                    {diagnostic.message}
+                  </Text>
+                  {location && (
+                    <Link
+                      href={'#'}
+                      color={'gray.500'}
+                      fontFamily={'monospace'}
+                      fontSize={'xs'}
+                      whiteSpace={'nowrap'}
+                      onClick={event => {
+                        event.preventDefault();
+                        openTab('query');
+                        setSelectedQueryDiagnostic({ ...diagnostic });
+                      }}
+                    >
+                      Ln {location.line}, Col {location.column}
+                    </Link>
+                  )}
+                </Flex>
+              );
+            })}
+          </Flex>
         </Flex>
       );
     }
@@ -663,6 +709,8 @@ export function CreatePipeline() {
                   updateQuery={updateQuery}
                   previewOptions={previewOptions}
                   setPreviewOptions={setPreviewOptions}
+                  queryDiagnostics={queryDiagnostics}
+                  selectedQueryDiagnostic={selectedQueryDiagnostic}
                   job={job}
                 />
               </Panel>

--- a/webui/src/routes/pipelines/PipelineEditorTabs.tsx
+++ b/webui/src/routes/pipelines/PipelineEditorTabs.tsx
@@ -36,7 +36,7 @@ import UdfEditTab from '../udfs/UdfEditTab';
 import { FiCheckCircle, FiPlay } from 'react-icons/fi';
 import { IoRocketOutline } from 'react-icons/io5';
 import { PreviewOptions } from './CreatePipeline';
-import { Job } from '../../lib/data_fetching';
+import { Job, SqlDiagnostic } from '../../lib/data_fetching';
 
 export interface PipelineEditorTabsProps {
   queryInput: string;
@@ -49,6 +49,8 @@ export interface PipelineEditorTabsProps {
   updateQuery: (s: string) => void;
   previewOptions: PreviewOptions;
   setPreviewOptions: Dispatch<PreviewOptions>;
+  queryDiagnostics: SqlDiagnostic[];
+  selectedQueryDiagnostic?: SqlDiagnostic;
   job?: Job;
 }
 
@@ -63,6 +65,8 @@ const PipelineEditorTabs: React.FC<PipelineEditorTabsProps> = ({
   updateQuery,
   previewOptions,
   setPreviewOptions,
+  queryDiagnostics,
+  selectedQueryDiagnostic,
   job,
 }) => {
   const { openedUdfs, isGlobal, editorTab, handleEditorTabChange } = useContext(LocalUdfsContext);
@@ -136,7 +140,12 @@ const PipelineEditorTabs: React.FC<PipelineEditorTabsProps> = ({
   const tabPanels = (
     <TabPanels flex={1}>
       <TabPanel height={'100%'} p={0} display={'flex'}>
-        <CodeEditor code={queryInput} setCode={updateQuery} />
+        <CodeEditor
+          code={queryInput}
+          setCode={updateQuery}
+          diagnostics={queryDiagnostics}
+          selectedDiagnostic={selectedQueryDiagnostic}
+        />
       </TabPanel>
       {openedUdfs.map(udf => {
         let globalBanner = <></>;


### PR DESCRIPTION
This PR adds more sophisticated diagnostics to the validate_sql endpoint. Previously, we returned a list of strings. Now we return an object that includes a message and optional spans, allowing us to render IDE-style squiggles in our code editor:

<img width="446" height="286" alt="image" src="https://github.com/user-attachments/assets/a62881b7-61a1-47b6-98a1-617da84a2816" />

This relies on Datafusion's new Diagnostic support. This is somewhat basic in our current DF version (48) and doesn't yet have good integration with the parser, so a number of errors will not have proper spans associated with them. This will improve as we upgrade DF and sql parser.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->