### PR TITLE
correctly handle errors while validating existing files in multipart recovery

### DIFF
--- a/crates/arroyo-connectors/src/filesystem/sink/v2/uploads.rs
+++ b/crates/arroyo-connectors/src/filesystem/sink/v2/uploads.rs
@@ -175,28 +175,45 @@ async fn validate_already_there(
 ) -> DataflowResult<()> {
     // check if the file is already there with the correct size -- in which case it means
     // that we've already finalized it
-    if let Ok(meta) = storage.head(path.as_ref()).await.map_err(map_storage_error) {
-        if meta.size != expected_size {
-            Err(connector_err!(
-                External,
-                NoRetry,
-                "file written to {} should have length of {}, not {}",
-                path,
-                expected_size,
-                meta.size,
-            ))
-        } else {
-            debug!(
-                path = %path,
-                size = expected_size,
-                original_error = %e,
-                "file already exists with expected size; \
-                 treating as successful recovery from prior finalization"
-            );
-            Ok(())
+    match storage.head(path.as_ref()).await {
+        Ok(meta) => {
+            if meta.size != expected_size {
+                Err(connector_err!(
+                    External,
+                    NoRetry,
+                    "file written to {} should have length of {}, not {}",
+                    path,
+                    expected_size,
+                    meta.size,
+                ))
+            } else {
+                debug!(
+                    path = %path,
+                    size = expected_size,
+                    original_error = %e,
+                    "file already exists with expected size; \
+                     treating as successful recovery from prior finalization"
+                );
+                Ok(())
+            }
         }
-    } else {
-        Err(handle_error(started, logger, e))
+        Err(head_error) => {
+            if matches!(
+                head_error,
+                StorageError::ObjectStore(object_store::Error::NotFound { .. })
+            ) {
+                // we failed to write the file; return the original write error
+                Err(handle_error(started, logger, e))
+            } else {
+                // we failed to determine the state of the file because head also failed
+                Err(connector_err!(
+                    External,
+                    WithBackoff,
+                    source: head_error.into(),
+                    "failed to validate whether failed multipart write successfully completed",
+                ))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes a bug with a sequence like this: 

1. We ttempt to complete a multipart, this is successful but we get a 500/timeout from the object store
2. We retry the completion, but now get a 404 because it's actually completed
3. We fall back to our validation logic which attempts to check for this, but the validation also fails with transient errors
4. We then return back the original error (the 404) which gets translated into a user error and fails the pipeline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->