### PR TITLE
Validate that user-supplied pipeline ids are valid path components

### DIFF
--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -31,7 +31,7 @@ use arroyo_formats::ser::ArrowSerializer;
 use arroyo_planner::{ArroyoSchemaProvider, CompiledSql, PlannerError, SqlConfig};
 use arroyo_rpc::formats::Format;
 use arroyo_rpc::grpc::rpc::compiler_grpc_client::CompilerGrpcClient;
-use arroyo_rpc::public_ids::{IdTypes, generate_id};
+use arroyo_rpc::public_ids::{IdTypes, generate_id, validate_public_id};
 use arroyo_rpc::schema_resolver::{ConfluentSchemaRegistry, ConfluentSchemaType};
 use arroyo_rpc::{OperatorConfig, error_chain, log_event};
 use arroyo_udf_host::ParsedUdfFile;
@@ -316,6 +316,7 @@ pub(crate) async fn create_pipeline_int(
     }
 
     let pub_id = pub_id.unwrap_or_else(|| generate_id(IdTypes::Pipeline));
+    validate_pipeline_id(&pub_id)?;
 
     if compiled.program.graph.node_count() > auth.org_metadata.max_operators as usize {
         return Err(bad_request(
@@ -634,6 +635,10 @@ pub async fn put_pipeline(
     WithRejection(Json(pipeline_post), _): WithRejection<Json<PipelinePost>, ApiError>,
 ) -> Result<Json<Pipeline>, ErrorResp> {
     create_pipeline_inner(state, bearer_auth, Some(id), pipeline_post).await
+}
+
+fn validate_pipeline_id(id: &str) -> Result<(), ErrorResp> {
+    validate_public_id(id).map_err(|reason| bad_request(format!("invalid pipeline id: {reason}")))
 }
 
 async fn create_pipeline_inner(

--- a/crates/arroyo-rpc/src/public_ids.rs
+++ b/crates/arroyo-rpc/src/public_ids.rs
@@ -2,6 +2,8 @@ use nanoid::nanoid;
 
 const ID_LENGTH: usize = 10;
 
+pub const MAX_PUBLIC_ID_LENGTH: usize = 255;
+
 const ALPHABET: [char; 62] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
     'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b',
@@ -22,6 +24,30 @@ pub enum IdTypes {
     ConnectionTable,
     ConnectionTablePipeline,
     Udf,
+}
+
+pub fn validate_public_id(id: &str) -> Result<(), &'static str> {
+    if id.is_empty() {
+        return Err("id must not be empty");
+    }
+
+    if id.len() > MAX_PUBLIC_ID_LENGTH {
+        return Err("id must be at most 255 bytes");
+    }
+
+    if id == "." || id == ".." {
+        return Err("id must not be a relative path segment");
+    }
+
+    if id.contains('/') || id.contains('\\') {
+        return Err("id must not contain path separators");
+    }
+
+    if id.chars().any(char::is_control) {
+        return Err("id must not contain control characters");
+    }
+
+    Ok(())
 }
 
 pub fn generate_id(id_type: IdTypes) -> String {


### PR DESCRIPTION
We recently introduced a new control plane API that allows users to create pipelines with a user-set pipeline id. However, in worker mode, pipeline ids are used as part of the path in the pipeline protocol, and we assume pipeline ids are a single path segment. This PR introduces additional validation on public ids to ensure they do not break those invariants.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->