### PR TITLE
ci: update action versions in ci.yml to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           components: clippy, rustfmt
           toolchain: 1.95
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -26,7 +26,7 @@ jobs:
       DATABASE_URL: "postgres://arroyo:arroyo@localhost:5432/arroyo"
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
@@ -36,7 +36,7 @@ jobs:
         with:
           components: clippy, rustfmt
           toolchain: 1.95
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check Formatting
         run: cargo fmt -- --check
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         name: Setup Python
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -26,7 +26,7 @@ jobs:
       DATABASE_URL: "postgres://arroyo:arroyo@localhost:5432/arroyo"
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Updates the CI workflow to use current action versions.

Changes in .github/workflows/ci.yml:
- actions/checkout@v3 -> actions/checkout@v7 (3 occurrences)
- actions/setup-java@v3 -> actions/setup-java@v6
- actions/setup-python@v5 -> actions/setup-python@v7
- actions/cache@v4 -> actions/cache@v6.1.0

The workflow does not use the pip-install input, which setup-python v7 removed, and the setup-java step uses only distribution and java-version, which v6 keeps, so all bumps are drop-in.

Validation:
- workflow YAML parses after every change
- CI, Semgrep, lint-console, build-rust, and build-console checks pass on the branch

Scope: .github/workflows/ci.yml only. Other workflow files (binaries.yml, docker.yaml, semgrep.yml) still reference older action versions and can be follow-ups if wanted.

Commit author katsugtgz, unsigned.