### PR TITLE
Don't fail pipelines when checkpointing fails during restart

### DIFF
--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -1,6 +1,6 @@
 use super::{
-    JobContext, State, StateError, Transition, fatal, leader_stop_if_desired_running,
-    scheduling::Scheduling,
+    JobContext, State, StateError, Transition, controller_job_failure,
+    leader_stop_if_desired_running, scheduling::Scheduling,
 };
 use crate::JobMessage;
 use crate::states::recovering::Recovering;
@@ -71,7 +71,11 @@ impl State for LeaderRestarting {
                         }
                         resp = ctx.leader_manager.as_mut().expect("leader manager not initialized").wait_for_state(JobState::JobStopped) => {
                             return if let Err(e) = resp {
-                                Err(fatal("failed while waiting for checkpoint-stop during restart",e))
+                                ctx.handle_job_failure(*self, controller_job_failure(
+                                    format!("failed while taking final checkpoint: {e}"),
+                                    rpc::ErrorDomain::Internal,
+                                    rpc::RetryHint::WithBackoff,
+                                )).await
                             } else {
                                 Ok(Transition::next(*self, Scheduling {}))
                             };


### PR DESCRIPTION
Currently, if we fail to take the final checkpoint from a pipeline during a restart operation, we will immediately transition to failing via a Fatal error. This doesn't make any sense — there's no world in which moving to failed is a better option than either leaving the existing cluster or continuing with the restart with the last successful checkpoint. This PR changes that to choose progress; i.e., we will continue on with the restart via the Recovering state.