### PR TITLE
Preserve edge schemas when chaining operators

### DIFF
--- a/crates/arroyo-datastream/src/optimizers.rs
+++ b/crates/arroyo-datastream/src/optimizers.rs
@@ -93,6 +93,11 @@ impl Optimizer for ChainingOptimizer {
                 .edges
                 .push(edge.weight().schema.clone());
 
+            new_cur
+                .operator_chain
+                .edges
+                .extend(successor_node.operator_chain.edges.clone());
+
             mem::swap(&mut new_cur, plan.node_weight_mut(node_idx).unwrap());
 
             // remove the old successor
@@ -101,5 +106,77 @@ impl Optimizer for ChainingOptimizer {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical::{LogicalEdge, LogicalNode, OperatorName};
+    use arrow_schema::{DataType, Field};
+    use arroyo_rpc::df::ArroyoSchema;
+    use std::sync::Arc;
+
+    fn node(id: u32, operator_id: &str, name: OperatorName) -> LogicalNode {
+        LogicalNode::single(
+            id,
+            operator_id.to_string(),
+            name,
+            vec![],
+            operator_id.to_string(),
+            1,
+        )
+    }
+
+    fn schema(name: &str) -> Arc<ArroyoSchema> {
+        Arc::new(ArroyoSchema::from_fields(vec![Field::new(
+            name,
+            DataType::Int64,
+            false,
+        )]))
+    }
+
+    #[test]
+    fn preserves_edges_when_merging_into_chain() {
+        let mut graph = LogicalGraph::new();
+
+        // Reverse-topological insertion makes B merge with C before A merges with B.
+        let c = graph.add_node(node(2, "c", OperatorName::ArrowValue));
+        let b = graph.add_node(node(1, "b", OperatorName::ExpressionWatermark));
+        let a = graph.add_node(node(0, "a", OperatorName::ArrowValue));
+
+        let ab_schema = schema("a_to_b");
+        let bc_schema = schema("b_to_c");
+
+        graph.add_edge(
+            a,
+            b,
+            LogicalEdge {
+                edge_type: LogicalEdgeType::Forward,
+                schema: ab_schema.clone(),
+            },
+        );
+        graph.add_edge(
+            b,
+            c,
+            LogicalEdge {
+                edge_type: LogicalEdgeType::Forward,
+                schema: bc_schema.clone(),
+            },
+        );
+
+        ChainingOptimizer {}.optimize(&mut graph);
+
+        assert_eq!(graph.node_count(), 1);
+        let chain = &graph.node_weights().next().unwrap().operator_chain;
+        assert_eq!(
+            chain
+                .operators
+                .iter()
+                .map(|operator| operator.operator_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(chain.edges, vec![ab_schema, bc_schema]);
     }
 }


### PR DESCRIPTION
I don't know this code well, but with the help of an LLM, I now think this is a real bug.

***
I was able to reliably reproduce a panic with the following pipeline:

```
CREATE TABLE source_1 WITH (connector = 'impulse', event_rate = '100');

CREATE TABLE source_2 WITH (connector = 'impulse', event_rate = '100');

CREATE TABLE source_3 WITH (connector = 'impulse', event_rate = '100');

CREATE TABLE output (counter BIGINT, subtask_index BIGINT, source TEXT) WITH (connector = 'blackhole');

INSERT INTO output
SELECT *, 'first' AS source FROM source_1
UNION ALL
SELECT *, 'second' AS source FROM source_2
UNION ALL
SELECT *, 'third' AS source FROM source_3;
```
Panic
```
2026-08-25T18:16:19.164794Z ERROR arroyo_server_common: panicked at /Users/broy/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-55.2.0/src/record_batch.rs:607:22:
index out of bounds: the len is 3 but the index is 3 panic.file="/Users/broy/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-55.2.0/src/record_batch.rs" panic.line=607 panic.column=22
```

**Root cause**
The bug seems to be in the optimizer, where we were not copying the edges of the successor node.

More details produced by LLM: https://gist.github.com/QnJ1c2kNCg/581a698f5e7abacd66c53645c009899b

**Testing**
The above repro no longer panics.