### PR TITLE
Add support for pipeline-level configs

### DIFF
--- a/crates/arroyo-api/migrations/V33__pipeline_config.sql
+++ b/crates/arroyo-api/migrations/V33__pipeline_config.sql
@@ -1,0 +1,4 @@
+-- Per-job pipeline config overlay. Same shape as the controller's
+-- global pipeline config; an empty object means "no overrides, use
+-- the global config as-is".
+ALTER TABLE job_configs ADD COLUMN pipeline_config JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/crates/arroyo-api/migrations/V34__checkpoint_interval_pipeline_config.sql
+++ b/crates/arroyo-api/migrations/V34__checkpoint_interval_pipeline_config.sql
@@ -1,0 +1,13 @@
+-- Preserve existing per-job checkpoint intervals while moving runtime handling
+-- to the generic pipeline config overlay.
+UPDATE job_configs
+SET pipeline_config = jsonb_set(
+    pipeline_config,
+    '{checkpoint}',
+    COALESCE(pipeline_config -> 'checkpoint', '{}'::jsonb)
+        || jsonb_build_object('interval', checkpoint_interval_micros::text || 'micros'),
+    true
+)
+WHERE pipeline_config #> '{checkpoint,interval}' IS NULL;
+
+ALTER TABLE job_configs DROP COLUMN checkpoint_interval_micros;

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -128,7 +128,7 @@ INSERT INTO pipelines (pub_id, organization_id, created_by, name, type, textual_
 VALUES (:pub_id, :organization_id, :created_by, :name, :type, :textual_repr, :udfs, :program, :proto_version, :state_url, :tags);
 
 --! get_pipelines : DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -143,7 +143,7 @@ ORDER BY pipelines.created_at DESC
 LIMIT cast(:limit as integer);
 
 --! get_pipeline: DbPipeline
-SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, checkpoint_interval_micros, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
+SELECT pipelines.id, pipelines.pub_id, name, type, textual_repr, udfs, program, stop, pipelines.created_at, state, parallelism_overrides, ttl_micros, state_url, tags
 FROM pipelines
     INNER JOIN job_configs on pipelines.id = job_configs.pipeline_id
     INNER JOIN job_statuses ON job_configs.id = job_statuses.id
@@ -165,14 +165,13 @@ WHERE pub_id = :pub_id AND organization_id = :organization_id;
 
 ----------- jobs -----------------------
 
---! update_job(checkpoint_interval_micros?, stop?, parallelism_overrides?, env_vars?, scheduler_config?, pipeline_config?)
+--! update_job(stop?, parallelism_overrides?, env_vars?, scheduler_config?, pipeline_config?)
 UPDATE job_configs
 SET
    updated_at = :updated_at,
    updated_by = :updated_by,
 
    stop = COALESCE(:stop, stop),
-   checkpoint_interval_micros = COALESCE(:checkpoint_interval_micros, checkpoint_interval_micros),
    parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides),
    env_vars = COALESCE(:env_vars, env_vars),
    scheduler_config = COALESCE(:scheduler_config, scheduler_config),
@@ -190,8 +189,8 @@ WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
-(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros, env_vars, scheduler_config, pipeline_config)
-VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros, :env_vars, :scheduler_config, :pipeline_config);
+(id, organization_id, pipeline_name, created_by, pipeline_id, ttl_micros, env_vars, scheduler_config, pipeline_config)
+VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :ttl_micros, :env_vars, :scheduler_config, :pipeline_config);
 
 --! create_job_status
 INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :organization_id);
@@ -199,11 +198,9 @@ INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :or
 --! clone_job_without_state
 INSERT INTO job_configs
     (id, organization_id, pipeline_name, created_by, updated_by, updated_at,
-     ttl_micros, stop, pipeline_id, parallelism_overrides,
-     checkpoint_interval_micros, env_vars, scheduler_config, pipeline_config)
+     ttl_micros, stop, pipeline_id, parallelism_overrides, env_vars, scheduler_config, pipeline_config)
 SELECT :new_job_id, organization_id, pipeline_name, created_by, :updated_by, CURRENT_TIMESTAMP,
-       ttl_micros, 'none', pipeline_id, parallelism_overrides,
-       checkpoint_interval_micros, env_vars, scheduler_config, pipeline_config
+       ttl_micros, 'none', pipeline_id, parallelism_overrides, env_vars, scheduler_config, pipeline_config
 FROM job_configs
 WHERE id = :old_job_id;
 
@@ -222,7 +219,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
 --! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -230,7 +227,7 @@ WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pub
 ORDER BY job_configs.created_at DESC;
 
 --! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -238,7 +235,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY job_configs.created_at DESC;
 
 --! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id

--- a/crates/arroyo-api/queries/api_queries.sql
+++ b/crates/arroyo-api/queries/api_queries.sql
@@ -165,7 +165,7 @@ WHERE pub_id = :pub_id AND organization_id = :organization_id;
 
 ----------- jobs -----------------------
 
---! update_job(checkpoint_interval_micros?, stop?, parallelism_overrides?, env_vars?, scheduler_config?)
+--! update_job(checkpoint_interval_micros?, stop?, parallelism_overrides?, env_vars?, scheduler_config?, pipeline_config?)
 UPDATE job_configs
 SET
    updated_at = :updated_at,
@@ -175,7 +175,8 @@ SET
    checkpoint_interval_micros = COALESCE(:checkpoint_interval_micros, checkpoint_interval_micros),
    parallelism_overrides = COALESCE(:parallelism_overrides, parallelism_overrides),
    env_vars = COALESCE(:env_vars, env_vars),
-   scheduler_config = COALESCE(:scheduler_config, scheduler_config)
+   scheduler_config = COALESCE(:scheduler_config, scheduler_config),
+   pipeline_config = COALESCE(:pipeline_config, pipeline_config)
 WHERE id = :job_id AND organization_id = :organization_id;
 
 --! restart_job(mode)
@@ -189,8 +190,8 @@ WHERE id = :job_id AND organization_id = :organization_id;
 
 --! create_job(ttl_micros?)
 INSERT INTO job_configs
-(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros, env_vars, scheduler_config)
-VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros, :env_vars, :scheduler_config);
+(id, organization_id, pipeline_name, created_by, pipeline_id, checkpoint_interval_micros, ttl_micros, env_vars, scheduler_config, pipeline_config)
+VALUES (:id, :organization_id, :pipeline_name, :created_by, :pipeline_id, :checkpoint_interval_micros, :ttl_micros, :env_vars, :scheduler_config, :pipeline_config);
 
 --! create_job_status
 INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :organization_id);
@@ -199,10 +200,10 @@ INSERT INTO job_statuses (pub_id, id, organization_id) VALUES (:pub_id, :id, :or
 INSERT INTO job_configs
     (id, organization_id, pipeline_name, created_by, updated_by, updated_at,
      ttl_micros, stop, pipeline_id, parallelism_overrides,
-     checkpoint_interval_micros, env_vars, scheduler_config)
+     checkpoint_interval_micros, env_vars, scheduler_config, pipeline_config)
 SELECT :new_job_id, organization_id, pipeline_name, created_by, :updated_by, CURRENT_TIMESTAMP,
        ttl_micros, 'none', pipeline_id, parallelism_overrides,
-       checkpoint_interval_micros, env_vars, scheduler_config
+       checkpoint_interval_micros, env_vars, scheduler_config, pipeline_config
 FROM job_configs
 WHERE id = :old_job_id;
 
@@ -221,7 +222,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY COALESCE(job_configs.updated_at, job_configs.created_at) DESC;
 
 --! get_pipeline_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -229,7 +230,7 @@ WHERE job_configs.organization_id = :organization_id AND pipelines.pub_id = :pub
 ORDER BY job_configs.created_at DESC;
 
 --! get_all_jobs : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id
@@ -237,7 +238,7 @@ WHERE job_configs.organization_id = :organization_id AND ttl_micros IS NULL
 ORDER BY job_configs.created_at DESC;
 
 --! get_pipeline_job : DbPipelineJob(start_time?, finish_time?, state?, tasks?, failure_message?, failure_domain?, run_id?, state_context?)
-SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, env_vars
+SELECT job_configs.id, pipelines.pub_id as pipeline_id, stop, start_time, finish_time, state, tasks, failure_message, failure_domain, run_id, checkpoint_interval_micros, job_configs.created_at, state_context, scheduler_config, pipeline_config, env_vars
 FROM job_configs
          INNER JOIN job_statuses ON job_configs.id = job_statuses.id
          INNER JOIN pipelines ON pipelines.id = job_configs.pipeline_id

--- a/crates/arroyo-api/sqlite_migrations/V11__pipeline_config.sql
+++ b/crates/arroyo-api/sqlite_migrations/V11__pipeline_config.sql
@@ -1,0 +1,4 @@
+-- Per-job pipeline config overlay. Same shape as the controller's
+-- global pipeline config; an empty object means "no overrides, use
+-- the global config as-is".
+ALTER TABLE job_configs ADD COLUMN pipeline_config TEXT NOT NULL DEFAULT '{}';

--- a/crates/arroyo-api/sqlite_migrations/V12__checkpoint_interval_pipeline_config.sql
+++ b/crates/arroyo-api/sqlite_migrations/V12__checkpoint_interval_pipeline_config.sql
@@ -1,0 +1,11 @@
+-- Preserve existing per-job checkpoint intervals while moving runtime handling
+-- to the generic pipeline config overlay.
+UPDATE job_configs
+SET pipeline_config = json_set(
+    pipeline_config,
+    '$.checkpoint.interval',
+    CAST(checkpoint_interval_micros AS TEXT) || 'micros'
+)
+WHERE json_type(pipeline_config, '$.checkpoint.interval') IS NULL;
+
+ALTER TABLE job_configs DROP COLUMN checkpoint_interval_micros;

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -167,11 +167,6 @@ pub(crate) async fn create_job(
     let env_vars_json =
         serde_json::to_value(&env_vars).expect("HashMap<String, String> is always serializable");
 
-    // validate the pipeline config is valid
-    if let Err(e) = config().pipeline.try_merge(&pipeline_config) {
-        return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
-    }
-
     // TODO: handle chance of collision in ids
     api_queries::execute_create_job(
         &db.client().await?,

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -119,7 +119,6 @@ fn operator_checkpoint_groups(
 pub(crate) async fn create_job(
     pipeline_name: &str,
     pipeline_id: i64,
-    checkpoint_interval: Duration,
     preview: bool,
     auth: &AuthData,
     db: &DatabaseSource,
@@ -127,20 +126,6 @@ pub(crate) async fn create_job(
     scheduler_config: serde_json::Value,
     pipeline_config: serde_json::Value,
 ) -> Result<String, ErrorResp> {
-    let checkpoint_interval = if preview {
-        Duration::from_secs(24 * 60 * 60)
-    } else {
-        checkpoint_interval
-    };
-
-    if checkpoint_interval < Duration::from_secs(1)
-        || checkpoint_interval > Duration::from_secs(24 * 60 * 60)
-    {
-        return Err(bad_request(
-            "Checkpoint_interval_micros must be between 1 second and 1 day.".to_string(),
-        ));
-    }
-
     let running_jobs = api_queries::fetch_get_jobs(&db.client().await?, &auth.organization_id)
         .await?
         .iter()
@@ -175,7 +160,6 @@ pub(crate) async fn create_job(
         &pipeline_name,
         &auth.user_id,
         &pipeline_id,
-        &(checkpoint_interval.as_micros() as i64),
         &(if preview {
             Some(PREVIEW_TTL.as_micros() as i64)
         } else {
@@ -676,7 +660,6 @@ mod tests {
                     ttl_micros INTEGER,
                     stop TEXT DEFAULT 'none' NOT NULL,
                     parallelism_overrides TEXT DEFAULT '{}' NOT NULL,
-                    checkpoint_interval_micros INTEGER DEFAULT 10000000 NOT NULL,
                     pipeline_id INTEGER NOT NULL,
                     restart_nonce INTEGER DEFAULT 0 NOT NULL,
                     restart_mode TEXT DEFAULT 'safe' NOT NULL,
@@ -707,11 +690,11 @@ mod tests {
                     VALUES (1, 'pl_1', 'org_1');
                 INSERT INTO job_configs
                     (id, organization_id, pipeline_name, created_by, updated_by, ttl_micros, stop,
-                     parallelism_overrides, checkpoint_interval_micros, pipeline_id, restart_nonce,
-                     restart_mode, env_vars, scheduler_config, pipeline_config)
+                     parallelism_overrides, pipeline_id, restart_nonce, restart_mode,
+                     env_vars, scheduler_config, pipeline_config)
                     VALUES
                     ('job_old', 'org_1', 'pipeline', 'user_1', 'user_1', 123, 'immediate',
-                     '{\"1\": 4}', 5000000, 1, 3, 'force',
+                     '{\"1\": 4}', 1, 3, 'force',
                      '{\"ENV\": \"value\"}', '{\"scheduler\": true}',
                      '{\"allowed_restarts\": 3}');
                 INSERT INTO checkpoints (job_id) VALUES ('job_old');

--- a/crates/arroyo-api/src/jobs.rs
+++ b/crates/arroyo-api/src/jobs.rs
@@ -125,6 +125,7 @@ pub(crate) async fn create_job(
     db: &DatabaseSource,
     env_vars: HashMap<String, String>,
     scheduler_config: serde_json::Value,
+    pipeline_config: serde_json::Value,
 ) -> Result<String, ErrorResp> {
     let checkpoint_interval = if preview {
         Duration::from_secs(24 * 60 * 60)
@@ -166,6 +167,11 @@ pub(crate) async fn create_job(
     let env_vars_json =
         serde_json::to_value(&env_vars).expect("HashMap<String, String> is always serializable");
 
+    // validate the pipeline config is valid
+    if let Err(e) = config().pipeline.try_merge(&pipeline_config) {
+        return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
+    }
+
     // TODO: handle chance of collision in ids
     api_queries::execute_create_job(
         &db.client().await?,
@@ -182,6 +188,7 @@ pub(crate) async fn create_job(
         }),
         &env_vars_json,
         &scheduler_config,
+        &pipeline_config,
     )
     .await?;
 
@@ -679,7 +686,8 @@ mod tests {
                     restart_nonce INTEGER DEFAULT 0 NOT NULL,
                     restart_mode TEXT DEFAULT 'safe' NOT NULL,
                     env_vars TEXT DEFAULT '{}' NOT NULL,
-                    scheduler_config TEXT DEFAULT '{}' NOT NULL
+                    scheduler_config TEXT DEFAULT '{}' NOT NULL,
+                    pipeline_config TEXT DEFAULT '{}' NOT NULL
                 );
                 CREATE TABLE job_statuses (
                     pub_id TEXT NOT NULL UNIQUE,
@@ -705,11 +713,12 @@ mod tests {
                 INSERT INTO job_configs
                     (id, organization_id, pipeline_name, created_by, updated_by, ttl_micros, stop,
                      parallelism_overrides, checkpoint_interval_micros, pipeline_id, restart_nonce,
-                     restart_mode, env_vars, scheduler_config)
+                     restart_mode, env_vars, scheduler_config, pipeline_config)
                     VALUES
                     ('job_old', 'org_1', 'pipeline', 'user_1', 'user_1', 123, 'immediate',
                      '{\"1\": 4}', 5000000, 1, 3, 'force',
-                     '{\"ENV\": \"value\"}', '{\"scheduler\": true}');
+                     '{\"ENV\": \"value\"}', '{\"scheduler\": true}',
+                     '{\"allowed_restarts\": 3}');
                 INSERT INTO checkpoints (job_id) VALUES ('job_old');
                 INSERT INTO job_log_messages (job_id) VALUES ('job_old');",
             )
@@ -739,10 +748,10 @@ mod tests {
         };
         let connection = connection.lock().unwrap();
 
-        let job: (String, String, i64, String, String, String, String) = connection
+        let job: (String, String, i64, String, String, String, String, String) = connection
             .query_row(
                 "SELECT id, stop, restart_nonce, restart_mode, updated_by,
-                        env_vars, scheduler_config
+                        env_vars, scheduler_config, pipeline_config
                  FROM job_configs",
                 [],
                 |row| {
@@ -754,6 +763,7 @@ mod tests {
                         row.get(4)?,
                         row.get(5)?,
                         row.get(6)?,
+                        row.get(7)?,
                     ))
                 },
             )
@@ -768,6 +778,7 @@ mod tests {
                 "user_2".to_string(),
                 "{\"ENV\": \"value\"}".to_string(),
                 "{\"scheduler\": true}".to_string(),
+                "{\"allowed_restarts\": 3}".to_string(),
             )
         );
 

--- a/crates/arroyo-api/src/lib.rs
+++ b/crates/arroyo-api/src/lib.rs
@@ -37,7 +37,7 @@ use crate::pipelines::{
     __path_get_pipeline, __path_get_pipeline_jobs, __path_patch_pipeline, __path_put_pipeline,
     __path_restart_pipeline, __path_validate_query,
 };
-use crate::rest::__path_ping;
+use crate::rest::{__path_get_configs, __path_ping};
 use crate::rest_utils::{ErrorResp, service_unavailable};
 use crate::udfs::{__path_create_udf, __path_delete_udf, __path_get_udfs, __path_validate_udf};
 use arroyo_rpc::api_types::{checkpoints::*, connections::*, metrics::*, pipelines::*, udfs::*, *};
@@ -247,6 +247,7 @@ impl IntoResponse for HttpError {
     servers((url = "/api/")),
     paths(
         ping,
+        get_configs,
         validate_query,
         validate_udf,
         create_pipeline,
@@ -362,6 +363,7 @@ impl IntoResponse for HttpError {
     )),
     tags(
         (name = "ping", description = "Ping endpoint"),
+        (name = "configs", description = "Controller configuration endpoint"),
         (name = "connection_profiles", description = "Connection profiles management endpoints"),
         (name = "connection_tables", description = "Connection tables management endpoints"),
         (name = "pipelines", description = "Pipeline management endpoints"),

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -295,7 +295,6 @@ pub(crate) async fn create_pipeline_int(
     query: String,
     udfs: Vec<Udf>,
     parallelism: u64,
-    checkpoint_interval: Duration,
     is_preview: bool,
     enable_sinks: bool,
     auth: AuthData,
@@ -325,10 +324,10 @@ pub(crate) async fn create_pipeline_int(
                 contact support@arroyo.systems for an increase", auth.org_metadata.max_operators)));
     }
 
-    // validate the pipeline config is valid
-    if let Err(e) = config().pipeline.try_merge(&pipeline_config) {
-        return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
-    }
+    config()
+        .pipeline
+        .try_merge(&pipeline_config)
+        .map_err(|e| bad_request(format!("pipeline_config is invalid: {e}")))?;
 
     set_parallelism(&mut compiled.program, parallelism as usize);
 
@@ -445,7 +444,6 @@ pub(crate) async fn create_pipeline_int(
     let job_id = jobs::create_job(
         &name,
         pipeline_id,
-        checkpoint_interval,
         is_preview,
         &auth,
         db,
@@ -480,7 +478,6 @@ impl TryInto<Pipeline> for DbPipeline {
         let running_desired = self.stop == StopMode::none;
         let state = self.state.unwrap_or_else(|| "Created".to_string());
         let (action_text, action, action_in_progress) = get_action(&state, &running_desired);
-
         let mut program: LogicalProgram = ArrowProgram::decode(&self.program[..])
             .map_err(log_and_map)?
             .try_into()
@@ -510,7 +507,6 @@ impl TryInto<Pipeline> for DbPipeline {
             name: self.name,
             query: self.textual_repr,
             udfs: serde_json::from_value(self.udfs).map_err(log_and_map)?,
-            checkpoint_interval_micros: self.checkpoint_interval_micros as u64,
             stop,
             created_at: to_micros(self.created_at),
             graph: program.try_into().map_err(log_and_map)?,
@@ -657,10 +653,10 @@ async fn create_pipeline_inner(
 ) -> Result<Json<Pipeline>, ErrorResp> {
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
-    let checkpoint_interval = pipeline_post
-        .checkpoint_interval_micros
-        .map(Duration::from_micros)
-        .unwrap_or(*config().default_checkpoint_interval);
+    let pipeline_config = match pipeline_post.pipeline_config {
+        None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
+        Some(v) => v,
+    };
 
     let udfs = pipeline_post.udfs.unwrap_or_default();
 
@@ -679,7 +675,6 @@ async fn create_pipeline_inner(
         pipeline_post.query,
         udfs,
         pipeline_post.parallelism,
-        checkpoint_interval,
         /* is_preview */ false,
         /* enable_sinks */ true,
         auth_data.clone(),
@@ -693,10 +688,7 @@ async fn create_pipeline_inner(
             None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
             Some(v) => v,
         },
-        match pipeline_post.pipeline_config {
-            None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
-            Some(v) => v,
-        },
+        pipeline_config,
     )
     .await?;
 
@@ -736,12 +728,16 @@ pub async fn create_preview_pipeline(
     )
     .await??;
 
+    let mut pipeline_config = config().pipeline.clone();
+    pipeline_config.worker.checkpoint.interval = Duration::from_secs(24 * 60 * 60).into();
+    let pipeline_config = serde_json::to_value(pipeline_config)
+        .map_err(|e| log_and_map(anyhow!("failed to serialize preview config: {e}")))?;
+
     let pipeline_id = create_pipeline_int(
         format!("preview_{}", to_millis(SystemTime::now())),
         req.query,
         udfs,
         1,
-        Duration::MAX,
         /* is_preview */ true,
         req.enable_sinks,
         auth_data.clone(),
@@ -752,7 +748,7 @@ pub async fn create_preview_pipeline(
         HashMap::default(),
         HashMap::default(),
         serde_json::Value::Object(Default::default()),
-        serde_json::Value::Object(Default::default()),
+        pipeline_config,
     )
     .await?;
 
@@ -795,10 +791,6 @@ pub async fn patch_pipeline(
             .ok_or_else(|| not_found("Job for pipeline"))?
             .id;
 
-    let interval = pipeline_patch
-        .checkpoint_interval_micros
-        .map(Duration::from_micros);
-
     let stop = &pipeline_patch.stop.map(|s| match s {
         StopType::None => types::public::StopMode::none,
         StopType::Graceful => types::public::StopMode::graceful,
@@ -806,14 +798,6 @@ pub async fn patch_pipeline(
         StopType::Checkpoint => types::public::StopMode::checkpoint,
         StopType::Force => types::public::StopMode::force,
     });
-
-    if let Some(interval) = interval
-        && (interval < Duration::from_secs(1) || interval > Duration::from_secs(24 * 60 * 60))
-    {
-        return Err(bad_request(
-            "checkpoint_interval_micros must be between 1 second and 1 day".to_string(),
-        ));
-    }
 
     let parallelism_overrides = if let Some(parallelism) = pipeline_patch.parallelism {
         let res = api_queries::fetch_get_job_details(&db, &auth_data.organization_id, &job_id)
@@ -847,9 +831,10 @@ pub async fn patch_pipeline(
     }
 
     if let Some(pc) = &pipeline_patch.pipeline_config {
-        if let Err(e) = config().pipeline.try_merge(pc) {
-            return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
-        }
+        config()
+            .pipeline
+            .try_merge(pc)
+            .map_err(|e| bad_request(format!("pipeline_config is invalid: {e}")))?;
     }
 
     let res = api_queries::execute_update_job(
@@ -857,7 +842,6 @@ pub async fn patch_pipeline(
         &OffsetDateTime::now_utc(),
         &auth_data.user_id,
         stop,
-        &interval.map(|i| i.as_micros() as i64),
         &parallelism_overrides,
         &env_vars,
         &pipeline_patch.scheduler_config,

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -306,6 +306,7 @@ pub(crate) async fn create_pipeline_int(
     tags: HashMap<String, String>,
     env_vars: HashMap<String, String>,
     scheduler_config: serde_json::Value,
+    pipeline_config: serde_json::Value,
 ) -> Result<String, ErrorResp> {
     if parallelism > auth.org_metadata.max_parallelism as u64 {
         return Err(bad_request(format!(
@@ -445,6 +446,7 @@ pub(crate) async fn create_pipeline_int(
         db,
         env_vars,
         scheduler_config,
+        pipeline_config,
     )
     .await?;
 
@@ -537,6 +539,7 @@ impl From<DbPipelineJob> for Job {
             }),
             created_at: to_micros(val.created_at),
             scheduler_config: val.scheduler_config,
+            pipeline_config: val.pipeline_config,
             env_vars: val.env_vars,
         }
     }
@@ -685,6 +688,10 @@ async fn create_pipeline_inner(
             None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
             Some(v) => v,
         },
+        match pipeline_post.pipeline_config {
+            None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
+            Some(v) => v,
+        },
     )
     .await?;
 
@@ -739,6 +746,7 @@ pub async fn create_preview_pipeline(
         None,
         HashMap::default(),
         HashMap::default(),
+        serde_json::Value::Object(Default::default()),
         serde_json::Value::Object(Default::default()),
     )
     .await?;
@@ -831,6 +839,11 @@ pub async fn patch_pipeline(
         v => v,
     });
 
+    let pipeline_config = pipeline_patch.pipeline_config.map(|v| match v {
+        serde_json::Value::Null => serde_json::Value::Object(Default::default()),
+        v => v,
+    });
+
     let res = api_queries::execute_update_job(
         &db,
         &OffsetDateTime::now_utc(),
@@ -840,6 +853,7 @@ pub async fn patch_pipeline(
         &parallelism_overrides,
         &env_vars,
         &scheduler_config,
+        &pipeline_config,
         &job_id,
         &auth_data.organization_id,
     )

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -325,6 +325,11 @@ pub(crate) async fn create_pipeline_int(
                 contact support@arroyo.systems for an increase", auth.org_metadata.max_operators)));
     }
 
+    // validate the pipeline config is valid
+    if let Err(e) = config().pipeline.try_merge(&pipeline_config) {
+        return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
+    }
+
     set_parallelism(&mut compiled.program, parallelism as usize);
 
     if is_preview {
@@ -834,15 +839,18 @@ pub async fn patch_pipeline(
         .map(|e| serde_json::to_value(e).map_err(log_and_map))
         .transpose()?;
 
-    let scheduler_config = pipeline_patch.scheduler_config.map(|v| match v {
-        serde_json::Value::Null => serde_json::Value::Object(Default::default()),
-        v => v,
-    });
+    if !matches!(
+        pipeline_patch.scheduler_config,
+        None | Some(serde_json::Value::Object(_))
+    ) {
+        return Err(bad_request("scheduler_config field must be an object"));
+    }
 
-    let pipeline_config = pipeline_patch.pipeline_config.map(|v| match v {
-        serde_json::Value::Null => serde_json::Value::Object(Default::default()),
-        v => v,
-    });
+    if let Some(pc) = &pipeline_patch.pipeline_config {
+        if let Err(e) = config().pipeline.try_merge(pc) {
+            return Err(bad_request(format!("pipeline_config is invalid: {}", e)));
+        }
+    }
 
     let res = api_queries::execute_update_job(
         &db,
@@ -852,8 +860,8 @@ pub async fn patch_pipeline(
         &interval.map(|i| i.as_micros() as i64),
         &parallelism_overrides,
         &env_vars,
-        &scheduler_config,
-        &pipeline_config,
+        &pipeline_patch.scheduler_config,
+        &pipeline_patch.pipeline_config,
         &job_id,
         &auth_data.organization_id,
     )
@@ -1044,7 +1052,7 @@ pub async fn delete_pipeline(
         .any(|job| job.state != "Stopped" && job.state != "Finished" && job.state != "Failed")
     {
         return Err(bad_request("Pipeline's jobs must be in a terminal state (stopped, finished, or failed) before it can be deleted"
-                .to_string()
+            .to_string()
         ));
     }
 

--- a/crates/arroyo-api/src/pipelines.rs
+++ b/crates/arroyo-api/src/pipelines.rs
@@ -52,7 +52,7 @@ use crate::rest_utils::{
 use crate::types::public::{PipelineType, RestartMode, StopMode};
 use crate::udfs::build_udf;
 use crate::{connection_tables, to_micros};
-use arroyo_rpc::config::config;
+use arroyo_rpc::config::{PipelineCompilerConfigs, config};
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_types::to_millis;
 use cornucopia_async::{Database, DatabaseSource};
@@ -65,6 +65,7 @@ async fn compile_sql(
     auth_data: &AuthData,
     validate_only: bool,
     db: &DatabaseSource,
+    compiler_config: &PipelineCompilerConfigs,
 ) -> Result<Result<CompiledSql, PlannerError>, ErrorResp> {
     let mut schema_provider = ArroyoSchemaProvider::new();
 
@@ -177,9 +178,7 @@ async fn compile_sql(
     Ok(arroyo_planner::parse_and_get_program(
         &query,
         schema_provider,
-        SqlConfig {
-            default_parallelism: parallelism,
-        },
+        SqlConfig::new(parallelism, compiler_config),
     )
     .await)
 }
@@ -324,7 +323,7 @@ pub(crate) async fn create_pipeline_int(
                 contact support@arroyo.systems for an increase", auth.org_metadata.max_operators)));
     }
 
-    config()
+    let effective_pipeline_config = config()
         .pipeline
         .try_merge(&pipeline_config)
         .map_err(|e| bad_request(format!("pipeline_config is invalid: {e}")))?;
@@ -332,6 +331,7 @@ pub(crate) async fn create_pipeline_int(
     set_parallelism(&mut compiled.program, parallelism as usize);
 
     if is_preview {
+        let default_sink = default_sink(&effective_pipeline_config.compiler);
         // in Preview, we either replace sinks with a preview sink, or add a preview sink
         // next to them depending on the `enable_sinks` option
         let g = &mut compiled.program.graph;
@@ -339,8 +339,7 @@ pub(crate) async fn create_pipeline_int(
             let should_replace = {
                 let node = &g.node_weight(idx).unwrap().operator_chain;
                 node.is_sink()
-                    && node.iter().next().unwrap().0.operator_config
-                        != default_sink().encode_to_vec()
+                    && node.iter().next().unwrap().0.operator_config != default_sink.encode_to_vec()
             };
             if should_replace {
                 if enable_sinks {
@@ -357,7 +356,7 @@ pub(crate) async fn create_pipeline_int(
                                     .operator_id
                             ),
                             operator_name: OperatorName::ConnectorSink,
-                            operator_config: default_sink().encode_to_vec(),
+                            operator_config: default_sink.encode_to_vec(),
                         }),
                         parallelism: 1,
                     });
@@ -377,7 +376,7 @@ pub(crate) async fn create_pipeline_int(
                         .next()
                         .unwrap()
                         .0
-                        .operator_config = default_sink().encode_to_vec();
+                        .operator_config = default_sink.encode_to_vec();
                 }
             }
         }
@@ -564,6 +563,7 @@ pub async fn validate_query(
     let auth_data = authenticate(&state.database, bearer_auth).await?;
 
     let udfs = validate_query_post.udfs.unwrap_or(vec![]);
+    let global_config = config();
 
     let pipeline_graph_validation_result = match compile_sql(
         validate_query_post.query,
@@ -572,6 +572,7 @@ pub async fn validate_query(
         &auth_data,
         true,
         &state.database,
+        &global_config.pipeline.compiler,
     )
     .await?
     {
@@ -657,6 +658,10 @@ async fn create_pipeline_inner(
         None | Some(serde_json::Value::Null) => serde_json::Value::Object(Default::default()),
         Some(v) => v,
     };
+    let effective_pipeline_config = config()
+        .pipeline
+        .try_merge(&pipeline_config)
+        .map_err(|e| bad_request(format!("pipeline_config is invalid: {e}")))?;
 
     let udfs = pipeline_post.udfs.unwrap_or_default();
 
@@ -667,6 +672,7 @@ async fn create_pipeline_inner(
         &auth_data,
         false,
         &state.database,
+        &effective_pipeline_config.compiler,
     )
     .await??;
 
@@ -718,6 +724,9 @@ pub async fn create_preview_pipeline(
 
     let udfs = req.udfs.unwrap_or_default();
 
+    let mut effective_pipeline_config = config().pipeline.clone();
+    effective_pipeline_config.worker.checkpoint.interval = Duration::from_secs(24 * 60 * 60).into();
+
     let compiled = compile_sql(
         req.query.clone(),
         &udfs,
@@ -725,12 +734,11 @@ pub async fn create_preview_pipeline(
         &auth_data,
         false,
         &state.database,
+        &effective_pipeline_config.compiler,
     )
     .await??;
 
-    let mut pipeline_config = config().pipeline.clone();
-    pipeline_config.worker.checkpoint.interval = Duration::from_secs(24 * 60 * 60).into();
-    let pipeline_config = serde_json::to_value(pipeline_config)
+    let pipeline_config = serde_json::to_value(effective_pipeline_config)
         .map_err(|e| log_and_map(anyhow!("failed to serialize preview config: {e}")))?;
 
     let pipeline_id = create_pipeline_int(
@@ -783,13 +791,13 @@ pub async fn patch_pipeline(
     let db = state.database.client().await?;
 
     // this assumes there is just one job for the pipeline
-    let job_id =
+    let job =
         api_queries::fetch_get_pipeline_jobs(&db, &auth_data.organization_id, &pipeline_pub_id)
             .await?
             .into_iter()
             .next()
-            .ok_or_else(|| not_found("Job for pipeline"))?
-            .id;
+            .ok_or_else(|| not_found("Job for pipeline"))?;
+    let job_id = job.id.clone();
 
     let stop = &pipeline_patch.stop.map(|s| match s {
         StopType::None => types::public::StopMode::none,
@@ -831,10 +839,21 @@ pub async fn patch_pipeline(
     }
 
     if let Some(pc) = &pipeline_patch.pipeline_config {
-        config()
+        let global_config = config();
+        let current_pipeline_config = global_config
+            .pipeline
+            .try_merge(&job.pipeline_config)
+            .map_err(|e| log_and_map(anyhow!("stored pipeline_config is invalid: {e}")))?;
+        let updated_pipeline_config = global_config
             .pipeline
             .try_merge(pc)
             .map_err(|e| bad_request(format!("pipeline_config is invalid: {e}")))?;
+
+        if current_pipeline_config.compiler != updated_pipeline_config.compiler {
+            return Err(bad_request(
+                "compiler pipeline config cannot be changed after pipeline creation",
+            ));
+        }
     }
 
     let res = api_queries::execute_update_job(

--- a/crates/arroyo-api/src/rest.rs
+++ b/crates/arroyo-api/src/rest.rs
@@ -58,6 +58,22 @@ pub async fn ping() -> impl IntoResponse {
     Json("Pong")
 }
 
+/// Controller configuration endpoint
+#[utoipa::path(
+    get,
+    path = "/v1/configs",
+    tag = "configs",
+    responses(
+        (status = 200, description = "Controller configuration", body = Object),
+    ),
+)]
+pub async fn get_configs() -> impl IntoResponse {
+    Json(
+        serde_json::to_value(config().as_ref())
+            .expect("controller configuration is always serializable"),
+    )
+}
+
 pub async fn api_fallback() -> impl IntoResponse {
     not_found("Route")
 }
@@ -207,6 +223,7 @@ pub fn create_rest_app(database: DatabaseSource) -> anyhow::Result<Router> {
 
     let api_routes = Router::new()
         .route("/ping", get(ping))
+        .route("/configs", get(get_configs))
         .route("/connectors", get(get_connectors))
         .route("/connection_profiles/test", post(test_connection_profile))
         .route("/connection_profiles", post(create_connection_profile))

--- a/crates/arroyo-api/src/rest.rs
+++ b/crates/arroyo-api/src/rest.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 
 use anyhow::{Context, bail};
+use axum::extract::State;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, header};
 use rust_embed::RustEmbed;
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, Any, CorsLayer};
@@ -12,6 +13,7 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::ApiDoc;
+use crate::cloud::BearerAuth;
 use crate::connection_profiles::{
     create_connection_profile, delete_connection_profile, get_connection_profile_autocomplete,
     get_connection_profiles, test_connection_profile,
@@ -29,7 +31,7 @@ use crate::pipelines::{
     create_pipeline, create_preview_pipeline, delete_pipeline, get_pipeline, get_pipeline_jobs,
     get_pipelines, patch_pipeline, put_pipeline, restart_pipeline, validate_query,
 };
-use crate::rest_utils::not_found;
+use crate::rest_utils::{ErrorResp, authenticate, not_found};
 use crate::udfs::{create_udf, delete_udf, get_udfs, validate_udf};
 use arroyo_rpc::config::{CorsConfig, CorsOriginPolicy, config};
 use cornucopia_async::DatabaseSource;
@@ -67,11 +69,16 @@ pub async fn ping() -> impl IntoResponse {
         (status = 200, description = "Controller configuration", body = Object),
     ),
 )]
-pub async fn get_configs() -> impl IntoResponse {
-    Json(
+pub async fn get_configs(
+    State(state): State<AppState>,
+    bearer_auth: BearerAuth,
+) -> Result<impl IntoResponse, ErrorResp> {
+    let _ = authenticate(&state.database, bearer_auth).await?;
+
+    Ok(Json(
         serde_json::to_value(config().as_ref())
             .expect("controller configuration is always serializable"),
-    )
+    ))
 }
 
 pub async fn api_fallback() -> impl IntoResponse {

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -4,7 +4,6 @@ SELECT
     c.organization_id as org_id,
     pipeline_name,
     pipeline_id,
-    checkpoint_interval_micros,
     ttl_micros,
     parallelism_overrides,
     stop,

--- a/crates/arroyo-controller/queries/controller_queries.sql
+++ b/crates/arroyo-controller/queries/controller_queries.sql
@@ -23,7 +23,8 @@ SELECT
     restart_mode,
     state_context,
     env_vars,
-    scheduler_config
+    scheduler_config,
+    pipeline_config
 FROM job_configs c
 INNER JOIN job_statuses s ON c.id = s.id;
 

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::needless_lifetimes)]
 
 use anyhow::Result;
-use arroyo_rpc::config::config;
+use arroyo_rpc::config::{PipelineConfig, config};
 use arroyo_rpc::grpc::rpc::controller_grpc_server::{ControllerGrpc, ControllerGrpcServer};
 use arroyo_rpc::grpc::rpc::{
     GrpcOutputSubscription, HeartbeatNodeReq, HeartbeatNodeResp, OutputData, RegisterNodeReq,
@@ -83,6 +83,7 @@ fn update_job_state_metrics(counts: &HashMap<&str, i64>) {
 include!(concat!(env!("OUT_DIR"), "/controller-sql.rs"));
 
 use crate::schedulers::{ManualScheduler, NodeScheduler, ProcessScheduler, Scheduler};
+use crate::states::{StateError, fatal};
 use types::public::{RestartMode, StopMode};
 
 #[derive(PartialEq, Clone, Debug)]
@@ -100,10 +101,19 @@ pub struct JobConfig {
     /// Per-job environment variables forwarded to workers at scheduling time.
     env_vars: serde_json::Value,
     /// Per-job scheduler configuration overlay as raw JSON (same
-    /// shape as the controller-wide scheduler config). The scheduler
-    /// interprets this; the controller treats it as opaque. An empty
-    /// object is the no-override case.
+    /// shape as the controller-wide scheduler config)
     scheduler_config: serde_json::Value,
+    /// The process-wide pipeline config with this job's overlay applied
+    pipeline_config: serde_json::Value,
+}
+
+impl JobConfig {
+    pub fn pipeline_config(&self) -> Result<PipelineConfig, StateError> {
+        config()
+            .pipeline
+            .try_merge(&self.pipeline_config)
+            .map_err(|e| fatal("invalid pipeline_config", e))
+    }
 }
 
 /// Per-pipeline data that doesn't change for the lifetime of a job.
@@ -500,6 +510,7 @@ impl ControllerServer {
                         restart_mode: p.restart_mode,
                         env_vars: p.env_vars,
                         scheduler_config: p.scheduler_config,
+                        pipeline_config: p.pipeline_config,
                     };
 
                     let mut jobs = jobs.lock().await;

--- a/crates/arroyo-controller/src/lib.rs
+++ b/crates/arroyo-controller/src/lib.rs
@@ -93,7 +93,6 @@ pub struct JobConfig {
     pipeline_name: String,
     pipeline_id: i64,
     stop_mode: StopMode,
-    checkpoint_interval: Duration,
     ttl: Option<Duration>,
     parallelism_overrides: HashMap<u32, usize>,
     restart_nonce: i32,
@@ -493,9 +492,6 @@ impl ControllerServer {
                         pipeline_id: p.pipeline_id,
                         pipeline_name: p.pipeline_name,
                         stop_mode: p.stop,
-                        checkpoint_interval: Duration::from_micros(
-                            p.checkpoint_interval_micros as u64,
-                        ),
                         ttl: p.ttl_micros.map(|t| Duration::from_micros(t as u64)),
                         parallelism_overrides: p
                             .parallelism_overrides

--- a/crates/arroyo-controller/src/schedulers/mod.rs
+++ b/crates/arroyo-controller/src/schedulers/mod.rs
@@ -107,10 +107,7 @@ pub struct StartPipelineReq {
     pub slots: usize,
     pub env_vars: HashMap<String, String>,
     pub pipeline_tags: HashMap<String, String>,
-    /// Per-job scheduler configuration overlay as raw JSON. An empty
-    /// object means "use the controller's global scheduler config
-    /// unchanged". The scheduler interprets the shape; the controller
-    /// treats it as opaque and passes it through verbatim.
+    /// Per-job scheduler configuration overlay as raw JSON
     pub scheduler_config: serde_json::Value,
 }
 

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -24,8 +24,7 @@ impl State for LeaderCheckpointStopping {
         let timeout = ctx
             .config
             .pipeline_config()?
-            .checkpoint
-            .timeout
+            .stopping_timeout
             .as_ref()
             .map(|t| **t);
 

--- a/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_checkpoint_stopping.rs
@@ -1,7 +1,6 @@
 use super::{JobContext, State, Stopped, Transition};
 use crate::leader_manager::handle_leader_stopping;
 use crate::states::StateError;
-use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
 
 #[derive(Debug)]
@@ -22,7 +21,13 @@ impl State for LeaderCheckpointStopping {
             return Err(ctx.retryable(self, "failed to send stop message to leader", e, 10));
         }
 
-        let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
+        let timeout = ctx
+            .config
+            .pipeline_config()?
+            .checkpoint
+            .timeout
+            .as_ref()
+            .map(|t| **t);
 
         handle_leader_stopping(*self, ctx, JobState::JobStopped, Stopped {}, timeout).await
     }

--- a/crates/arroyo-controller/src/states/leader_rescaling.rs
+++ b/crates/arroyo-controller/src/states/leader_rescaling.rs
@@ -28,8 +28,7 @@ impl State for LeaderRescaling {
         let timeout = ctx
             .config
             .pipeline_config()?
-            .checkpoint
-            .timeout
+            .stopping_timeout
             .as_ref()
             .map(|t| **t);
         handle_leader_stopping(*self, ctx, JobState::JobStopped, Scheduling {}, timeout).await

--- a/crates/arroyo-controller/src/states/leader_rescaling.rs
+++ b/crates/arroyo-controller/src/states/leader_rescaling.rs
@@ -1,6 +1,5 @@
 use super::{JobContext, State, StateError, Transition, scheduling::Scheduling};
 use crate::leader_manager::handle_leader_stopping;
-use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
 
 #[derive(Debug)]
@@ -26,7 +25,13 @@ impl State for LeaderRescaling {
             ));
         }
 
-        let timeout = config().pipeline.checkpoint.timeout.as_ref().map(|t| **t);
+        let timeout = ctx
+            .config
+            .pipeline_config()?
+            .checkpoint
+            .timeout
+            .as_ref()
+            .map(|t| **t);
         handle_leader_stopping(*self, ctx, JobState::JobStopped, Scheduling {}, timeout).await
     }
 }

--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::JobMessage;
 use crate::states::recovering::Recovering;
 use crate::types::public::RestartMode;
-use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::{JobFailure, JobState, JobStopMode};
 use std::time::{Duration, Instant};
@@ -41,8 +40,9 @@ impl State for LeaderRestarting {
                 let started = Instant::now();
 
                 loop {
-                    let timeout = config()
-                        .pipeline
+                    let timeout = ctx
+                        .config
+                        .pipeline_config()?
                         .stopping_timeout
                         .as_ref()
                         .map(|t| (started + **t).saturating_duration_since(Instant::now()))

--- a/crates/arroyo-controller/src/states/leader_restarting.rs
+++ b/crates/arroyo-controller/src/states/leader_restarting.rs
@@ -43,8 +43,7 @@ impl State for LeaderRestarting {
                 loop {
                     let timeout = config()
                         .pipeline
-                        .checkpoint
-                        .timeout
+                        .stopping_timeout
                         .as_ref()
                         .map(|t| (started + **t).saturating_duration_since(Instant::now()))
                         .unwrap_or(Duration::MAX);

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -27,7 +27,7 @@ impl State for LeaderRunning {
     }
 
     async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
-        let pipeline_config = &config().clone().pipeline;
+        let pipeline_config = ctx.config.pipeline_config()?;
 
         let mut log_interval = tokio::time::interval(Duration::from_secs(60));
         log_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -112,11 +112,13 @@ impl State for LeaderRunning {
                                 ));
                             }
 
-                            // env_vars and scheduler_config are only applied when workers are
+                            // env_vars, scheduler_config, and pipeline_config are applied when workers are
                             // (re)scheduled, so a change to either while the job is running
                             // requires a restart to take effect.
                             if c.scheduler_config != ctx.config.scheduler_config
-                                || c.env_vars != ctx.config.env_vars {
+                                || c.env_vars != ctx.config.env_vars
+                                || c.pipeline_config != ctx.config.pipeline_config
+                            {
                                 return Ok(Transition::next(
                                     *self,
                                     LeaderRestarting {

--- a/crates/arroyo-controller/src/states/leader_running.rs
+++ b/crates/arroyo-controller/src/states/leader_running.rs
@@ -117,7 +117,8 @@ impl State for LeaderRunning {
                             // requires a restart to take effect.
                             if c.scheduler_config != ctx.config.scheduler_config
                                 || c.env_vars != ctx.config.env_vars
-                                || c.pipeline_config != ctx.config.pipeline_config
+                                || c.pipeline_config()?.worker
+                                    != ctx.config.pipeline_config()?.worker
                             {
                                 return Ok(Transition::next(
                                     *self,

--- a/crates/arroyo-controller/src/states/leader_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_stopping.rs
@@ -1,6 +1,5 @@
 use super::{JobContext, State, Stopped, Transition};
 use crate::states::StateError;
-use arroyo_rpc::config::config;
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::JobStopMode;
 use std::time::Duration;
@@ -37,8 +36,9 @@ impl State for LeaderStopping {
                 }
 
                 let timeout = match self.stop_behavior {
-                    LeaderStopBehavior::StopJob(JobStopMode::JobStopCheckpoint) => config()
-                        .pipeline
+                    LeaderStopBehavior::StopJob(JobStopMode::JobStopCheckpoint) => ctx
+                        .config
+                        .pipeline_config()?
                         .stopping_timeout
                         .as_ref()
                         .map(|t| **t)

--- a/crates/arroyo-controller/src/states/leader_stopping.rs
+++ b/crates/arroyo-controller/src/states/leader_stopping.rs
@@ -39,8 +39,7 @@ impl State for LeaderStopping {
                 let timeout = match self.stop_behavior {
                     LeaderStopBehavior::StopJob(JobStopMode::JobStopCheckpoint) => config()
                         .pipeline
-                        .checkpoint
-                        .timeout
+                        .stopping_timeout
                         .as_ref()
                         .map(|t| **t)
                         .unwrap_or(Duration::MAX),

--- a/crates/arroyo-controller/src/states/recovering.rs
+++ b/crates/arroyo-controller/src/states/recovering.rs
@@ -2,7 +2,6 @@ use super::{
     JobContext, State, StateError, Transition, compiling::Compiling, fatal, state_backoff,
 };
 use crate::leader_manager::LeaderManager;
-use arroyo_rpc::config::config;
 use arroyo_rpc::errors::ErrorDomain;
 use arroyo_rpc::grpc::rpc::{JobState, JobStopMode};
 use arroyo_rpc::retry;
@@ -185,7 +184,7 @@ impl State for Recovering {
     }
 
     async fn next(mut self: Box<Self>, ctx: &mut JobContext) -> Result<Transition, StateError> {
-        let pipeline_config = &config().pipeline;
+        let pipeline_config = ctx.config.pipeline_config()?;
 
         // only allow one restart for preview pipelines
         if ctx.config.ttl.is_some() {

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -490,7 +490,8 @@ impl State for Scheduling {
             .map(|(id, status)| (*id, status.rpc_address.clone()))
             .unwrap();
 
-        let checkpoint_interval_micros = ctx.config.checkpoint_interval.as_micros() as u64;
+        let pipeline_worker_config_json = serde_json::to_string(&pipeline_config.worker)
+            .map_err(|e| fatal("failed to serialize pipeline worker config", e.into()))?;
 
         let tasks: Vec<_> = worker_connects
             .into_iter()
@@ -502,6 +503,7 @@ impl State for Scheduling {
                 let program = program.clone();
                 let machine_id = workers.get(&id).as_ref().unwrap().machine_id.clone();
                 let leader_addr = leader_addr.clone();
+                let pipeline_worker_config_json = pipeline_worker_config_json.clone();
                 let checkpoint_manifest_ref = checkpoint_info.as_ref().map(|ci| ci.id.clone());
                 tokio::spawn(async move {
                     info!(
@@ -522,8 +524,8 @@ impl State for Scheduling {
                             job_controller_addr: leader_addr,
                             is_leader: leader_id == id,
                             wait_for_leader: true,
-                            checkpoint_interval_micros,
                             checkpoint_manifest_ref: checkpoint_manifest_ref.clone(),
+                            pipeline_worker_config_json,
                         }))
                         .await
                     {

--- a/crates/arroyo-controller/src/states/scheduling.rs
+++ b/crates/arroyo-controller/src/states/scheduling.rs
@@ -421,7 +421,7 @@ impl State for Scheduling {
         let worker_connects = Arc::new(Mutex::new(HashMap::new()));
         let mut handles = vec![];
 
-        let pipeline_config = &config().pipeline;
+        let pipeline_config = ctx.config.pipeline_config()?;
 
         let start = Instant::now();
         loop {

--- a/crates/arroyo-datastream/src/lib.rs
+++ b/crates/arroyo-datastream/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod logical;
 pub mod optimizers;
 
-use arroyo_rpc::config::{DefaultSink, config};
+use arroyo_rpc::config::{DefaultSink, PipelineCompilerConfigs};
 use arroyo_rpc::grpc::api;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
@@ -217,8 +217,8 @@ pub enum ImpulseSpec {
     EventsPerSecond(f32),
 }
 
-pub fn default_sink() -> api::ConnectorOp {
-    match config().pipeline.default_sink {
+pub fn default_sink(compiler_config: &PipelineCompilerConfigs) -> api::ConnectorOp {
+    match &compiler_config.default_sink {
         DefaultSink::Preview => api::ConnectorOp {
             connector: "preview".to_string(),
             config: json!({

--- a/crates/arroyo-formats/src/lib.rs
+++ b/crates/arroyo-formats/src/lib.rs
@@ -13,7 +13,7 @@ pub fn should_flush(buffered_count: usize, buffered_bytes: usize, time: Instant)
     if buffered_count == 0 {
         return false;
     }
-    let cfg = &config().pipeline;
+    let cfg = &config().pipeline.worker;
     buffered_count >= cfg.source_batch_size
         || time.elapsed() >= *cfg.source_batch_linger
         || cfg
@@ -49,9 +49,9 @@ mod tests {
         // config() auto-initialises from defaults; update() panics without it
         let _ = config();
         update(|c| {
-            c.pipeline.source_batch_size = batch_size;
-            c.pipeline.source_batch_linger = Duration::from_millis(linger_ms).into();
-            c.pipeline.source_batch_max_bytes = max_bytes;
+            c.pipeline.worker.source_batch_size = batch_size;
+            c.pipeline.worker.source_batch_linger = Duration::from_millis(linger_ms).into();
+            c.pipeline.worker.source_batch_max_bytes = max_bytes;
         });
     }
 

--- a/crates/arroyo-operator/src/context.rs
+++ b/crates/arroyo-operator/src/context.rs
@@ -376,7 +376,7 @@ impl SourceCollector {
         for error in errors {
             match (bad_data, error) {
                 (BadData::Drop { .. }, DataflowError::DataError { count, details }) => {
-                    if config().pipeline.store_deserialization_errors {
+                    if config().pipeline.worker.store_deserialization_errors {
                         self.error_rate_limiter
                             .rate_limit(|| async {
                                 warn!("Dropping invalid data ({count}): {details}");
@@ -626,7 +626,10 @@ impl ArrowCollector {
             "Size of a tx queue",
             &chain_info,
             &out_qs,
-            config().worker.queue_size as i64,
+            config()
+                .worker
+                .queue_size
+                .unwrap_or(config().pipeline.worker.queue_size) as i64,
         );
 
         let tx_queue_rem_gauges = register_queue_gauge(
@@ -634,7 +637,10 @@ impl ArrowCollector {
             "Remaining space in a tx queue",
             &chain_info,
             &out_qs,
-            config().worker.queue_size as i64,
+            config()
+                .worker
+                .queue_size
+                .unwrap_or(config().pipeline.worker.queue_size) as i64,
         );
 
         let tx_queue_bytes_gauges = register_queue_gauge(

--- a/crates/arroyo-planner/src/builder.rs
+++ b/crates/arroyo-planner/src/builder.rs
@@ -24,7 +24,6 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use tokio::runtime::Builder;
 use tokio::sync::oneshot;
 
-use crate::ArroyoSchemaProvider;
 use crate::extension::debezium::{
     DEBEZIUM_UNROLLING_EXTENSION_NAME, DebeziumUnrollingExtension, TO_DEBEZIUM_EXTENSION_NAME,
 };
@@ -35,6 +34,7 @@ use crate::physical::{
     ToDebeziumExec,
 };
 use crate::schemas::add_timestamp_field_arrow;
+use crate::{ArroyoSchemaProvider, SqlConfig};
 use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
 use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
 use datafusion_proto::{
@@ -54,13 +54,17 @@ pub(crate) struct PlanToGraphVisitor<'a> {
 }
 
 impl<'a> PlanToGraphVisitor<'a> {
-    pub fn new(schema_provider: &'a ArroyoSchemaProvider, session_state: &'a SessionState) -> Self {
+    pub fn new(
+        schema_provider: &'a ArroyoSchemaProvider,
+        session_state: &'a SessionState,
+        sql_config: &'a SqlConfig,
+    ) -> Self {
         Self {
             graph: Default::default(),
             output_schemas: Default::default(),
             named_nodes: Default::default(),
             traversal: vec![],
-            planner: Planner::new(schema_provider, session_state),
+            planner: Planner::new(schema_provider, session_state, sql_config),
         }
     }
 }
@@ -69,12 +73,14 @@ pub(crate) struct Planner<'a> {
     schema_provider: &'a ArroyoSchemaProvider,
     planner: DefaultPhysicalPlanner,
     session_state: &'a SessionState,
+    pub(crate) sql_config: &'a SqlConfig,
 }
 
 impl<'a> Planner<'a> {
     pub(crate) fn new(
         schema_provider: &'a ArroyoSchemaProvider,
         session_state: &'a SessionState,
+        sql_config: &'a SqlConfig,
     ) -> Self {
         let planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
             ArroyoExtensionPlanner {},
@@ -83,6 +89,7 @@ impl<'a> Planner<'a> {
             schema_provider,
             planner,
             session_state,
+            sql_config,
         }
     }
 

--- a/crates/arroyo-planner/src/extension/sink.rs
+++ b/crates/arroyo-planner/src/extension/sink.rs
@@ -158,13 +158,13 @@ impl ArroyoExtension for SinkExtension {
 
     fn plan_node(
         &self,
-        _planner: &Planner,
+        planner: &Planner,
         index: usize,
         input_schemas: Vec<ArroyoSchemaRef>,
     ) -> Result<NodeWithIncomingEdges> {
         let operator_config = (self
             .table
-            .connector_op()
+            .connector_op(&planner.sql_config.compiler)
             .map_err(|e| e.context("connector op"))?)
         .encode_to_vec();
 
@@ -173,7 +173,10 @@ impl ArroyoExtension for SinkExtension {
             format!("sink_{}_{}", self.name, index),
             OperatorName::ConnectorSink,
             operator_config,
-            self.table.connector_op()?.description.clone(),
+            self.table
+                .connector_op(&planner.sql_config.compiler)?
+                .description
+                .clone(),
             1,
         );
 

--- a/crates/arroyo-planner/src/extension/updating_aggregate.rs
+++ b/crates/arroyo-planner/src/extension/updating_aggregate.rs
@@ -3,7 +3,6 @@ use crate::builder::{NamedNode, Planner};
 use crate::functions::multi_hash;
 use crate::physical::ArroyoPhysicalExtensionCodec;
 use arroyo_datastream::logical::{LogicalEdge, LogicalEdgeType, LogicalNode, OperatorName};
-use arroyo_rpc::config::config;
 use arroyo_rpc::{df::ArroyoSchema, grpc::api::UpdatingAggregateOperator};
 use datafusion::common::{DFSchemaRef, Result, TableReference, ToDFSchema, plan_err};
 use datafusion::logical_expr::expr::ScalarFunction;
@@ -138,8 +137,9 @@ impl ArroyoExtension for UpdatingAggregateExtension {
             aggregate_exec: aggregate_exec.encode_to_vec(),
             metadata_expr: planner
                 .serialize_as_physical_expr(&updating_meta_expr, &input_dfschema)?,
-            flush_interval_micros: config()
-                .pipeline
+            flush_interval_micros: planner
+                .sql_config
+                .compiler
                 .update_aggregate_flush_interval
                 .as_micros() as u64,
             ttl_micros: self.ttl.as_micros() as u64,

--- a/crates/arroyo-planner/src/lib.rs
+++ b/crates/arroyo-planner/src/lib.rs
@@ -65,6 +65,7 @@ use arroyo_datastream::logical::LogicalProgram;
 use arroyo_datastream::optimizers::ChainingOptimizer;
 use arroyo_operator::connector::Connection;
 use arroyo_rpc::api_types::pipelines::{SqlDiagnostic, SqlLocation, SqlSpan};
+use arroyo_rpc::config::{PipelineCompilerConfigs, config as global_config};
 use arroyo_rpc::df::ArroyoSchema;
 use arroyo_rpc::{TIMESTAMP_FIELD, duration_from_sql};
 use arroyo_udf_host::ParsedUdfFile;
@@ -539,13 +540,21 @@ impl FunctionRegistry for ArroyoSchemaProvider {
 #[derive(Clone, Debug)]
 pub struct SqlConfig {
     pub default_parallelism: usize,
+    pub compiler: PipelineCompilerConfigs,
+}
+
+impl SqlConfig {
+    pub fn new(default_parallelism: usize, compiler: &PipelineCompilerConfigs) -> Self {
+        Self {
+            default_parallelism,
+            compiler: compiler.clone(),
+        }
+    }
 }
 
 impl Default for SqlConfig {
     fn default() -> Self {
-        Self {
-            default_parallelism: 4,
-        }
+        Self::new(4, &global_config().pipeline.compiler)
     }
 }
 
@@ -825,22 +834,24 @@ pub(crate) fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
 pub async fn parse_and_get_arrow_program(
     query: String,
     mut schema_provider: ArroyoSchemaProvider,
-    // TODO: use config
-    _config: SqlConfig,
+    config: SqlConfig,
 ) -> Result<CompiledSql> {
-    let mut config = SessionConfig::new();
-    config
+    let mut session_config = SessionConfig::new();
+    session_config
         .options_mut()
         .optimizer
         .enable_round_robin_repartition = false;
-    config.options_mut().optimizer.repartition_aggregations = false;
-    config.options_mut().optimizer.repartition_windows = false;
-    config.options_mut().optimizer.repartition_sorts = false;
-    config.options_mut().optimizer.repartition_joins = false;
-    config.options_mut().execution.target_partitions = 1;
+    session_config
+        .options_mut()
+        .optimizer
+        .repartition_aggregations = false;
+    session_config.options_mut().optimizer.repartition_windows = false;
+    session_config.options_mut().optimizer.repartition_sorts = false;
+    session_config.options_mut().optimizer.repartition_joins = false;
+    session_config.options_mut().execution.target_partitions = 1;
 
     let session_state = SessionStateBuilder::new()
-        .with_config(config)
+        .with_config(session_config)
         .with_default_features()
         .with_physical_optimizer_rules(vec![])
         .build();
@@ -953,7 +964,8 @@ pub async fn parse_and_get_arrow_program(
     // rewrite sink's inputs, and remove duplicated sink
     let extensions = rewrite_sinks(extensions)?;
 
-    let mut plan_to_graph_visitor = PlanToGraphVisitor::new(&schema_provider, &session_state);
+    let mut plan_to_graph_visitor =
+        PlanToGraphVisitor::new(&schema_provider, &session_state, &config);
     for extension in extensions {
         plan_to_graph_visitor.add_plan(extension)?;
     }
@@ -967,7 +979,7 @@ pub async fn parse_and_get_arrow_program(
         },
     );
 
-    if arroyo_rpc::config::config().pipeline.chaining.enabled {
+    if config.compiler.chaining.enabled {
         program.optimize(&ChainingOptimizer {});
     }
 

--- a/crates/arroyo-planner/src/tables.rs
+++ b/crates/arroyo-planner/src/tables.rs
@@ -14,6 +14,7 @@ use arroyo_rpc::ConnectorOptions;
 use arroyo_rpc::api_types::connections::{
     ConnectionProfile, ConnectionSchema, ConnectionType, SourceField,
 };
+use arroyo_rpc::config::PipelineCompilerConfigs;
 use arroyo_rpc::formats::{BadData, Format, Framing, JsonCompression, JsonFormat};
 use arroyo_rpc::grpc::api::ConnectorOp;
 use arroyo_types::ArroyoExtensionType;
@@ -979,12 +980,12 @@ impl Table {
         }
     }
 
-    pub fn connector_op(&self) -> Result<ConnectorOp> {
+    pub fn connector_op(&self, compiler_config: &PipelineCompilerConfigs) -> Result<ConnectorOp> {
         match self {
             Table::ConnectorTable(c) | Table::LookupTable(c) => Ok(c.connector_op()),
             Table::MemoryTable { .. } => plan_err!("can't write to a memory table"),
             Table::TableFromQuery { .. } => todo!(),
-            Table::PreviewSink { logical_plan: _ } => Ok(default_sink()),
+            Table::PreviewSink { logical_plan: _ } => Ok(default_sink(compiler_config)),
         }
     }
 

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -13,6 +13,8 @@ state-initial-backoff = "500ms"
 state-max-backoff = "1m"
 chaining.enabled = true
 store-deserialization-errors = true
+queue-size = 8192
+checkpoint-details-to-keep = 10
 
 [pipeline.compaction]
 enabled = false
@@ -53,8 +55,6 @@ bind-address = "0.0.0.0"
 rpc-port = 0
 data-port = 0
 task-slots = 16
-queue-size = 8192
-checkpoint-details-to-keep = 10
 
 [node]
 bind-address = "0.0.0.0"

--- a/crates/arroyo-rpc/default.toml
+++ b/crates/arroyo-rpc/default.toml
@@ -1,5 +1,4 @@
 checkpoint-url = "/tmp/arroyo/checkpoints"
-default-checkpoint-interval = "10s"
 [pipeline]
 source-batch-size = 512
 source-batch-linger = "100ms"
@@ -21,6 +20,7 @@ enabled = false
 checkpoints-to-compact = 4
 
 [pipeline.checkpoint]
+interval = "10s"
 
 # Services
 

--- a/crates/arroyo-rpc/proto/rpc.proto
+++ b/crates/arroyo-rpc/proto/rpc.proto
@@ -489,9 +489,12 @@ message StartExecutionReq {
   // Always send true so older workers wait for job_controller_init before running.
   // New workers always wait for the leader and ignore this field.
   bool wait_for_leader = 8;
-  uint64 checkpoint_interval_micros = 9;
+  reserved 9;
+  reserved "checkpoint_interval_micros";
   // Path to the restore checkpoint manifest.
   optional string checkpoint_manifest_ref = 10;
+  // JSON-encoded config.PipelineWorkerConfigs
+  string pipeline_worker_config_json = 11;
 }
 
 message StartExecutionResp {

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -53,7 +53,6 @@ pub struct PipelinePost {
     pub query: String,
     pub udfs: Option<Vec<Udf>>,
     pub parallelism: u64,
-    pub checkpoint_interval_micros: Option<u64>,
     pub state_url: Option<String>,
     pub tags: Option<HashMap<String, String>>,
     /// Per-job environment variables forwarded to workers.
@@ -85,7 +84,6 @@ pub struct PreviewPost {
 #[serde(rename_all = "snake_case")]
 pub struct PipelinePatch {
     pub parallelism: Option<u64>,
-    pub checkpoint_interval_micros: Option<u64>,
     pub stop: Option<StopType>,
     /// Per-job environment variables forwarded to workers.
     pub env_vars: Option<HashMap<String, String>>,
@@ -115,7 +113,6 @@ pub struct Pipeline {
     pub name: String,
     pub query: String,
     pub udfs: Vec<Udf>,
-    pub checkpoint_interval_micros: u64,
     pub stop: StopType,
     pub created_at: u64,
     pub action: Option<StopType>,

--- a/crates/arroyo-rpc/src/api_types/pipelines.rs
+++ b/crates/arroyo-rpc/src/api_types/pipelines.rs
@@ -65,6 +65,11 @@ pub struct PipelinePost {
     /// all mean "use the controller's global scheduler config
     /// unchanged".
     pub scheduler_config: Option<serde_json::Value>,
+    /// Per-job pipeline configuration overlay. The shape mirrors the
+    /// controller's global `pipeline` config block and is merged on top
+    /// of it when the job runs. An omitted field, `null`, or an empty
+    /// object all mean "use the global pipeline config unchanged".
+    pub pipeline_config: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -91,6 +96,9 @@ pub struct PipelinePatch {
     /// all mean "use the controller's global scheduler config
     /// unchanged".
     pub scheduler_config: Option<serde_json::Value>,
+    /// Per-job pipeline configuration overlay (see `PipelinePost`).
+    /// Supplying this field replaces the job's existing overlay.
+    pub pipeline_config: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
@@ -182,6 +190,10 @@ pub struct Job {
     /// An empty object means "no overrides, use the controller's
     /// global scheduler config unchanged".
     pub scheduler_config: serde_json::Value,
+    /// Per-job pipeline configuration overlay (see `PipelinePost`).
+    /// An empty object means "no overrides, use the global pipeline
+    /// config unchanged".
+    pub pipeline_config: serde_json::Value,
     /// Per-job environment variables forwarded to workers.
     pub env_vars: serde_json::Value,
 }

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use arc_swap::ArcSwapOption;
-use figment::Figment;
 use figment::providers::{Env, Format, Json, Toml, Yaml};
+use figment::{Figment, providers};
 use k8s_openapi::api::core::v1::{
     EnvVar, LocalObjectReference, ResourceRequirements, Toleration, Volume, VolumeMount,
 };
@@ -541,6 +541,9 @@ pub enum DefaultSink {
     Stdout,
 }
 
+/// Configs that apply to individual pipelines. Not that overrides for these are stored in the
+/// control plane's job_configs table, so changing or removing fields here can break existing
+/// pipelines.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PipelineConfig {
@@ -590,6 +593,16 @@ pub struct PipelineConfig {
     pub compaction: CompactionConfig,
 
     pub checkpoint: CheckpointConfig,
+}
+
+impl PipelineConfig {
+    pub fn try_merge(&self, overrides: &serde_json::Value) -> anyhow::Result<Self> {
+        let overrides = serde_json::to_string(overrides)?;
+        let figment =
+            Figment::from(providers::Serialized::defaults(self)).merge(Json::string(&overrides));
+
+        Ok(figment.extract()?)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -1054,7 +1067,13 @@ impl TlsConfig {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{Config, DatabaseType, Scheduler, SchemaName, SqliteConfig, load_config};
+    use crate::config::{
+        Config, DEFAULT_CONFIG, DatabaseType, Scheduler, SchemaName, SqliteConfig, load_config,
+    };
+    use figment::{
+        Figment,
+        providers::{Format, Toml},
+    };
     use url::Url;
 
     #[test]
@@ -1114,6 +1133,30 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_pipeline_config_try_merge() {
+        let config: Config = Figment::from(Toml::string(DEFAULT_CONFIG))
+            .extract()
+            .unwrap();
+        let merged = config
+            .pipeline
+            .try_merge(&serde_json::json!({
+                "allowed-restarts": 3,
+                "compaction": {
+                    "enabled": true,
+                },
+            }))
+            .unwrap();
+
+        assert_eq!(merged.allowed_restarts, 3);
+        assert!(merged.compaction.enabled);
+        assert_eq!(
+            merged.compaction.checkpoints_to_compact,
+            config.pipeline.compaction.checkpoints_to_compact
+        );
+        assert_eq!(merged.source_batch_size, config.pipeline.source_batch_size);
     }
 
     #[test]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -530,7 +530,7 @@ pub struct AdminConfig {
     pub allow_unauthenticated_metrics: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum DefaultSink {
     #[default]
@@ -590,6 +590,20 @@ pub struct CheckpointConfig {
     pub interval: HumanReadableDuration,
 }
 
+/// Options that affect the compiled pipeline program.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineCompilerConfigs {
+    /// How often to flush aggregates
+    pub update_aggregate_flush_interval: HumanReadableDuration,
+
+    /// Default sink, for when none is specified
+    #[serde(default)]
+    pub default_sink: DefaultSink,
+
+    pub chaining: ChainingConfig,
+}
+
 /// Configs that apply to individual pipelines. Not that overrides for these are stored in the
 /// control plane's job_configs table, so changing or removing fields here can break existing
 /// pipelines.
@@ -617,18 +631,12 @@ pub struct PipelineConfig {
     /// Maximum backoff delay for retryable state errors
     pub state_max_backoff: HumanReadableDuration,
 
-    /// How often to flush aggregates
-    pub update_aggregate_flush_interval: HumanReadableDuration,
-
-    /// Default sink, for when none is specified
-    #[serde(default)]
-    pub default_sink: DefaultSink,
-
-    pub chaining: ChainingConfig,
-
     /// Timeout for final (stopping) checkpoints
     #[serde(default)]
     pub stopping_timeout: Option<HumanReadableDuration>,
+
+    #[serde(flatten)]
+    pub compiler: PipelineCompilerConfigs,
 
     #[serde(flatten)]
     pub worker: PipelineWorkerConfigs,
@@ -644,7 +652,7 @@ impl PipelineConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ChainingConfig {
     /// Whether to enable operator chaining
@@ -1175,6 +1183,11 @@ mod tests {
             .pipeline
             .try_merge(&serde_json::json!({
                 "allowed-restarts": 3,
+                "default-sink": "stdout",
+                "update-aggregate-flush-interval": "7s",
+                "chaining": {
+                    "enabled": false,
+                },
                 "compaction": {
                     "enabled": true,
                 },
@@ -1185,6 +1198,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(merged.allowed_restarts, 3);
+        assert_eq!(merged.compiler.default_sink, super::DefaultSink::Stdout);
+        assert!(!merged.compiler.chaining.enabled);
+        assert_eq!(
+            *merged.compiler.update_aggregate_flush_interval,
+            std::time::Duration::from_secs(7)
+        );
         assert!(merged.worker.compaction.enabled);
         assert_eq!(
             merged.worker.compaction.checkpoints_to_compact,
@@ -1202,6 +1221,13 @@ mod tests {
         let encoded = serde_json::to_string(&merged.worker).unwrap();
         let decoded: super::PipelineWorkerConfigs = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, merged.worker);
+
+        let encoded = serde_json::to_value(&merged).unwrap();
+        assert!(encoded.get("compiler").is_none());
+        assert_eq!(
+            encoded.pointer("/chaining/enabled"),
+            Some(&serde_json::Value::Bool(false))
+        );
 
         assert!(
             config

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -409,7 +409,7 @@ pub struct ControllerConfig {
     pub metrics: MetricsConfig,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct CompactionConfig {
     /// Whether to enable compaction for checkpoints
@@ -476,15 +476,15 @@ pub struct WorkerConfig {
     /// Name to identify this worker (e.g., e.g., its hostname or a pod name)
     pub name: Option<String>,
 
-    /// Size of the queues between nodes in the dataflow graph
-    pub queue_size: u32,
+    /// DEPRECATED -- use pipelines.queue-size
+    pub queue_size: Option<u32>,
 
     /// TLS configuration for worker TCP shuffling
     #[serde(default)]
     pub tls: Option<TlsConfig>,
 
-    /// Maximum number of checkpoints to keep in history for serving the checkpoint details APIs
-    pub checkpoint_details_to_keep: u32,
+    /// DEPRECATED -- use pipelines.checkpoint-details-to-keep
+    pub checkpoint_details_to_keep: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -541,12 +541,10 @@ pub enum DefaultSink {
     Stdout,
 }
 
-/// Configs that apply to individual pipelines. Not that overrides for these are stored in the
-/// control plane's job_configs table, so changing or removing fields here can break existing
-/// pipelines.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+/// Runtime options that apply to a particular pipeline
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct PipelineConfig {
+pub struct PipelineWorkerConfigs {
     /// Batch size
     pub source_batch_size: usize,
 
@@ -557,9 +555,34 @@ pub struct PipelineConfig {
     /// Currently measured as raw input bytes.
     pub source_batch_max_bytes: Option<usize>,
 
-    /// How often to flush aggregates
-    pub update_aggregate_flush_interval: HumanReadableDuration,
+    /// Whether to persist deserialization errors to job_log_messages
+    pub store_deserialization_errors: bool,
 
+    /// Size of the queues between nodes in the dataflow graph
+    pub queue_size: u32,
+
+    /// Maximum number of checkpoints to keep in history for serving the checkpoint details APIs
+    pub checkpoint_details_to_keep: u32,
+
+    pub compaction: CompactionConfig,
+
+    pub checkpoint: CheckpointConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct CheckpointConfig {
+    /// Checkpoint interval
+    #[serde(default)]
+    pub interval: Option<HumanReadableDuration>,
+}
+
+/// Configs that apply to individual pipelines. Not that overrides for these are stored in the
+/// control plane's job_configs table, so changing or removing fields here can break existing
+/// pipelines.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PipelineConfig {
     /// How many restarts to allow before moving to failed (-1 for infinite)
     pub allowed_restarts: i32,
 
@@ -581,18 +604,21 @@ pub struct PipelineConfig {
     /// Maximum backoff delay for retryable state errors
     pub state_max_backoff: HumanReadableDuration,
 
+    /// How often to flush aggregates
+    pub update_aggregate_flush_interval: HumanReadableDuration,
+
     /// Default sink, for when none is specified
     #[serde(default)]
     pub default_sink: DefaultSink,
 
-    /// Whether to persist deserialization errors to job_log_messages
-    pub store_deserialization_errors: bool,
-
     pub chaining: ChainingConfig,
 
-    pub compaction: CompactionConfig,
+    /// Timeout for final (stopping) checkpoints
+    #[serde(default)]
+    pub stopping_timeout: Option<HumanReadableDuration>,
 
-    pub checkpoint: CheckpointConfig,
+    #[serde(flatten)]
+    pub worker: PipelineWorkerConfigs,
 }
 
 impl PipelineConfig {
@@ -603,14 +629,6 @@ impl PipelineConfig {
 
         Ok(figment.extract()?)
     }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct CheckpointConfig {
-    /// Checkpoint timeout
-    #[serde(default)]
-    pub timeout: Option<HumanReadableDuration>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -855,7 +873,7 @@ impl KubernetesWorkerConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct HumanReadableDuration {
     duration: Duration,
     original: String,
@@ -1151,12 +1169,15 @@ mod tests {
             .unwrap();
 
         assert_eq!(merged.allowed_restarts, 3);
-        assert!(merged.compaction.enabled);
+        assert!(merged.worker.compaction.enabled);
         assert_eq!(
-            merged.compaction.checkpoints_to_compact,
-            config.pipeline.compaction.checkpoints_to_compact
+            merged.worker.compaction.checkpoints_to_compact,
+            config.pipeline.worker.compaction.checkpoints_to_compact
         );
-        assert_eq!(merged.source_batch_size, config.pipeline.source_batch_size);
+        assert_eq!(
+            merged.worker.source_batch_size,
+            config.pipeline.worker.source_batch_size
+        );
     }
 
     #[test]

--- a/crates/arroyo-rpc/src/config.rs
+++ b/crates/arroyo-rpc/src/config.rs
@@ -236,9 +236,6 @@ pub struct Config {
     /// URL of an object store or filesystem for storing checkpoints
     pub checkpoint_url: String,
 
-    /// Default interval for checkpointing
-    pub default_checkpoint_interval: HumanReadableDuration,
-
     /// The endpoint of the controller, used by other services to connect to it. This must be set
     /// if running the controller on a separate machine from the other services or on a separate
     /// process with a non-standard port.
@@ -569,12 +566,28 @@ pub struct PipelineWorkerConfigs {
     pub checkpoint: CheckpointConfig,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+fn deserialize_checkpoint_interval<'de, D>(
+    deserializer: D,
+) -> Result<HumanReadableDuration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let interval = HumanReadableDuration::deserialize(deserializer)?;
+    if !(Duration::from_secs(1)..=Duration::from_secs(24 * 60 * 60)).contains(&interval.duration) {
+        return Err(de::Error::custom(
+            "checkpoint interval must be between 1 second and 1 day",
+        ));
+    }
+
+    Ok(interval)
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct CheckpointConfig {
     /// Checkpoint interval
-    #[serde(default)]
-    pub interval: Option<HumanReadableDuration>,
+    #[serde(deserialize_with = "deserialize_checkpoint_interval")]
+    pub interval: HumanReadableDuration,
 }
 
 /// Configs that apply to individual pipelines. Not that overrides for these are stored in the
@@ -1165,6 +1178,9 @@ mod tests {
                 "compaction": {
                     "enabled": true,
                 },
+                "checkpoint": {
+                    "interval": "5s",
+                },
             }))
             .unwrap();
 
@@ -1177,6 +1193,31 @@ mod tests {
         assert_eq!(
             merged.worker.source_batch_size,
             config.pipeline.worker.source_batch_size
+        );
+        assert_eq!(
+            *merged.worker.checkpoint.interval,
+            std::time::Duration::from_secs(5)
+        );
+
+        let encoded = serde_json::to_string(&merged.worker).unwrap();
+        let decoded: super::PipelineWorkerConfigs = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, merged.worker);
+
+        assert!(
+            config
+                .pipeline
+                .try_merge(&serde_json::json!({
+                    "checkpoint": { "interval": "999ms" }
+                }))
+                .is_err()
+        );
+        assert!(
+            config
+                .pipeline
+                .try_merge(&serde_json::json!({
+                    "checkpoint": { "interval": "86401s" }
+                }))
+                .is_err()
         );
     }
 

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -50,7 +50,7 @@ async fn run_smoketest(path: &Path) {
     config::config();
     config::update(|c| {
         // reduce the batch size to increase consistency
-        c.pipeline.source_batch_size = 32;
+        c.pipeline.worker.source_batch_size = 32;
     });
 
     // read text at path

--- a/crates/arroyo-sql-testing/src/smoke_tests.rs
+++ b/crates/arroyo-sql-testing/src/smoke_tests.rs
@@ -754,9 +754,7 @@ async fn get_graph(query_string: String, udfs: &[LocalUdf]) -> Result<LogicalPro
     let program = parse_and_get_arrow_program(
         query_string,
         schema_provider,
-        SqlConfig {
-            default_parallelism: 1,
-        },
+        SqlConfig::new(1, &config::config().pipeline.compiler),
     )
     .await?
     .program;

--- a/crates/arroyo-state/src/parquet.rs
+++ b/crates/arroyo-state/src/parquet.rs
@@ -174,7 +174,8 @@ impl ParquetBackend {
         operator_id: &str,
         epoch: u32,
     ) -> Result<HashMap<String, TableCheckpointMetadata>, StateError> {
-        let min_files_to_compact = config().pipeline.compaction.checkpoints_to_compact as usize;
+        let min_files_to_compact =
+            config().pipeline.worker.compaction.checkpoints_to_compact as usize;
 
         let operator_checkpoint_metadata =
             Self::load_operator_metadata(role, &job_id, operator_id, epoch)

--- a/crates/arroyo-worker/src/engine.rs
+++ b/crates/arroyo-worker/src/engine.rs
@@ -298,7 +298,10 @@ impl Program {
             }
         }
 
-        let queue_size = config().worker.queue_size;
+        let queue_size = config()
+            .worker
+            .queue_size
+            .unwrap_or(config().pipeline.worker.queue_size);
 
         for idx in logical.edge_indices() {
             let edge = logical.edge_weight(idx).unwrap();

--- a/crates/arroyo-worker/src/job_controller/mod.rs
+++ b/crates/arroyo-worker/src/job_controller/mod.rs
@@ -73,7 +73,13 @@ fn checkpoint_span_to_rpc(span: JobCheckpointSpan) -> rpc::JobCheckpointEventSpa
 
 impl CheckpointHistory {
     fn prune(&mut self) {
-        while self.checkpoints.len() > config().worker.checkpoint_details_to_keep as usize {
+        while self.checkpoints.len()
+            > config()
+                .worker
+                .checkpoint_details_to_keep
+                .unwrap_or(config().pipeline.worker.checkpoint_details_to_keep)
+                as usize
+        {
             self.checkpoints.pop_front();
         }
     }

--- a/crates/arroyo-worker/src/lib.rs
+++ b/crates/arroyo-worker/src/lib.rs
@@ -47,7 +47,7 @@ use crate::job_controller::controller::WorkerJobController;
 use crate::utils::{MAX_TASK_ERROR_FIELD_BYTES, maybe_truncate, to_d2};
 use arroyo_datastream::logical::LogicalProgram;
 use arroyo_planner::physical::new_registry;
-use arroyo_rpc::config::config;
+use arroyo_rpc::config::{PipelineWorkerConfigs, config, update};
 use arroyo_rpc::grpc::rpc;
 use arroyo_rpc::grpc::rpc::job_controller_grpc_server::{
     JobControllerGrpc, JobControllerGrpcServer,
@@ -322,6 +322,11 @@ impl WorkerState {
         shutdown_guard: ShutdownGuard,
         req: StartExecutionReq,
     ) -> Result<()> {
+        let pipeline_worker_config: PipelineWorkerConfigs =
+            serde_json::from_str(&req.pipeline_worker_config_json)
+                .context("invalid pipeline worker config")?;
+        update(|config| config.pipeline.worker = pipeline_worker_config.clone());
+
         let mut registry = new_registry();
         let logical = Arc::new(
             LogicalProgram::try_from(req.program.expect("Program is None"))
@@ -386,7 +391,7 @@ impl WorkerState {
                     Epoch(req.start_epoch),
                     Epoch(req.min_epoch),
                     &shutdown_guard,
-                    Duration::from_micros(req.checkpoint_interval_micros),
+                    *config().pipeline.worker.checkpoint.interval,
                     parent.clone(),
                 )
                 .await?

--- a/crates/arroyo/src/run.rs
+++ b/crates/arroyo/src/run.rs
@@ -454,7 +454,7 @@ pub async fn run(args: RunArgs) {
             c.controller.scheduler = Scheduler::Process;
         }
 
-        c.pipeline.default_sink = DefaultSink::Stdout;
+        c.pipeline.compiler.default_sink = DefaultSink::Stdout;
     });
 
     let db = db_source().await;

--- a/crates/integ/tests/api_tests.rs
+++ b/crates/integ/tests/api_tests.rs
@@ -86,7 +86,9 @@ async fn start_pipeline(test_id: u32, query: &str, udfs: &[&str]) -> anyhow::Res
             PipelinePost::builder()
                 .name(pipeline_name)
                 .parallelism(1)
-                .checkpoint_interval_micros(1_000_000)
+                .pipeline_config(Some(serde_json::json!({
+                    "checkpoint": { "interval": "1s" }
+                })))
                 .query(query)
                 .udfs(Some(
                     udfs.iter()

--- a/webui/pnpm-workspace.yaml
+++ b/webui/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/webui/src/components/ConfigViewer.tsx
+++ b/webui/src/components/ConfigViewer.tsx
@@ -1,0 +1,240 @@
+import { Badge, Box, Button, Flex, Grid, Input, Select, Stack, Text } from '@chakra-ui/react';
+import React, { useRef } from 'react';
+
+type ConfigObject = Record<string, unknown>;
+export type ConfigPath = string[];
+
+function isConfigObject(value: unknown): value is ConfigObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isEmpty(value: unknown): boolean {
+  return (
+    value == null ||
+    (Array.isArray(value) && value.length === 0) ||
+    (isConfigObject(value) && Object.keys(value).length === 0)
+  );
+}
+
+function hasConfigPath(value: unknown, path: ConfigPath): boolean {
+  let current = value;
+
+  for (const part of path) {
+    if (!isConfigObject(current) || !Object.prototype.hasOwnProperty.call(current, part)) {
+      return false;
+    }
+    current = current[part];
+  }
+
+  return true;
+}
+
+function ScalarValue({ value }: { value: unknown }) {
+  if (value === null) {
+    return (
+      <Text as="span" fontSize="xs" fontStyle="italic">
+        null
+      </Text>
+    );
+  }
+
+  return (
+    <Text as="span" fontFamily="mono" fontSize="xs" overflowWrap="anywhere">
+      {String(value)}
+    </Text>
+  );
+}
+
+function EditableScalar({
+  value,
+  onChange,
+}: {
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const valueType = useRef(value === null ? 'string' : typeof value);
+
+  if (valueType.current === 'boolean') {
+    return (
+      <Select
+        size="xs"
+        height={6}
+        maxWidth="120px"
+        fontFamily="mono"
+        fontSize="xs"
+        value={String(value)}
+        onChange={event => onChange(event.target.value === 'true')}
+      >
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </Select>
+    );
+  }
+
+  return (
+    <Input
+      size="xs"
+      height={6}
+      maxWidth="360px"
+      fontFamily="mono"
+      fontSize="xs"
+      type={valueType.current === 'number' ? 'number' : 'text'}
+      value={value === null ? '' : String(value)}
+      onChange={event => {
+        const input = event.target.value;
+        if (valueType.current !== 'number' || input === '' || Number.isNaN(Number(input))) {
+          onChange(input);
+        } else {
+          onChange(Number(input));
+        }
+      }}
+    />
+  );
+}
+
+interface ConfigEntryProps {
+  name: string;
+  value: unknown;
+  path: ConfigPath;
+  overrides?: unknown;
+  isEditing?: boolean;
+  onChange?: (path: ConfigPath, value: unknown) => void;
+  onReset?: (path: ConfigPath) => void;
+}
+
+function ConfigEntry({
+  name,
+  value,
+  path,
+  overrides,
+  isEditing,
+  onChange,
+  onReset,
+}: ConfigEntryProps) {
+  const nested = Array.isArray(value) || isConfigObject(value);
+  const overridden = hasConfigPath(overrides, path);
+
+  if (!nested || value === null) {
+    return (
+      <Grid
+        templateColumns={{ base: 'minmax(120px, 35%) 1fr', xl: '280px 1fr' }}
+        gap={4}
+        px={3}
+        py={2}
+        borderBottomWidth="1px"
+        borderColor="whiteAlpha.200"
+        _last={{ borderBottomWidth: 0 }}
+      >
+        <Flex align="center" gap={2} minWidth={0}>
+          <Text fontFamily="mono" fontSize="xs" fontWeight="semibold" overflowWrap="anywhere">
+            {name}
+          </Text>
+          {overridden ? (
+            <Badge variant="outline" flexShrink={0} px={1} fontSize="8px" lineHeight={4}>
+              override
+            </Badge>
+          ) : null}
+        </Flex>
+        <Flex align="center" gap={2} minWidth={0}>
+          {isEditing && onChange ? (
+            <EditableScalar value={value} onChange={next => onChange(path, next)} />
+          ) : (
+            <ScalarValue value={value} />
+          )}
+          {isEditing && overridden && onReset ? (
+            <Button
+              flexShrink={0}
+              height={6}
+              minWidth="auto"
+              px={2}
+              size="xs"
+              variant="ghost"
+              onClick={() => onReset(path)}
+            >
+              Reset
+            </Button>
+          ) : null}
+        </Flex>
+      </Grid>
+    );
+  }
+
+  const entries: [string, unknown][] = Array.isArray(value)
+    ? value.map((item, index) => [`[${index}]`, item])
+    : Object.entries(value);
+
+  return (
+    <Box px={3} py={2} borderBottomWidth="1px" borderColor="whiteAlpha.200" _last={{ border: 0 }}>
+      <Text fontFamily="mono" fontSize="xs" fontWeight="semibold" overflowWrap="anywhere">
+        {name}
+      </Text>
+      {entries.length === 0 ? (
+        <Text mt={1} ml={3} color="gray.500" fontFamily="mono" fontSize="xs">
+          {Array.isArray(value) ? '[]' : '{}'}
+        </Text>
+      ) : (
+        <Box mt={1} ml={2} borderLeftWidth="1px" borderColor="whiteAlpha.300">
+          {entries.map(([key, child]) => (
+            <ConfigEntry
+              key={[...path, key].join('.')}
+              name={key}
+              value={child}
+              path={[...path, key]}
+              overrides={overrides}
+              isEditing={isEditing}
+              onChange={onChange}
+              onReset={onReset}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function ConfigViewer({
+  value,
+  emptyMessage = 'No configuration values.',
+  overrides,
+  isEditing = false,
+  onChange,
+  onReset,
+}: {
+  value: unknown;
+  emptyMessage?: string;
+  overrides?: unknown;
+  isEditing?: boolean;
+  onChange?: (path: ConfigPath, value: unknown) => void;
+  onReset?: (path: ConfigPath) => void;
+}) {
+  if (isEmpty(value)) {
+    return (
+      <Text color="gray.500" fontSize="sm" fontStyle="italic">
+        {emptyMessage}
+      </Text>
+    );
+  }
+
+  const entries: [string, unknown][] = Array.isArray(value)
+    ? value.map((item, index) => [`[${index}]`, item])
+    : isConfigObject(value)
+    ? Object.entries(value)
+    : [['value', value]];
+
+  return (
+    <Stack spacing={0} borderWidth="1px" borderColor="whiteAlpha.300" borderRadius="md">
+      {entries.map(([key, child]) => (
+        <ConfigEntry
+          key={key}
+          name={key}
+          value={child}
+          path={[key]}
+          overrides={overrides}
+          isEditing={isEditing}
+          onChange={onChange}
+          onReset={onReset}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -816,8 +816,6 @@ export interface components {
             action_in_progress: boolean;
             action_text: string;
             /** Format: int64 */
-            checkpoint_interval_micros: number;
-            /** Format: int64 */
             created_at: number;
             graph: components["schemas"]["PipelineGraph"];
             id: string;
@@ -860,14 +858,10 @@ export interface components {
         };
         PipelinePatch: {
             /** Format: int64 */
-            checkpoint_interval_micros?: number | null;
-            /** Format: int64 */
             parallelism?: number | null;
             stop?: components["schemas"]["StopType"] | null;
         };
         PipelinePost: {
-            /** Format: int64 */
-            checkpoint_interval_micros?: number | null;
             /** @description Per-job environment variables forwarded to workers. */
             env_vars?: {
                 [key: string]: string;

--- a/webui/src/gen/api-types.ts
+++ b/webui/src/gen/api-types.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/v1/configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Controller configuration endpoint */
+        get: operations["get_configs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/connection_profiles": {
         parameters: {
             query?: never;
@@ -694,6 +711,10 @@ export interface components {
             /** Format: int64 */
             finish_time?: number | null;
             id: string;
+            /** @description Per-job pipeline configuration overlay (see `PipelinePost`).
+             *     An empty object means "no overrides, use the global pipeline
+             *     config unchanged". */
+            pipeline_config: unknown;
             /** @description The `pub_id` of the pipeline this job belongs to. */
             pipeline_id: string;
             /** Format: int64 */
@@ -857,8 +878,22 @@ export interface components {
             parallelism: number;
         };
         PipelinePatch: {
+            /** @description Per-job environment variables forwarded to workers. */
+            env_vars?: {
+                [key: string]: string;
+            } | null;
             /** Format: int64 */
             parallelism?: number | null;
+            /** @description Per-job pipeline configuration overlay (see `PipelinePost`).
+             *     Supplying this field replaces the job's existing overlay. */
+            pipeline_config?: unknown;
+            /** @description Per-job scheduler configuration overlay. The shape mirrors the
+             *     controller's global scheduler config (e.g. the
+             *     `kubernetes-scheduler.*` block) and is merged on top of it at
+             *     scheduling time. An omitted field, `null`, or an empty object
+             *     all mean "use the controller's global scheduler config
+             *     unchanged". */
+            scheduler_config?: unknown;
             stop?: components["schemas"]["StopType"] | null;
         };
         PipelinePost: {
@@ -869,6 +904,11 @@ export interface components {
             name: string;
             /** Format: int64 */
             parallelism: number;
+            /** @description Per-job pipeline configuration overlay. The shape mirrors the
+             *     controller's global `pipeline` config block and is merged on top
+             *     of it when the job runs. An omitted field, `null`, or an empty
+             *     object all mean "use the global pipeline config unchanged". */
+            pipeline_config?: unknown;
             query: string;
             /** @description Per-job scheduler configuration overlay. The shape mirrors the
              *     controller's global scheduler config (e.g. the
@@ -1006,6 +1046,26 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_configs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Controller configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
     get_connection_profiles: {
         parameters: {
             query?: never;

--- a/webui/src/lib/data_fetching.ts
+++ b/webui/src/lib/data_fetching.ts
@@ -62,6 +62,10 @@ const connectionProfilesKey = () => {
   return { key: 'Connections' };
 };
 
+const controllerConfigKey = () => {
+  return { key: 'ControllerConfig' };
+};
+
 const connectionProfileAutocompleteKey = (id: string) => {
   return { key: `ConnectionProfileAutocomplete`, connectionProfileId: id };
 };
@@ -166,6 +170,27 @@ export const usePing = () => {
     ping: data,
     pingLoading: isLoading,
     pingError: error,
+  };
+};
+
+// Controller config
+
+const controllerConfigFetcher = async () => {
+  const { data, error } = await get('/v1/configs', {});
+  return processResponse(data, error);
+};
+
+export const useControllerConfig = () => {
+  const { data, error, isLoading } = useSWR<unknown>(
+    controllerConfigKey(),
+    controllerConfigFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    controllerConfig: data,
+    controllerConfigError: error,
+    controllerConfigLoading: isLoading,
   };
 };
 
@@ -504,16 +529,29 @@ export const usePipeline = (pipelineId?: string, refresh: boolean = false) => {
     options
   );
 
-  const updatePipeline = async (params: { stop?: StopType; parallelism?: number }) => {
+  const updatePipeline = async (params: {
+    stop?: StopType;
+    parallelism?: number;
+    pipelineConfig?: unknown;
+  }) => {
     if (!pipelineId) {
       return;
     }
 
-    await patch('/v1/pipelines/{id}', {
+    const {
+      data: updatedPipeline,
+      error: updateError,
+      response,
+    } = await patch('/v1/pipelines/{id}', {
       params: { path: { id: pipelineId } },
-      body: { stop: params.stop, parallelism: params.parallelism },
+      body: {
+        stop: params.stop,
+        parallelism: params.parallelism,
+        pipeline_config: params.pipelineConfig,
+      },
     });
-    await mutate();
+    processResponse(updatedPipeline, updateError, response);
+    await Promise.all([mutate(), globalMutate(pipelineJobsKey(pipelineId))]);
   };
 
   const restartPipeline = async (ignoreState?: boolean) => {

--- a/webui/src/routes/pipelines/PipelineConfigs.tsx
+++ b/webui/src/routes/pipelines/PipelineConfigs.tsx
@@ -1,0 +1,275 @@
+import {
+  Alert,
+  AlertIcon,
+  Button,
+  ButtonGroup,
+  Flex,
+  Heading,
+  Spinner,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@chakra-ui/react';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+
+import { ConfigPath, ConfigViewer } from '../../components/ConfigViewer';
+import { Job, useControllerConfig } from '../../lib/data_fetching';
+import { formatError } from '../../lib/util';
+
+type ConfigObject = Record<string, unknown>;
+
+function isConfigObject(value: unknown): value is ConfigObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneConfig(value: unknown): unknown {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function asConfigObject(value: unknown): ConfigObject {
+  return isConfigObject(value) ? (cloneConfig(value) as ConfigObject) : {};
+}
+
+function mergeConfig(base: unknown, overrides: unknown): unknown {
+  if (!isConfigObject(base) || !isConfigObject(overrides)) {
+    return cloneConfig(overrides);
+  }
+
+  const merged = asConfigObject(base);
+  for (const [key, value] of Object.entries(overrides)) {
+    merged[key] = key in base ? mergeConfig(base[key], value) : cloneConfig(value);
+  }
+  return merged;
+}
+
+function setConfigValue(config: ConfigObject, path: ConfigPath, value: unknown): ConfigObject {
+  const next = asConfigObject(config);
+  let current = next;
+
+  path.slice(0, -1).forEach(part => {
+    if (!isConfigObject(current[part])) {
+      current[part] = {};
+    }
+    current = current[part] as ConfigObject;
+  });
+
+  current[path[path.length - 1]] = value;
+  return next;
+}
+
+function removeConfigValue(config: ConfigObject, path: ConfigPath): ConfigObject {
+  const next = asConfigObject(config);
+  const parents: Array<{ parent: ConfigObject; key: string }> = [];
+  let current = next;
+
+  for (const part of path) {
+    if (!Object.prototype.hasOwnProperty.call(current, part)) {
+      return next;
+    }
+    parents.push({ parent: current, key: part });
+    if (isConfigObject(current[part])) {
+      current = current[part] as ConfigObject;
+    }
+  }
+
+  const leaf = parents.pop();
+  if (leaf) {
+    delete leaf.parent[leaf.key];
+  }
+
+  parents.reverse().forEach(({ parent, key }) => {
+    if (isConfigObject(parent[key]) && Object.keys(parent[key] as ConfigObject).length === 0) {
+      delete parent[key];
+    }
+  });
+
+  return next;
+}
+
+interface ConfigPanelProps {
+  title: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+function ConfigPanel({ title, actions, children }: ConfigPanelProps) {
+  return (
+    <TabPanel px={5} py={0}>
+      <Flex align="start" justify="space-between" gap={4} mb={3}>
+        <div>
+          <Heading as="h3" fontSize="sm">
+            {title}
+          </Heading>
+        </div>
+        {actions}
+      </Flex>
+      {children}
+    </TabPanel>
+  );
+}
+
+export function PipelineConfigs({
+  job,
+  updatePipelineConfig,
+}: {
+  job: Job;
+  updatePipelineConfig: (config: ConfigObject) => Promise<void>;
+}) {
+  const { controllerConfig, controllerConfigError, controllerConfigLoading } =
+    useControllerConfig();
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string>();
+  const overrideFingerprint = JSON.stringify(job.pipeline_config);
+  const originalOverrides = useMemo(
+    () => asConfigObject(job.pipeline_config),
+    [overrideFingerprint]
+  );
+  const [draftOverrides, setDraftOverrides] = useState<ConfigObject>(() => originalOverrides);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraftOverrides(originalOverrides);
+    }
+  }, [isEditing, originalOverrides]);
+
+  const controllerPipelineConfig = isConfigObject(controllerConfig)
+    ? controllerConfig.pipeline
+    : {};
+  const effectivePipelineConfig = mergeConfig(controllerPipelineConfig, draftOverrides);
+  const dirty = JSON.stringify(draftOverrides) !== JSON.stringify(originalOverrides);
+
+  const startEditing = () => {
+    setDraftOverrides(asConfigObject(originalOverrides));
+    setSaveError(undefined);
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setDraftOverrides(asConfigObject(originalOverrides));
+    setSaveError(undefined);
+    setIsEditing(false);
+  };
+
+  const save = async () => {
+    setIsSaving(true);
+    setSaveError(undefined);
+    try {
+      await updatePipelineConfig(draftOverrides);
+      setIsEditing(false);
+    } catch (error) {
+      setSaveError(formatError(error));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const controllerContents = controllerConfigError ? (
+    <Alert status="error" py={2} fontSize="xs">
+      <AlertIcon boxSize={4} />
+      {formatError(controllerConfigError)}
+    </Alert>
+  ) : controllerConfigLoading ? (
+    <Spinner size="sm" />
+  ) : (
+    <ConfigViewer value={controllerConfig} />
+  );
+
+  return (
+    <Tabs orientation="vertical" variant="unstyled" width="100%" height="100%" isLazy>
+      <TabList
+        width="190px"
+        flexShrink={0}
+        gap={1}
+        pr={4}
+        borderRightWidth="1px"
+        borderColor="whiteAlpha.300"
+      >
+        {['Global', 'Pipeline', 'Scheduler', 'Environment Variables'].map(label => (
+          <Tab
+            key={label}
+            justifyContent="flex-start"
+            borderRadius="md"
+            fontSize="sm"
+            fontWeight="medium"
+            px={3}
+            py={2}
+            textAlign="left"
+            _hover={{ bg: 'whiteAlpha.100' }}
+            _selected={{ bg: 'whiteAlpha.200', color: 'blue.200' }}
+          >
+            {label}
+          </Tab>
+        ))}
+      </TabList>
+      <TabPanels minWidth={0} overflow="auto">
+        <ConfigPanel
+          title="Global Config"
+        >
+          {controllerContents}
+        </ConfigPanel>
+        <ConfigPanel
+          title="Pipeline Config"
+          actions={
+            isEditing ? (
+              <ButtonGroup size="xs" flexShrink={0}>
+                <Button variant="ghost" onClick={() => setDraftOverrides({})}>
+                  Clear overrides
+                </Button>
+                <Button variant="ghost" onClick={cancelEditing}>
+                  Cancel
+                </Button>
+                <Button colorScheme="blue" isDisabled={!dirty} isLoading={isSaving} onClick={save}>
+                  Save
+                </Button>
+              </ButtonGroup>
+            ) : (
+              <Button
+                size="xs"
+                flexShrink={0}
+                isDisabled={controllerConfigLoading || !!controllerConfigError}
+                onClick={startEditing}
+              >
+                Edit
+              </Button>
+            )
+          }
+        >
+          {saveError ? (
+            <Alert status="error" py={2} mb={3} fontSize="xs">
+              <AlertIcon boxSize={4} />
+              {saveError}
+            </Alert>
+          ) : null}
+          <ConfigViewer
+            value={effectivePipelineConfig}
+            overrides={draftOverrides}
+            isEditing={isEditing}
+            onChange={(path, value) =>
+              setDraftOverrides(current => setConfigValue(current, path, value))
+            }
+            onReset={path => setDraftOverrides(current => removeConfigValue(current, path))}
+          />
+        </ConfigPanel>
+        <ConfigPanel
+          title="Scheduler Config Overrides"
+        >
+          <ConfigViewer
+            value={job.scheduler_config}
+            emptyMessage="This pipeline does not override the scheduler config."
+          />
+        </ConfigPanel>
+        <ConfigPanel
+          title="Environment Variable Overrides"
+        >
+          <ConfigViewer
+            value={job.env_vars}
+            emptyMessage="This pipeline does not define environment variable overrides."
+          />
+        </ConfigPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}

--- a/webui/src/routes/pipelines/PipelineConfigs.tsx
+++ b/webui/src/routes/pipelines/PipelineConfigs.tsx
@@ -205,11 +205,7 @@ export function PipelineConfigs({
         ))}
       </TabList>
       <TabPanels minWidth={0} overflow="auto">
-        <ConfigPanel
-          title="Global Config"
-        >
-          {controllerContents}
-        </ConfigPanel>
+        <ConfigPanel title="Global Config">{controllerContents}</ConfigPanel>
         <ConfigPanel
           title="Pipeline Config"
           actions={
@@ -253,17 +249,13 @@ export function PipelineConfigs({
             onReset={path => setDraftOverrides(current => removeConfigValue(current, path))}
           />
         </ConfigPanel>
-        <ConfigPanel
-          title="Scheduler Config Overrides"
-        >
+        <ConfigPanel title="Scheduler Config Overrides">
           <ConfigViewer
             value={job.scheduler_config}
             emptyMessage="This pipeline does not override the scheduler config."
           />
         </ConfigPanel>
-        <ConfigPanel
-          title="Environment Variable Overrides"
-        >
+        <ConfigPanel title="Environment Variable Overrides">
           <ConfigViewer
             value={job.env_vars}
             emptyMessage="This pipeline does not define environment variable overrides."

--- a/webui/src/routes/pipelines/PipelineDetails.tsx
+++ b/webui/src/routes/pipelines/PipelineDetails.tsx
@@ -20,12 +20,6 @@ import {
   Grid,
   Heading,
   Icon,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
   Popover,
   PopoverArrow,
   PopoverBody,
@@ -66,24 +60,11 @@ import PipelineNotFound from '../../components/PipelineNotFound';
 import { QuestionOutlineIcon, WarningIcon } from '@chakra-ui/icons';
 import { formatError } from '../../lib/util';
 import { PipelineOutputs } from './PipelineOutputs';
+import { PipelineConfigs } from './PipelineConfigs';
 import PaginatedContent from '../../components/PaginatedContent';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { useNavbar } from '../../App';
-
-function flattenConfig(value: unknown, prefix = ''): [string, string][] {
-  if (value === null || typeof value !== 'object') {
-    return [[prefix, String(value)]];
-  }
-  if (Array.isArray(value)) {
-    return [[prefix, JSON.stringify(value)]];
-  }
-  const entries = Object.entries(value as Record<string, unknown>);
-  if (entries.length === 0) {
-    return prefix ? [[prefix, '{}']] : [];
-  }
-  return entries.flatMap(([key, v]) => flattenConfig(v, prefix ? `${prefix}.${key}` : key));
-}
 
 export function PipelineDetails() {
   const [activeOperator, setActiveOperator] = useState<number | undefined>(undefined);
@@ -96,11 +77,6 @@ export function PipelineDetails() {
     isOpen: restartWithoutStateModalIsOpen,
     onOpen: onRestartWithoutStateModalOpen,
     onClose: onRestartWithoutStateModalClose,
-  } = useDisclosure();
-  const {
-    isOpen: schedulerConfigModalIsOpen,
-    onOpen: onSchedulerConfigModalOpen,
-    onClose: onSchedulerConfigModalClose,
   } = useDisclosure();
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -144,6 +120,10 @@ export function PipelineDetails() {
   async function updateJobParallelism(parallelism: number) {
     console.log(`Setting pipeline parallelism=${parallelism}`);
     updatePipeline({ parallelism });
+  }
+
+  async function updateJobPipelineConfig(pipelineConfig: Record<string, unknown>) {
+    await updatePipeline({ pipelineConfig });
   }
 
   let operatorDetail = undefined;
@@ -219,32 +199,6 @@ export function PipelineDetails() {
             </Box>
           </Box>
         ) : null}
-        {job.env_vars && Object.keys(job.env_vars as Record<string, string>).length > 0 ? (
-          <Box className="field">
-            <Box className="fieldName">Env Vars</Box>
-            <Box className="fieldValue">
-              <Wrap spacing={1}>
-                {Object.entries(job.env_vars as Record<string, string>).map(([k, v]) => (
-                  <WrapItem key={k}>
-                    <Badge>
-                      {k}: {v}
-                    </Badge>
-                  </WrapItem>
-                ))}
-              </Wrap>
-            </Box>
-          </Box>
-        ) : null}
-        {job.scheduler_config && Object.keys(job.scheduler_config as object).length > 0 ? (
-          <Box className="field">
-            <Box className="fieldName">Scheduler Config</Box>
-            <Box className="fieldValue">
-              <Button size="sm" onClick={onSchedulerConfigModalOpen}>
-                View
-              </Button>
-            </Box>
-          </Box>
-        ) : null}
         {operatorDetail}
       </Stack>
     </TabPanel>
@@ -270,6 +224,12 @@ export function PipelineDetails() {
           checkpointsError={checkpointsError}
         />
       }
+    </TabPanel>
+  );
+
+  const configsTab = (
+    <TabPanel height="100%" overflow="hidden" padding={5}>
+      <PipelineConfigs job={job} updatePipelineConfig={updateJobPipelineConfig} />
     </TabPanel>
   );
 
@@ -319,6 +279,7 @@ export function PipelineDetails() {
         <Tab>Operators</Tab>
         <Tab>Outputs</Tab>
         <Tab>Checkpoints</Tab>
+        <Tab>Configs</Tab>
         <Tab>Query</Tab>
         <Tab>UDFs</Tab>
         <Tab>Errors {hasErrors && <Icon as={WarningIcon} color={'red.400'} ml={2} />}</Tab>
@@ -327,6 +288,7 @@ export function PipelineDetails() {
         {operatorsTab}
         {outputsTab}
         {checkpointsTab}
+        {configsTab}
         {queryTab}
         {udfsTab}
         {errorsTab}
@@ -460,27 +422,6 @@ export function PipelineDetails() {
           </AlertDialogContent>
         </AlertDialogOverlay>
       </AlertDialog>
-      <Modal
-        isOpen={schedulerConfigModalIsOpen}
-        onClose={onSchedulerConfigModalClose}
-        isCentered
-        size="xl"
-      >
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Scheduler Config</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody pb={6}>
-            <Stack spacing={1}>
-              {flattenConfig(job.scheduler_config).map(([k, v]) => (
-                <Text key={k} fontFamily="mono" fontSize="sm" wordBreak="break-all">
-                  {k}: {v}
-                </Text>
-              ))}
-            </Stack>
-          </ModalBody>
-        </ModalContent>
-      </Modal>
     </>
   );
 }


### PR DESCRIPTION
Adds the ability to set pipeline configs (those under the pipelines.* config namespace) on individual pipelines rather than cluster-wide.

Pipeline configs come in a few flavors. Some affect the controller (scheduling/recovery behavior primarily) while some affect the actual worker. Changes to worker pipeline configs will trigger a restart of the pipeline with the new configs, while changes to the controller will be applied dynamically (possibly not causing an effect until the next cycle of the pipeline).

In addition to the API updates (adding pipeline_configs to pipeline creation and updates), there is also a new UI for showing all configs and supporting setting pipeline configs;

<img width="1851" height="561" alt="image" src="https://github.com/user-attachments/assets/b1af393e-a4e7-4171-ab6b-281e25f54389" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arroyosystems/arroyo/pull/1151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->