### PR TITLE
Fix race condition that could prevent stopping checkpoint finalization in leader mode

### DIFF
--- a/crates/arroyo-worker/src/job_controller/controller.rs
+++ b/crates/arroyo-worker/src/job_controller/controller.rs
@@ -51,6 +51,7 @@ pub struct WorkerJobController {
     cleanup_backoff: Option<SystemTime>,
     rx: Receiver<RunningMessage>,
     stopping: bool,
+    checkpoint_stopping: bool,
     failing: bool,
     final_checkpoint_started: bool,
     replay_commits: Option<(CommitReq, CommitPermit)>,
@@ -279,6 +280,7 @@ impl WorkerJobController {
             cleanup_backoff: None,
             rx,
             stopping: false,
+            checkpoint_stopping: false,
             failing: false,
             final_checkpoint_started: false,
             replay_commits,
@@ -523,12 +525,14 @@ impl WorkerJobController {
 
         if self.stopping {
             if stop_mode == JobStopMode::JobStopImmediate {
+                self.checkpoint_stopping = false;
                 self.stop_job(StopMode::Immediate).await?;
             }
             return Ok(());
         }
 
         self.stopping = true;
+        self.checkpoint_stopping = stop_mode == JobStopMode::JobStopCheckpoint;
         self.status.transition(rpc::JobState::JobStopping)?;
 
         match stop_mode {
@@ -557,11 +561,6 @@ impl WorkerJobController {
         // have any tasks failed?
         if let Some(event) = self.model.task_failed() {
             return Ok(ControllerProgress::TaskFailed(event));
-        }
-
-        // if we're stopping and all tasks have finished, we're done
-        if self.stopping && self.model.all_tasks_finished() {
-            return Ok(ControllerProgress::Stopped);
         }
 
         if !self.stopping && self.model.all_tasks_finished() {
@@ -622,7 +621,9 @@ impl WorkerJobController {
             }
         }
 
-        if self.stopping && !self.final_checkpoint_started && self.model.checkpoint_state.is_none()
+        if self.checkpoint_stopping
+            && !self.final_checkpoint_started
+            && self.model.checkpoint_state.is_none()
         {
             info!(
                 message = "retrying deferred final checkpoint",
@@ -641,6 +642,16 @@ impl WorkerJobController {
         {
             // or do we need to start checkpointing?
             self.checkpoint(false).await?;
+        }
+
+        // on final checkpoint we have to wait until we've written the metadata before shutting
+        // down the job controller
+        if self.stopping
+            && self.model.all_tasks_finished()
+            && (!self.checkpoint_stopping
+                || (self.final_checkpoint_started && self.model.checkpoint_state.is_none()))
+        {
+            return Ok(ControllerProgress::Stopped);
         }
 
         // do we need to start cleaning?

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -1096,13 +1096,6 @@ impl WorkerGrpc for WorkerServer {
     ) -> Result<Response<JobFinishedResp>, Status> {
         let is_worker_leader = self.state.job_controller_tx.get().is_some();
 
-        let mut phase = self.state.phase.lock().unwrap();
-        if let WorkerExecutionPhase::Running(engine_state) = &*phase {
-            engine_state.shutdown_guard.cancel();
-        }
-        *phase = WorkerExecutionPhase::Idle;
-        drop(phase);
-
         if is_worker_leader {
             // Keep the worker leader reachable so the controller can observe the
             // terminal job status before explicitly stopping the worker process.
@@ -1114,6 +1107,13 @@ impl WorkerGrpc for WorkerServer {
                 generation = self.state.worker_context.generation,
             );
         } else {
+            let mut phase = self.state.phase.lock().unwrap();
+            if let WorkerExecutionPhase::Running(engine_state) = &*phase {
+                engine_state.shutdown_guard.cancel();
+            }
+            *phase = WorkerExecutionPhase::Idle;
+            drop(phase);
+
             let token = self.shutdown_guard.token();
             tokio::task::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/integ/tests/api_tests.rs
+++ b/crates/integ/tests/api_tests.rs
@@ -2,7 +2,7 @@ use anyhow::bail;
 use std::collections::HashSet;
 use std::env;
 use std::sync::{Arc, OnceLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use arroyo_openapi::Client;
 use arroyo_openapi::types::{
@@ -512,30 +512,23 @@ async fn wait_until_next_checkpoint_is_underway(
     job_id: &str,
     completed_epoch: i64,
 ) {
-    let checkpoints = get_client()
-        .get_job_checkpoints()
-        .pipeline_id(pipeline_id)
-        .job_id(job_id)
-        .send()
-        .await
-        .unwrap()
-        .into_inner();
-    let finish_time = checkpoints
-        .data
-        .iter()
-        .find(|checkpoint| checkpoint.epoch == completed_epoch)
-        .and_then(|checkpoint| checkpoint.finish_time)
-        .expect("completed checkpoint should have a finish time");
+    loop {
+        let checkpoints = get_client()
+            .get_job_checkpoints()
+            .pipeline_id(pipeline_id)
+            .job_id(job_id)
+            .send()
+            .await
+            .unwrap()
+            .into_inner();
 
-    // Checkpoints run every second in this test. Starting the stop 1.25 seconds after the
-    // previous checkpoint completed puts it behind the next scheduled checkpoint.
-    let target_micros = finish_time + 1_250_000;
-    let now_micros = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_micros() as i64;
-    if target_micros > now_micros {
-        tokio::time::sleep(Duration::from_micros((target_micros - now_micros) as u64)).await;
+        if checkpoints.data.iter().any(|checkpoint| {
+            checkpoint.epoch > completed_epoch && checkpoint.finish_time.is_none()
+        }) {
+            return;
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/crates/integ/tests/api_tests.rs
+++ b/crates/integ/tests/api_tests.rs
@@ -1,7 +1,8 @@
 use anyhow::bail;
+use std::collections::HashSet;
 use std::env;
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use arroyo_openapi::Client;
 use arroyo_openapi::types::{
@@ -10,7 +11,9 @@ use arroyo_openapi::types::{
     ValidateUdfPost, builder,
 };
 use rand::random;
+use rdkafka::Message;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
+use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::{ClientConfig, ClientContext};
 use serde_json::json;
 use tracing::info;
@@ -105,6 +108,7 @@ async fn start_and_monitor(
     query: &str,
     udfs: &[&str],
     checkpoints_to_wait: u32,
+    verify_checkpoint_details: bool,
 ) -> anyhow::Result<(String, String, i64)> {
     let api_client = get_client();
 
@@ -145,18 +149,19 @@ async fn start_and_monitor(
             .find(|c| c.epoch == checkpoints_to_wait as i64)
             && checkpoint.finish_time.is_some()
         {
-            // get details
-            let details = api_client
-                .get_checkpoint_details()
-                .pipeline_id(&pipeline_id)
-                .job_id(&job.id)
-                .epoch(checkpoint.epoch)
-                .send()
-                .await
-                .unwrap()
-                .into_inner();
+            if verify_checkpoint_details {
+                let details = api_client
+                    .get_checkpoint_details()
+                    .pipeline_id(&pipeline_id)
+                    .job_id(&job.id)
+                    .epoch(checkpoint.epoch)
+                    .send()
+                    .await
+                    .unwrap()
+                    .into_inner();
 
-            assert!(!details.data.is_empty());
+                assert!(!details.data.is_empty());
+            }
 
             return Ok((pipeline_id, job.id.clone(), run_id));
         }
@@ -226,7 +231,9 @@ async fn basic_pipeline() {
     assert!(valid.errors.is_empty());
     assert!(valid.graph.is_some());
 
-    let (pipeline_id, job_id, _) = start_and_monitor(test_id, &query, &[], 10).await.unwrap();
+    let (pipeline_id, job_id, _) = start_and_monitor(test_id, &query, &[], 10, true)
+        .await
+        .unwrap();
 
     let sink_id = valid
         .graph
@@ -405,7 +412,9 @@ select my_double(cast(counter as bigint)) from impulse;
 
     let run_id: u32 = random();
 
-    let (pipeline_id, _job_id, _) = start_and_monitor(run_id, query, &[udf], 3).await.unwrap();
+    let (pipeline_id, _job_id, _) = start_and_monitor(run_id, query, &[udf], 3, true)
+        .await
+        .unwrap();
 
     // stop job
     patch_and_wait(
@@ -453,6 +462,175 @@ async fn delete_topic(client: &AdminClient<impl ClientContext>, topic: &str) {
         .delete_topics(&[topic], &AdminOptions::new())
         .await
         .expect("deletion should have worked");
+}
+
+fn create_kafka_consumer(topic: &str) -> StreamConsumer {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .set("group.id", format!("integ-{}", random::<u32>()))
+        .create()
+        .expect("consumer creation should succeed");
+    consumer
+        .subscribe(&[topic])
+        .expect("consumer subscription should succeed");
+    consumer
+}
+
+async fn read_kafka_counters(consumer: &StreamConsumer) -> anyhow::Result<Vec<i64>> {
+    let mut counters = vec![];
+
+    loop {
+        let wait = if counters.is_empty() {
+            Duration::from_secs(10)
+        } else {
+            Duration::from_secs(1)
+        };
+
+        match tokio::time::timeout(wait, consumer.recv()).await {
+            Ok(Ok(message)) => {
+                let payload = message
+                    .payload()
+                    .ok_or_else(|| anyhow::anyhow!("Kafka record had no payload"))?;
+                let value: serde_json::Value = serde_json::from_slice(payload)?;
+                let counter = value
+                    .get("counter")
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| anyhow::anyhow!("Kafka record had no counter: {value}"))?;
+                counters.push(counter);
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(_) if counters.is_empty() => bail!("timed out waiting for Kafka output"),
+            Err(_) => return Ok(counters),
+        }
+    }
+}
+
+async fn wait_until_next_checkpoint_is_underway(
+    pipeline_id: &str,
+    job_id: &str,
+    completed_epoch: i64,
+) {
+    let checkpoints = get_client()
+        .get_job_checkpoints()
+        .pipeline_id(pipeline_id)
+        .job_id(job_id)
+        .send()
+        .await
+        .unwrap()
+        .into_inner();
+    let finish_time = checkpoints
+        .data
+        .iter()
+        .find(|checkpoint| checkpoint.epoch == completed_epoch)
+        .and_then(|checkpoint| checkpoint.finish_time)
+        .expect("completed checkpoint should have a finish time");
+
+    // Checkpoints run every second in this test. Starting the stop 1.25 seconds after the
+    // previous checkpoint completed puts it behind the next scheduled checkpoint.
+    let target_micros = finish_time + 1_250_000;
+    let now_micros = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as i64;
+    if target_micros > now_micros {
+        tokio::time::sleep(Duration::from_micros((target_micros - now_micros) as u64)).await;
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_stop_does_not_duplicate_output() {
+    let api_client = get_client();
+    let test_id: u32 = random();
+    let topic = format!("checkpoint_stop_{test_id}");
+    let kafka_admin = create_kafka_admin();
+    create_topic(&kafka_admin, &topic).await;
+    let consumer = create_kafka_consumer(&topic);
+
+    let query = format!(
+        r#"
+CREATE TABLE impulse WITH (
+    connector = 'impulse',
+    event_rate = '100'
+);
+
+CREATE TABLE output (
+    counter BIGINT
+) WITH (
+    connector = 'kafka',
+    type = 'sink',
+    bootstrap_servers = 'localhost:9092',
+    format = 'json',
+    topic = '{topic}'
+);
+
+INSERT INTO output SELECT counter FROM impulse;
+"#
+    );
+
+    let (pipeline_id, job_id, _) = start_and_monitor(test_id, &query, &[], 2, false)
+        .await
+        .unwrap();
+
+    wait_until_next_checkpoint_is_underway(&pipeline_id, &job_id, 2).await;
+
+    // The stopping checkpoint follows the in-progress scheduled checkpoint. Records covered by
+    // the stopping checkpoint must not be emitted again after restart.
+    let run_id = patch_and_wait(
+        &pipeline_id,
+        None,
+        PipelinePatch::builder().stop(StopType::Checkpoint),
+        "Stopped",
+    )
+    .await
+    .unwrap();
+    let first_run = read_kafka_counters(&consumer).await.unwrap();
+
+    patch_and_wait(
+        &pipeline_id,
+        Some(run_id),
+        PipelinePatch::builder().stop(StopType::None),
+        "Running",
+    )
+    .await
+    .unwrap();
+
+    // Run long enough to replay every record between the scheduled and stopping checkpoints if
+    // recovery incorrectly chose the scheduled checkpoint.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    patch_and_wait(
+        &pipeline_id,
+        None,
+        PipelinePatch::builder().stop(StopType::Immediate),
+        "Stopped",
+    )
+    .await
+    .unwrap();
+
+    let second_run = read_kafka_counters(&consumer).await.unwrap();
+    let first_run: HashSet<_> = first_run.into_iter().collect();
+    let mut duplicates: Vec<_> = second_run
+        .iter()
+        .copied()
+        .filter(|counter| first_run.contains(counter))
+        .collect();
+    duplicates.sort_unstable();
+    duplicates.dedup();
+
+    api_client
+        .delete_pipeline()
+        .id(&pipeline_id)
+        .send()
+        .await
+        .unwrap();
+    drop(consumer);
+    delete_topic(&kafka_admin, &topic).await;
+
+    assert!(
+        duplicates.is_empty(),
+        "checkpoint-stop recovery duplicated counters: {duplicates:?}"
+    );
 }
 
 #[tokio::test]
@@ -622,6 +800,7 @@ async fn connection_table() {
         &format!("select * from {};", connection_table.name),
         &[],
         5,
+        true,
     )
     .await
     .unwrap();


### PR DESCRIPTION
This PR fixes a bug in leader mode that could cause final checkpoints to be skipped on recovery, rolling back to the previous checkpoint, despite the final checkpoint committing.

In leader mode, we orchestrate the shutdown process within the WorkerJobController. When stopping with checkpoint, we first initiate the checkpoint, then follow the normal shutdown procedure of waiting for all tasks to finish. This ensures that the tasks write their checkpoint state before we shut down, but does not ensure that we write the checkpoint metadata.

This PR fixes that by adding a new checkpoint_stopping state within the controller, which blocks shutdown until the checkpoint has completed. 

It also improves the integration tests to catch this class of error by validating correctness of the output.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->