### PR TITLE
Log full error chains for analytics and storage errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
 name = "arroyo-storage"
 version = "0.16.0-dev"
 dependencies = [
+ "anyhow",
  "arroyo-rpc",
  "arroyo-types",
  "async-trait",

--- a/crates/arroyo-server-common/src/lib.rs
+++ b/crates/arroyo-server-common/src/lib.rs
@@ -268,7 +268,7 @@ impl EventLogger for AnalyticsEventLogger {
                     .send()
                     .await
                 {
-                    debug!("Failed to record event: {}", e);
+                    debug!("Failed to record event: {:#}", anyhow::Error::new(e));
                 }
             });
         }

--- a/crates/arroyo-storage/Cargo.toml
+++ b/crates/arroyo-storage/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 default = []
 
 [dependencies]
+anyhow = { workspace = true }
 arroyo-types = { path = "../arroyo-types" }
 arroyo-rpc = { path = "../arroyo-rpc" }
 bytes = { workspace = true }

--- a/crates/arroyo-storage/src/lib.rs
+++ b/crates/arroyo-storage/src/lib.rs
@@ -189,7 +189,7 @@ macro_rules! storage_retry {
             10,
             Duration::from_millis(100),
             Duration::from_secs(10),
-            |e| error!("Error: {}. Retrying...", e),
+            |e| error!("Error: {:#}. Retrying...", anyhow::Error::new(e)),
             should_retry
         )
     };


### PR DESCRIPTION
These log lines were suppressing context on the errors (e.g. saying "request failed" but not saying exactly why.) That's been unhelpful for diagnosing issues.

The easiest way to fix this is to wrap errors in `anyhow::Error` and use its ability to print full error chains.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->